### PR TITLE
util: Prepare for tti.com/docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,11 @@ max_line_length = unset
 [*.go]
 indent_style = tab
 
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
 [Makefile]
 indent_style = tab
 indent_size = 2

--- a/.github/workflows/cloudformation.yml
+++ b/.github/workflows/cloudformation.yml
@@ -1,0 +1,33 @@
+name: CloudFormation Templates
+
+on:
+  push:
+    paths:
+    - 'deploy/**'
+  pull_request:
+    paths:
+    - 'deploy/**'
+
+jobs:
+  quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '~3.8'
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: pip3 install -r deploy/src/requirements.txt
+    - name: Rebuild templates
+      run: cd deploy && python3 src/stack.py
+    - name: Lint templates
+      uses: ScottBrenner/cfn-lint-action@1.6.0
+      with:
+        args: 'deploy/*.yaml'
+    - name: Check for diff
+      run: git diff --exit-code --name-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,12 @@ jobs:
   release:
     name: Release docs
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     steps:
     - name: Check out code
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -21,7 +22,7 @@ jobs:
     - name: Build docs
       run: make build.public
       env:
-        HUGO_BASE_URL: https://thethingsstack.io/
+        HUGO_BASE_URL: /docs
         HUGO_GOOGLEANALYTICS: ${{ secrets.HUGO_GOOGLEANALYTICS }}
         HUGO_PARAMS_FEEDBACK_CAMPAIGN: ${{ secrets.HUGO_PARAMS_FEEDBACK_CAMPAIGN }}
         HUGO_PARAMS_FEEDBACK_ENABLED: true
@@ -30,9 +31,23 @@ jobs:
         HUGO_PARAMS_SEARCH_APIKEY: ${{ secrets.HUGO_PARAMS_SEARCH_APIKEY }}
         HUGO_PARAMS_SEARCH_ENABLED: true
         HUGO_PARAMS_SEARCH_INDEX: thethingsstack
-    - name: Deploy documentation to Github pages
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: public
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Build docker image
+      run: sudo docker image build -t thethingsindustries/thethingsindustries:docs .
+    - name: Docker Login
+      run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Push docker image
+      run: docker push thethingsindustries/thethingsindustries:docs
+    - name: Restart ECS
+      run: |
+        aws ecs update-service --cluster docs-cluster --service docs-dev --force-new-deployment
+        aws ecs update-service --cluster docs-cluster --service docs-prod --force-new-deployment
+    - name: Wait for steady state
+      run: |
+        aws ecs wait services-stable --cluster docs-cluster --service docs-dev
+        aws ecs wait services-stable --cluster docs-cluster --service docs-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.19
+RUN rm -rf /etc/nginx/conf.d/default.conf
+RUN rm -rf /docker-entrypoint.d/*
+WORKDIR /docs
+ADD deploy/nginx.conf /etc/nginx/conf.d/
+ADD public /docs

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ output the site to `public`.
 The documentation site can be built for internal (offline) use by running `make build.internal`. This will
 output the site to `internal`.
 
+## thethingsindustries.com/docs deployment
+
+thethingsindustries.com/docs uses docker image thethingsindustries/thethingsindustries.com:docs that contains an nginx server serving docs. Repository has a github action that automatically, upon push to `master`, updates the image and restarts services in AWS.
+
 ## Contributing
 
 Please see the style, branch naming, and commit guidelines in [CONTRIBUTING](CONTRIBUTING.md)

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,16 @@
+error_log stderr;
+access_log /dev/stdout;
+
+server {
+    listen 80 default_server;
+    client_max_body_size 1m;
+    index index.html;
+    autoindex off;
+
+    error_page 404 /docs/404.html;
+
+    location /docs {
+      alias /docs;
+      try_files $uri $uri/ /docs/404.html =404;
+    }
+}

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,186 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Docs service template for thethingsindustries.com
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterLabels:
+      CPU:
+        default: CPU limit of a container
+      DockerImage:
+        default: Docker image
+      Memory:
+        default: Memory limit of a container
+      TaskDesiredCount:
+        default: Number of container instances to run (prod only)
+Parameters:
+  CPU:
+    AllowedPattern: .+
+    Default: '256'
+    Type: String
+  DockerImage:
+    AllowedPattern: .+
+    Default: thethingsindustries/thethingsindustries:docs
+    Type: String
+  Memory:
+    AllowedPattern: .+
+    Default: '512'
+    Type: String
+  TaskDesiredCount:
+    Default: 2
+    Type: Number
+Resources:
+  ECSServiceDev:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3002
+    Properties:
+      Cluster:
+        Ref: ECSTaskCluster
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+      - ContainerName: docs
+        ContainerPort: 80
+        TargetGroupArn:
+          Fn::ImportValue: tticom-dev-DocsTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+          - Fn::ImportValue: tticom-dev-AppSecurityGroup
+          Subnets:
+          - Fn::ImportValue: tticom-dev-SubnetAZa
+          - Fn::ImportValue: tticom-dev-SubnetAZb
+          - Fn::ImportValue: tticom-dev-SubnetAZc
+      ServiceName: docs-dev
+      TaskDefinition:
+        Ref: TaskDefinitionDev
+    Type: AWS::ECS::Service
+  ECSServiceProd:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3002
+    Properties:
+      Cluster:
+        Ref: ECSTaskCluster
+      DesiredCount:
+        Ref: TaskDesiredCount
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+      - ContainerName: docs
+        ContainerPort: 80
+        TargetGroupArn:
+          Fn::ImportValue: tticom-prod-DocsTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+          - Fn::ImportValue: tticom-prod-AppSecurityGroup
+          Subnets:
+          - Fn::ImportValue: tticom-prod-SubnetAZa
+          - Fn::ImportValue: tticom-prod-SubnetAZb
+          - Fn::ImportValue: tticom-prod-SubnetAZc
+      ServiceName: docs-prod
+      TaskDefinition:
+        Ref: TaskDefinitionProd
+    Type: AWS::ECS::Service
+  ECSTaskCluster:
+    Properties:
+      ClusterName: docs-cluster
+    Type: AWS::ECS::Cluster
+  TaskDefinitionDev:
+    Properties:
+      ContainerDefinitions:
+      - Image:
+          Ref: DockerImage
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: tticom-dev-LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: docs-dev
+        Name: docs
+        PortMappings:
+        - ContainerPort: 80
+          Protocol: tcp
+        RepositoryCredentials:
+          CredentialsParameter:
+            Fn::ImportValue: tticom-dev-DockerLogin
+      Cpu:
+        Ref: CPU
+      ExecutionRoleArn:
+        Ref: TaskExecutionRole
+      Family: docs-dev
+      Memory:
+        Ref: Memory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+      - FARGATE
+    Type: AWS::ECS::TaskDefinition
+  TaskDefinitionProd:
+    Properties:
+      ContainerDefinitions:
+      - Image:
+          Ref: DockerImage
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: tticom-prod-LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: docs-prod
+        Name: docs
+        PortMappings:
+        - ContainerPort: 80
+          Protocol: tcp
+        RepositoryCredentials:
+          CredentialsParameter:
+            Fn::ImportValue: tticom-prod-DockerLogin
+      Cpu:
+        Ref: CPU
+      ExecutionRoleArn:
+        Ref: TaskExecutionRole
+      Family: docs-prod
+      Memory:
+        Ref: Memory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+      - FARGATE
+    Type: AWS::ECS::TaskDefinition
+  TaskExecutionRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service:
+            - ecs-tasks.amazonaws.com
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action:
+            - secretsmanager:GetSecretValue
+            Effect: Allow
+            Resource:
+            - Fn::ImportValue: tticom-dev-DockerLogin
+            - Fn::ImportValue: tticom-prod-DockerLogin
+          - Action:
+            - logs:CreateLogStream
+            - logs:DescribeLogStreams
+            - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+            - Fn::ImportValue: tticom-dev-LogGroupArn
+            - Fn::ImportValue: tticom-prod-LogGroupArn
+          Version: '2012-10-17'
+        PolicyName: docs-execution
+      RoleName: docs-ExecutionRole
+    Type: AWS::IAM::Role

--- a/deploy/src/config.py
+++ b/deploy/src/config.py
@@ -1,0 +1,13 @@
+#!/bin/python3
+import troposphere as T
+
+AVAILABILITY_ZONES = ['a', 'b', 'c']
+PROJECTS = ["dev", "prod"]
+
+
+def make_template(description):
+    template = T.Template()
+    template.set_version("2010-09-09")
+    template.set_description(description)
+    template.add_resources = lambda resources: [template.add_resource(resource) for resource in resources]
+    return template

--- a/deploy/src/requirements.txt
+++ b/deploy/src/requirements.txt
@@ -1,0 +1,2 @@
+troposphere>=2.6.3
+pyyaml>=5.3.1

--- a/deploy/src/stack.py
+++ b/deploy/src/stack.py
@@ -1,0 +1,167 @@
+#!/bin/python3
+import os
+os.environ["TROPO_REAL_BOOL"] = "True"  # Before we import troposphere
+from collections import OrderedDict
+from config import *
+import yaml
+from troposphere import ecs, logs, iam, secretsmanager, ec2, elasticloadbalancingv2 as elb2
+
+
+def make_service_template():
+    template = make_template("Docs service template for thethingsindustries.com")
+
+    def import_value(project, name):
+        if project not in PROJECTS:
+            raise ValueError
+        return T.ImportValue(f'tticom-{project}-{name}')
+
+    service_params = {
+        "dev": {
+            "TaskDesiredCount": 1,
+        },
+        "prod": {
+            "TaskDesiredCount": T.Ref("TaskDesiredCount"),
+        },
+    }
+
+    for name, type, default, description in [
+        ("DockerImage", "String", "thethingsindustries/thethingsindustries:docs", "Docker image"),
+        ("CPU", "String", "256", "CPU limit of a container"),
+        ("Memory", "String", "512", "Memory limit of a container"),
+        ("TaskDesiredCount", "Number", 2, "Number of container instances to run (prod only)"),
+    ]:
+        if type == "String":
+            if default == '':
+                param = T.Parameter(name, AllowedPattern=".+", Type=type)
+            else:
+                param = T.Parameter(name, AllowedPattern=".+", Default=default, Type=type)
+        elif type == "Boolean":
+            param = T.Parameter(name, AllowedValues=["true", "false"], Default=default, Type="String")
+        else:
+            param = T.Parameter(name, Default=default, Type=type)
+        template.add_parameter(param)
+        template.set_parameter_label(param, description)
+
+    execution_role = T.iam.Role("TaskExecutionRole",
+                                AssumeRolePolicyDocument={
+                                    "Statement": [{
+                                        "Effect": "Allow",
+                                        "Principal": {"Service": ["ecs-tasks.amazonaws.com"]},
+                                        "Action": ["sts:AssumeRole"]
+                                    }]
+                                },
+                                Policies=[iam.Policy("SecretsPolicy",
+                                                     PolicyName="docs-execution",
+                                                     PolicyDocument={
+                                                         "Version": "2012-10-17",
+                                                         "Statement": [
+                                                             {
+                                                                 "Action": [
+                                                                     "secretsmanager:GetSecretValue",
+                                                                 ],
+                                                                 "Effect": "Allow",
+                                                                 "Resource": [import_value(p, "DockerLogin") for p in
+                                                                              PROJECTS],
+                                                             },
+                                                             {
+                                                                 "Action": [
+                                                                     "logs:CreateLogStream",
+                                                                     "logs:DescribeLogStreams",
+                                                                     "logs:PutLogEvents",
+                                                                 ],
+                                                                 "Effect": "Allow",
+                                                                 "Resource": [import_value(p, "LogGroupArn") for p in
+                                                                              PROJECTS],
+                                                             },
+                                                         ]
+                                                     })],
+                                RoleName="docs-ExecutionRole",
+                                )
+    template.add_resource(execution_role)
+
+    task_definitions = {
+        project: T.ecs.TaskDefinition("TaskDefinition" + project.capitalize(),
+                                      ContainerDefinitions=[
+                                          T.ecs.ContainerDefinition(
+                                              Image=T.Ref("DockerImage"),
+                                              LogConfiguration=T.ecs.LogConfiguration(
+                                                  LogDriver="awslogs",
+                                                  Options={
+                                                      "awslogs-group": f'tticom-{project}-LogGroup',
+                                                      "awslogs-region": T.Ref("AWS::Region"),
+                                                      "awslogs-stream-prefix": "docs-" + project,
+                                                  },
+                                              ),
+                                              Name="docs",
+                                              PortMappings=[
+                                                  T.ecs.PortMapping(ContainerPort=80, Protocol="tcp")],
+                                              RepositoryCredentials=T.ecs.RepositoryCredentials(
+                                                  CredentialsParameter=import_value(project,
+                                                                                    "DockerLogin"),
+                                              ),
+                                          )
+                                      ],
+                                      Cpu=T.Ref("CPU"),
+                                      ExecutionRoleArn=T.Ref(execution_role),
+                                      Family="docs-" + project,
+                                      Memory=T.Ref("Memory"),
+                                      NetworkMode="awsvpc",
+                                      RequiresCompatibilities=["FARGATE"],
+                                      ) for project in PROJECTS
+    }
+    template.add_resources(task_definitions.values())
+
+    ecs_cluster = T.ecs.Cluster("ECSTaskCluster",
+                                ClusterName="docs-cluster",
+                                )
+    template.add_resource(ecs_cluster)
+
+    services = {
+        project: T.ecs.Service("ECSService" + project.capitalize(),
+                               Cluster=T.Ref(ecs_cluster),
+                               DesiredCount=service_params[project]["TaskDesiredCount"],
+                               HealthCheckGracePeriodSeconds=60,
+                               LaunchType="FARGATE",
+                               LoadBalancers=[T.ecs.LoadBalancer(
+                                   ContainerName="docs",
+                                   ContainerPort=80,
+                                   TargetGroupArn=import_value(project, "DocsTargetGroup"),
+                               )],
+                               Metadata={  # https://github.com/aws-cloudformation/cfn-python-lint/issues/1706
+                                   "cfn-lint": {
+                                       "config": {
+                                           "ignore_checks": ["E3002"]
+                                       }
+                                   }
+                               },
+                               NetworkConfiguration=T.ecs.NetworkConfiguration(
+                                   AwsvpcConfiguration=T.ecs.AwsvpcConfiguration(
+                                       AssignPublicIp="ENABLED",
+                                       SecurityGroups=[import_value(project, "AppSecurityGroup")],
+                                       Subnets=[import_value(project, "SubnetAZ" + az) for az in AVAILABILITY_ZONES]
+                                   )
+                               ),
+                               ServiceName="docs-" + project,
+                               TaskDefinition=T.Ref(task_definitions[project]),
+                               ) for project in PROJECTS
+    }
+    template.add_resources(services.values())
+    return template
+
+
+def print_template(template, name):
+    dictionary = template.to_dict()
+    ordered_dictionary = OrderedDict()
+    for key in ["AWSTemplateFormatVersion", "Description", "Metadata", "Parameters", "Conditions", "Resources",
+                "Outputs"]:
+        if key in dictionary:
+            ordered_dictionary[key] = dictionary[key]
+    for key in dictionary.keys():
+        if key not in ordered_dictionary:
+            ordered_dictionary[key] = dictionary[key]
+    with open(f"{name}.yaml", 'w') as file:
+        for key, value in ordered_dictionary.items():
+            yaml.dump({key: value}, file, default_flow_style=False, allow_unicode=True)
+
+
+print_template(make_service_template(), "service")


### PR DESCRIPTION
#### Summary
See https://github.com/TheThingsIndustries/thethingsindustries.com/issues/245

#### Changes
1. Add generation of dockerhub image serving /docs
2. Remove generation of github-pages from github action

#### Notes for Reviewers
This PR is to be merged once we deploy tti.com on AWS on prod. We can accept earlier though.

#### Checklist
- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
