### PR TITLE
doc: Add archetype to easily create new docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,13 @@ Make sure that commits are scoped to something meaningful and could potentially 
 
 The body may contain a more detailed description of the commit, explaining what it changes and why. The "how" is less relevant, as this should be obvious from the diff.
 
+## Creating New Documentation
+
+Run `make new <path>` to create a new documentation section from the [template](doc/archetypes/section-bundle/_index.md) at `path`. For example, `make new getting-started/hello` will create a section in `getting-started/hello`.
+
 ## Style Guidelines
 
-Please respect the following guidelines for content in our documentation site. A copy and paste template for creating new documentation can be found [here](doc/content/example-template).
+Please respect the following guidelines for content in our documentation site.
 
 - Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
 - The title of a doc page is already rendered by the build system as a h1, don't add an extra one.

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ build.public: deps
 server: deps
 	$(HUGO) server -s $(DOC_ROOT) --environment $(ENVIRONMENT)
 
+.PHONY: new
+new:
+	$(HUGO) new --kind section-bundle -s $(DOC_ROOT) $(filter-out $@,$(MAKECMDGOALS))
+%:
+	@:
+
 .PHONY: deps
 deps: hooks $(FREQUENCY_PLAN_DEST) | $(YARN_DEPS)
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ output the site to `internal`.
 ## Contributing
 
 Please see the style, branch naming, and commit guidelines in [CONTRIBUTING](CONTRIBUTING.md)
+
+## Creating New Documentation
+
+Run `make new <path>` to create a new documentation section from the [template](doc/archetypes/section-bundle/_index.md) at `path`. For example, `make new getting-started/hello` will create a section in `getting-started/hello`.

--- a/doc/archetypes/section-bundle/_index.md
+++ b/doc/archetypes/section-bundle/_index.md
@@ -1,12 +1,11 @@
 ---
-title: "Draft Template"
-description: "This page is a draft template"
+title: "{{ replace .Name "-" " " | title }}"
+description: ""
 weight: 
-distributions: ["Marketplace Launcher", "Enterprise"]
-draft: true
+distributions: {{ jsonify (index site.Data "distributions") }}
 ---
 
-Guidelines here are taken from [DEVELOPMENT.md](https://github.com/TheThingsNetwork/lorawan-stack/blob/default/DEVELOPMENT.md), which you should read. This template exists as a copy and paste starting point for new documentation. Remove the `draft`key in the Front Matter to generate the page (otherwise hugo will skip it).
+Guidelines here are taken from [CONTRIBUTING.md](CONTRIBUTING.md) in this repository, which you should read. This template exists as a copy and paste starting point for new documentation. Remove the `draft`key in the Front Matter to generate the page (otherwise hugo will skip it).
 
 A documentation page starts with an introduction, and then the first heading. The first paragraph of the introduction is typically a summary of the page. Use a <!--more--> to indicate where the summary ends.
 
@@ -19,12 +18,16 @@ Use a requirements subheading to list requirements/prerequisites.
 1. Requirement 1
 2. Requirement 2
 
+## Links Within Docs
+
+Use the `ref` shortcode. For example, [this is a link to the component reference]({{< ref "reference/components" >}}).
+
 ## Distributions
 
 To mark a document as applicable to only one or more distributions, there are three options:
 
-1. Add an array of titles to a `distribution` front matter element. This will mark the page in the parent's table of contents, and will produce a notification on the page
-2. Use the {{< distribution "Enterprise" "Cloud" >}} shortcode to produce a notification on the page
+1. Add an array of titles to a `distributions` front matter element. This will mark the page in the parent's table of contents, and will produce a notification on the page
+2. Use the {{< distributions "Enterprise" "Cloud" >}} shortcode to produce a notification on the page
 3. Use the {{< distributions-inline "Enterprise" >}} shortcode to produce an inline notification. This is especially useful for tables and lists
 
 Available distributions are {{< distributions-list >}} and are stored in `data/distributions.yml`.
@@ -156,5 +159,5 @@ $ curl --location --header 'Authorization: Bearer NNSXS.XXXXXXXXX' --header 'Acc
 It is also possible to host source code (or any text file) and display it using shortcodes. For example:
 
 {{< highlight yaml "linenos=table,linenostart=5" >}}
-{{< readfile path="/content/getting-started/installation/configuration/docker-compose.yml" from=5 to=13 >}}
+{{< readfile path="/content/getting-started/installation/configuration/docker-compose-enterprise.yml" from=5 to=14 >}}
 {{< /highlight >}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Turned the example doc in to an archetype so we can easily create new docs with `make new <path>`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in `README.md`.
- [x] Style Guidelines: Documentation obeys style guidelines in `README.md`.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
