### PR TITLE
doc: Fix UDP forwarder reference

### DIFF
--- a/doc/content/gateways/ciscowirelessgateway/_index.md
+++ b/doc/content/gateways/ciscowirelessgateway/_index.md
@@ -227,7 +227,7 @@ bash-3.2# cp /tools/pkt_forwarder /etc/pktfwd/pkt_forwarder
 ```
 
 **Retrieve configuration from the Gateway Configuration Server**
-The Gateway Configuration Server can be used to retrieve a proper `global_conf.json` configuration file for your gateway. Follow instructions [here]({{< relref src="../semtech-udp-packet-forwarder" >}}).
+The Gateway Configuration Server can be used to retrieve a proper `global_conf.json` configuration file for your gateway. Follow instructions [here]({{< ref "/gateways/semtech-udp-packet-forwarder" >}}).
 
 Copy the downloaded `global_conf.json` configuration template as **config.json** to **/etc/pktfwd** 
 


### PR DESCRIPTION
#### Summary
Fixing reference to point to Semtech UDP packet forwarder page instead of looping to the same page.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
