### PR TITLE
util: Add license and contributing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,6 @@ implementation proposal in the referenced issues.
 
 - [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
 - [ ] Run Locally: Verified that the docs build using `make server`
-- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in `README.md`.
-- [ ] Style Guidelines: Documentation obeys style guidelines in `README.md`.
-- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
-- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
+- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
+- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
+- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to The Things Stack Docs
+
+Thank you for your interest in building this thing together with us. We're really happy with our active community and are glad that you're a part of it. There are many ways to contribute to our project, but given the fact that you're on Github looking at the code for The Things Stack Docs, you're probably here for one of the following reasons:
+
+- **Asking a question**: If you have questions, please use the [forum](https://www.thethingsnetwork.org/forum/). We have a special [category for The Things Stack](https://www.thethingsnetwork.org/forum/c/network-and-routing/v3).
+- **Writing documentation**: If you see that our documentation is lacking or incorrect, it would be great if you could help us improve it. This will help users and fellow contributors understand how to better work with our stack. Better documentation helps prevent making mistakes and introducing new bugs. Our documentation is spread across a number of places. Code documentation for The Things Stack lives together with the [code](https://github.com/TheThingsNetwork/lorawan-stack). User documentation for The Things Stack is built from the source files in the `doc` folder of this repository. More general documentation can be found on [The Things Network's official documentation pages](https://www.thethingsnetwork.org/docs). The source files for that documentation can be found in [the `docs` repository](https://github.com/TheThingsNetwork/docs).
+
+Style guidelines for contributing code and writing documentation can be found [here](README.md#style-guidelines).
+
+## Branching
+
+When contributing documentation to this repository, we follow a number of guidelines.
+
+### Branch Naming
+
+All branch names should begin with a topic. Accepted topics are:
+
+- `doc`: documentation
+- `util`: utilities
+
+All branches shall therefore have one of these names.
+
+- `doc/#-short-name` or `doc/short-name`: refers to a documentation update, preferably with issue number. The short name describes the topic.
+- `util/#-short-name` or `util/short-name`: refers to updates to the way this repository is deployed or managed. The short name describes the feature.
+
+### Scope
+
+A branch should be **small and focused** and should be scoped to a **single specific task**. Do not combine new features and refactoring of existing documentation or tooling.
+
+### Pull requests and rebasing
+
+Pull requests shall close or reference issues. Please file an issue first before submitting a pull request. When submitting a pull request, please fill out all the sections in the pull request template.
+
+- **Before** a reviewer is assigned, rebasing the branch to reduce the number of commits is highly advised. We recommend self-reviewing your own pull request: making the [commit](#commit) history clean, checking for typos or incoherences, and making sure Continuous Integration passes.
+- **During** a pull request's review, do not squash commits: it makes it harder for reviewers to read the evolution of a pull request. Making the commit history denser to answer reviewers' comments is acceptable at that point.
+- Once a pull request **has been approved** by the reviewers, it can be rebased on top of its target branch before it is merged. This is an opportunity for the contributor to clean up the commit history. A reviewer can also ask specifically for a rebase.
+
+## Commits
+
+Keep the commits to be merged clean: adhere to the commit message format defined below and instead of adding and deleting files within a pull request, drop or fix the concerning commit that added the file.
+
+Interactive rebase (`git rebase -i`) can be used to edit or rewrite commits that do not follow these contribution guidelines.
+
+## <a name="commit"></a>Commit Messages
+
+The first line of a commit message is the subject. The commit message may contain a body, separated from the subject by an empty line.
+
+### Commit Subject
+
+The subject contains the concerning topic and a concise message in [the imperative mood](https://chris.beams.io/posts/git-commit/#imperative), starting with a capital. The subject may also contain references to issues or other resources.
+
+The topic is typically a few characters long and should always be present. Accepted topics are:
+
+- `doc`: documentation
+- `util`: utilities
+
+Changes that affect multiple components can be comma separated.
+
+Good commit messages:
+
+- `doc: Add AppEUI to glossary`
+- `util: Refactor makefile`
+
+Make sure that commits are scoped to something meaningful and could potentially be cherry-picked individually.
+
+### Commit Body
+
+The body may contain a more detailed description of the commit, explaining what it changes and why. The "how" is less relevant, as this should be obvious from the diff.
+
+## Style Guidelines
+
+Please respect the following guidelines for content in our documentation site. A copy and paste template for creating new documentation can be found [here](doc/content/example-template).
+
+- Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
+- The title of a doc page is already rendered by the build system as a h1, don't add an extra one.
+- Use title case for headings.
+- A documentation page starts with an introduction, and then the first heading. The first paragraph of the introduction is typically a summary of the page. Use a `<!--more-->` to indicate where the summary ends.
+- Divide long documents into separate files, each with its own folder and `_index.md`.
+- Use the `weight`tag in the [Front Matter](https://gohugo.io/content-management/front-matter/) to manually sort sections if necessary. If not, they will be sorted alphabetically.
+- Since the title is a `h1`, everything in the content is at least `h2` (`##`).
+- Paragraphs typically consist of at least two sentences.
+- Use an empty line between all blocks (headings, paragraphs, lists, ...).
+- Prefer text over bullet lists or enumerations. For bullets, use `-`, for enumerations `1.` etc.
+- Explicitly call this product "The Things Stack". Not "the stack" etc. You can use the shortcode `{{% tts %}}` which will expand to "The Things Stack".
+- Avoid shortening, i.e. write "it is" instead of "it's".
+- Write guides as a goal-oriented journey.
+- Unless already clear from context, use a clearer term than "user", especially if there are multiple kinds (network operator, gateway owner, application developer, ...).
+- The user does not have a gender (so use they/them/their).
+- Taking screenshots is done as follows:
+  - In Chrome: activate the **Developer Tools** and toggle the **Device Toolbar**. In the **Device Toolbar**, select **Laptop with HiDPI screen** (add it if not already there), and click **Capture Screenshot** in the menu on the right.
+  - In Firefox: enter **Responsive Design Mode**. In the **Device Toolbar**, select "Laptop with HiDPI screen" (add it if not already there) and **Take a screenshot of the viewport**.
+- Use `**Strong**` when referring to buttons in the Console.
+- Use `>Note:`to add a note.
+- Use fenced code blocks with a language:
+  - `bash` for lists of environment variables: `SOME_ENV="value"`.
+  - `bash` for CLI examples. Prefix commands with `$ `. Wrap strings with double quotes `""` (except when working with JSON, which already uses double quotes).
+  - Wrap large CLI output with `<details><summary>Show CLI output</summary> ... output here ... </details>`.
+  - `yaml` (not `yml`) for YAML. Wrap strings with single quotes `''` (because of frequent Go templates that use double quotes).
+
+## Legal
+
+The Things Stack Documentation is Apache 2.0 licensed.

--- a/LICENSE
+++ b/LICENSE
@@ -172,30 +172,3 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lorawan Stack Documentation
+# The Things Stack Documentation
 
 The documentation site for The Things Stack is built with [Hugo](https://gohugo.io/documentation/).
 All content is stored as Markdown files in `doc/content`.
@@ -38,32 +38,6 @@ output the site to `public`.
 The documentation site can be built for internal (offline) use by running `make build.internal`. This will
 output the site to `internal`.
 
-## Style Guidelines
+## Contributing
 
-Please respect the following guidelines for content in our documentation site. A copy and paste template for creating new documentation can be found [here](doc/content/example-template).
-
-- Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
-- The title of a doc page is already rendered by the build system as a h1, don't add an extra one.
-- Use title case for headings.
-- A documentation page starts with an introduction, and then the first heading. The first paragraph of the introduction is typically a summary of the page. Use a `<!--more-->` to indicate where the summary ends.
-- Divide long documents into separate files, each with its own folder and `_index.md`.
-- Use the `weight`tag in the [Front Matter](https://gohugo.io/content-management/front-matter/) to manually sort sections if necessary. If not, they will be sorted alphabetically.
-- Since the title is a `h1`, everything in the content is at least `h2` (`##`).
-- Paragraphs typically consist of at least two sentences.
-- Use an empty line between all blocks (headings, paragraphs, lists, ...).
-- Prefer text over bullet lists or enumerations. For bullets, use `-`, for enumerations `1.` etc.
-- Explicitly call this product "The Things Stack". Not "the stack" etc. You can use the shortcode `{{% tts %}}` which will expand to "The Things Stack".
-- Avoid shortening, i.e. write "it is" instead of "it's".
-- Write guides as a goal-oriented journey.
-- Unless already clear from context, use a clearer term than "user", especially if there are multiple kinds (network operator, gateway owner, application developer, ...).
-- The user does not have a gender (so use they/them/their).
-- Taking screenshots is done as follows:
-  - In Chrome: activate the **Developer Tools** and toggle the **Device Toolbar**. In the **Device Toolbar**, select **Laptop with HiDPI screen** (add it if not already there), and click **Capture Screenshot** in the menu on the right.
-  - In Firefox: enter **Responsive Design Mode**. In the **Device Toolbar**, select "Laptop with HiDPI screen" (add it if not already there) and **Take a screenshot of the viewport**.
-- Use `**Strong**` when referring to buttons in the Console.
-- Use `>Note:`to add a note.
-- Use fenced code blocks with a language:
-  - `bash` for lists of environment variables: `SOME_ENV="value"`.
-  - `bash` for CLI examples. Prefix commands with `$ `. Wrap strings with double quotes `""` (except when working with JSON, which already uses double quotes).
-  - Wrap large CLI output with `<details><summary>Show CLI output</summary> ... output here ... </details>`.
-  - `yaml` (not `yml`) for YAML. Wrap strings with single quotes `''` (because of frequent Go templates that use double quotes).
+Please see the style, branch naming, and commit guidelines in [CONTRIBUTING](CONTRIBUTING.md)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Proposal for license and contributing doc.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Do we need a changelog here? How do we release the docs?

I am for build and deploy automatically on any merges to master, and I suppose we manually update versions whenever a new lorawan-stack tag is released.

Hugo uses a `master` and `next` scheme for changes which will apply to future releases -> https://github.com/gohugoio/hugoDocs

They also recommend that pull requests include changes to both the code repo and the docs repo, but I don't know how that's possible

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in `README.md`.
- [ ] Style Guidelines: Documentation obeys style guidelines in `README.md`.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
