### PR TITLE
doc: Add Chirpstack migration section to docs

### DIFF
--- a/doc/content/getting-started/migrating-from-networks/device-json.md
+++ b/doc/content/getting-started/migrating-from-networks/device-json.md
@@ -1,7 +1,7 @@
 ---
 title: "Create JSON file to be imported"
 description: ""
-weight: 10
+weight: 1
 ---
 
 {{% tts %}} allows you to import devices from other networks using a JSON file describing those devices. Devices imported this way can be migrated without the need for a rejoin.

--- a/doc/content/getting-started/migrating-from-networks/import-devices.md
+++ b/doc/content/getting-started/migrating-from-networks/import-devices.md
@@ -1,6 +1,6 @@
 ---
 title: Import End Devices in The Things Stack
-weight: 20
+weight: 2
 ---
 
 To import your devices, you need an application in {{% tts %}}. This can be done by following instructions for [Creating an Application]({{< ref "integrations/adding-applications" >}}).

--- a/doc/content/getting-started/migrating-from-networks/migrate-from-chirpstack.md
+++ b/doc/content/getting-started/migrating-from-networks/migrate-from-chirpstack.md
@@ -1,0 +1,75 @@
+---
+title: "Migrate from ChirpStack"
+description: ""
+weight: 3
+---
+
+This section contains instructions on how to migrate end devices from ChirpStack to {{% tts %}}.
+
+<!--more-->
+
+End devices and applications can easily be migrated from ChirpStack to {{% tts %}} with the `ttn-lw-migrate` tool. This tool is used for exporting end devices and applications to a [JSON file]({{< ref "getting-started/migrating-from-networks/device-json.md" >}}) containing their description. This file can later be imported in {{% tts %}} as described in the [Import End Devices in The Things Stack]({{< ref "getting-started/migrating-from-networks/import-devices.md" >}}) section.
+
+First, configure the environment with the following variables modified according to your setup:
+
+```bash
+$ export CHIRPSTACK_API_URL="localhost:8080"    # ChirpStack Application Server URL
+$ export CHIRPSTACK_API_TOKEN="7F0as987e61..."  # ChirpStack API key
+$ export JOIN_EUI="0101010102020203"            # Set JoinEUI for exported devices
+$ export FREQUENCY_PLAN_ID="EU_863_870"         # Set FrequencyPlanID for exported devices
+$ export CHIRPSTACK_API_INSECURE=0              # Set to 1 if not using TLS
+```
+
+>Note: `JoinEUI` and `FrequencyPlanID` have to be set because ChirpStack does not store these variables.
+
+## Export End Devices
+
+With `ttn-lw-migrate` tool you can export a single or multiple end devices based on their `DevEUI`.
+
+To export a single end device's description to a `device.json` file, use the following command in your terminal:
+
+```bash
+$ ttn-lw-migrate --source chirpstack device "0102030405060701" > device.json
+```
+
+To export multiple end devices, you need to create a `.txt` file containing one DevEUI per line as in example below.
+
+<details><summary>Example of devices.txt</summary>
+
+```bash
+0102030405060701
+0102030405060702
+0102030405060703
+0102030405060704
+0102030405060705
+0102030405060706
+```
+
+</details>
+
+To export multiple end devices to a `devices.json` file, run the following command in your terminal:
+
+```bash
+$ ttn-lw-migrate --source chirpstack device < devices.txt > devices.json
+```
+
+## Export Applications
+
+You can also export applications with `ttn-lw-migrate` tool using their names, which results with a JSON file containing descriptions of all the end devices that the application contains.
+
+Use the following command to export end devices from a single application:
+
+```bash
+$ ttn-lw-migrate --source chirpstack application "app1" > application.json
+```
+
+To export end devices from multiple applications to an `applications.json` file, you need to create a `.txt` file containing one application name per line and run the following command in your terminal:
+
+```bash
+$ ttn-lw-migrate --source chirpstack application < applications.txt > applications.json
+```
+
+>**Notes**: 
+>- ABP end devices without an active session can be exported from ChirpStack, but cannot be imported in {{% tts %}}.
+>- `MaxEIRP` parameter may not be always set properly.
+>- ChirpStack `variables` parameter related to payload formatting will always be converted to `null` when the end device is imported to {{% tts %}}.


### PR DESCRIPTION
#### Summary
Adding instructions for exporting devices from Chirpstack.
Ref: https://github.com/TheThingsIndustries/lorawan-stack/issues/2329

#### Testing
Tested `ttn-lw-migrate` tool according to [these instructions](https://github.com/TheThingsIndustries/lorawan-stack-migrate/blob/master/README.md) with local TTS and Chirpstack deployments.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
