### PR TITLE
Add ES5 warning to payload formatter doc

### DIFF
--- a/doc/content/integrations/payload-formatters/javascript.md
+++ b/doc/content/integrations/payload-formatters/javascript.md
@@ -7,6 +7,8 @@ Javascript payload formatters allow you to write your own functions to encode or
 
 <!--more-->
 
+> **Note:** There are major differences between EC5 and EC6. See [here](https://www.javatpoint.com/es5-vs-es6) for a quick comparison. Notably, `let`, `const`, and arrow functions are not supported by EC5.
+
 The payload formatters should be simple and lightweight. Use arithmetic operations and bit shifts to convert binary data to fields. Avoid using non-trivial logic or polyfills. The runtime does not support modules or any input/output other than defined below.
 
 ## Decode Uplink Function

--- a/doc/content/integrations/payload-formatters/javascript.md
+++ b/doc/content/integrations/payload-formatters/javascript.md
@@ -7,7 +7,7 @@ Javascript payload formatters allow you to write your own functions to encode or
 
 <!--more-->
 
-> **Note:** There are major differences between EC5 and EC6. See [here](https://www.javatpoint.com/es5-vs-es6) for a quick comparison. Notably, `let`, `const`, and arrow functions are not supported by EC5.
+> **Note:** Payload formatters use ECMAScript ES5 (2015), which has some distinct differences compared to newer, commonly used ECMAScript revisions. See [here](https://www.javatpoint.com/es5-vs-es6) for a quick comparison. Notably, `let`, `const`, and arrow functions are not supported by ES5.
 
 The payload formatters should be simple and lightweight. Use arithmetic operations and bit shifts to convert binary data to fields. Avoid using non-trivial logic or polyfills. The runtime does not support modules or any input/output other than defined below.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Warn about ES5 vs ES6

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
