### PR TITLE
util: Add user variables section to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,14 +98,13 @@ Mark documentation that applies only to a specific distribution in one of the fo
 
 Please respect the following guidelines for content in our documentation site.
 
-- Use the [`distributions`](#distributions) Front Matter element or shortcodes to mark documentation that applies to particular distributions of The Things Stack.
-- Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
 - The title of a doc page is already rendered by the build system as a h1, don't add an extra one.
 - Use title case for headings.
 - A documentation page starts with an introduction, and then the first heading. The first paragraph of the introduction is typically a summary of the page. Use a `<!--more-->` to indicate where the summary ends.
 - Divide long documents into separate files, each with its own folder and `_index.md`.
+- Use the [`distributions`](#distributions) Front Matter element or shortcodes to mark documentation that applies to particular distributions of The Things Stack.
+- Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
 - Use the `weight`tag in the [Front Matter](https://gohugo.io/content-management/front-matter/) to manually sort sections if necessary. If not, they will be sorted alphabetically.
-- Use the `distributions` tag in the front matter to emphasize the distribution of The Things Stack which the section refers to. This tag can take values "Cloud", "Dedicated Cloud", "Marketplace Launcher", "Enterprise", "Community" and "Open Source".
 - Since the title is a `h1`, everything in the content is at least `h2` (`##`).
 - Paragraphs typically consist of at least two sentences.
 - Use an empty line between all blocks (headings, paragraphs, lists, ...).
@@ -125,6 +124,8 @@ Please respect the following guidelines for content in our documentation site.
   - `bash` for CLI examples. Prefix commands with `$ `. Wrap strings with double quotes `""` (except when working with JSON, which already uses double quotes).
   - Wrap large CLI output with `<details><summary>Show CLI output</summary> ... output here ... </details>`.
   - `yaml` (not `yml`) for YAML. Wrap strings with single quotes `''` (because of frequent Go templates that use double quotes).
+- For variables which a user must replace, use a command to define the variable in the shell, if possible, e.g `API_KEY="your-api-key"`.
+- If not possible to define the variable, use angle brackets to indicate a variable that needs to be replaced, e.g `https://<server-address>`. 
 - In long command line examples or other code snippets, use the following guidelines:
   - If a line is longer than 80 columns, try to find a "natural" break
   - If a line is longer than 120 columns, insert a line break

--- a/doc/archetypes/section-bundle/_index.md
+++ b/doc/archetypes/section-bundle/_index.md
@@ -92,6 +92,19 @@ Thou shalt always use the shortcode {{% tts %}} when referring to this product.
 
 For documentation that requires the Command Line Interface, use the {{% cli-only %}} shortcode.
 
+## User Variables
+
+For variables which a user must replace, use a command to define the variable in the shell, if possible.
+
+```bash
+$ GTW_ID="your-gateway-id"
+$ LNS_KEY="your-lns-api-key"
+$ SECRET=$(echo $LNS_KEY | xxd -p -u | perl -pe 's/\n//')
+$ ttn-lw-cli gateways update $GTW_ID --lbs-lns-secret.value $SECRET
+```
+
+If not possible to define the variable, use angle brackets to indicate a variable that needs to be replaced, e.g `https://<server-address>`. 
+
 ## Syntax Highlighting
 
 See the following examples for types of syntax highlighting.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Define a standard for using variables which a user must replace in docs.

Also reordered/regrouped the style guidelines

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Exporting the variable in to the environment helps because
- It's easy for the user to see the strings they need to replace (they're also highlighted red in code)
- All variables can be moved to the top of the sequence of commands, and the user only need export once

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
