### PR TITLE
Fix old docs links in config

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -22,8 +22,8 @@ pygmentsUseClasses = true
 [params]
   description = "The Things Stack for LoRaWAN"
   keywords = []
-  github_repository = "https://github.com/TheThingsNetwork/lorawan-stack"
-  github_repository_edit = "https://github.com/TheThingsNetwork/lorawan-stack/blob/default/doc/content"
+  github_repository = "https://github.com/TheThingsIndustries/lorawan-stack-docs"
+  github_repository_edit = "https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/content"
   version = "v3.10"
 
 [markup]
@@ -34,7 +34,7 @@ pygmentsUseClasses = true
 [menu]
   [[menu.contributing]]
     name = "GitHub"
-    url = "https://github.com/TheThingsNetwork/lorawan-stack"
+    url = "https://github.com/TheThingsIndustries/lorawan-stack-docs"
     weight = 1
 
   [[menu.contributing]]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix old docs references in config

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
