### PR TITLE
Issue/add deprecated short code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,9 +102,10 @@ Please respect the following guidelines for content in our documentation site.
 - Use title case for headings.
 - A documentation page starts with an introduction, and then the first heading. The first paragraph of the introduction is typically a summary of the page. Use a `<!--more-->` to indicate where the summary ends.
 - Divide long documents into separate files, each with its own folder and `_index.md`.
-- Use the [`distributions`](#distributions) Front Matter element or shortcodes to mark documentation that applies to particular distributions of The Things Stack.
+- Use the [`distributions`](#distributions) [Front Matter](https://gohugo.io/content-management/front-matter/) element or shortcodes to mark documentation that applies to particular distributions of The Things Stack.
 - Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `develop` that's the next minor bump, e.g `3.x.0`.
-- Use the `weight`tag in the [Front Matter](https://gohugo.io/content-management/front-matter/) to manually sort sections if necessary. If not, they will be sorted alphabetically.
+- Use the `deprecated_in_version` Front Matter element to mark a section as deprecated, or the `{{< deprecated-in-version "3.11" >}}` shortcode to produce an inline deprecation warning. If necessary, use th `{{< warning >}}` shortcode in the section content to provide additional information, e.g `{{< warning "This feature will be removed in January 5, 2021 for Cloud deployments">}}`.
+- Use the `weight`tag in the Front Matter to manually sort sections if necessary. If not, they will be sorted alphabetically.
 - Since the title is a `h1`, everything in the content is at least `h2` (`##`).
 - Paragraphs typically consist of at least two sentences.
 - Use an empty line between all blocks (headings, paragraphs, lists, ...).

--- a/doc/archetypes/section-bundle/_index.md
+++ b/doc/archetypes/section-bundle/_index.md
@@ -45,6 +45,14 @@ This is new feature text {{< new-in-version "3.8.5">}}
 
 - This is a new feature bullet {{< new-in-version "3.8.5">}}
 
+## Deprecated Features {{< deprecated-in-version "3.11" >}}
+
+For entire sections that are deprecated, use the Front Matter element `deprecated_in_version`.
+
+For an inline tag, use the `{{< deprecated-in-version "3.8.5" >}}` shortcode.
+
+You may additionally provide information using the `{{< warning >}}` shortcode, e.g {{< warning "This feature will be removed in January 5, 2021 for Cloud deployments" >}} 
+
 ## Sections
 
 When possible, divide long documents into separate files, each with its own folder and `_index.md`. Use the `weight` tag in the [Front Matter](https://gohugo.io/content-management/front-matter/) to manually sort sections if necessary. If not, they will be sorted alphabetically.

--- a/doc/content/integrations/pubsub/_index.md
+++ b/doc/content/integrations/pubsub/_index.md
@@ -5,3 +5,7 @@ weight: 40
 ---
 
 The Pub/Sub integration allows the Application Server to publish and subscribe to topics, using {{%tts%}} built-in MQTT client or NATS client.
+
+<!--more-->
+
+>**Warning:** This feature will be removed in January 5, 2021 for Cloud deployments!

--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -371,7 +371,7 @@ details + blockquote {
   padding: 12px;
 }
 
-.new-in-version, .distribution-inline {
+.new-in-version, .distribution-inline, .deprecated-in-version {
   font-family: $family-sans-serif;
   vertical-align: super;
   font-size: 60%;

--- a/doc/themes/the-things-stack/layouts/_default/list.html
+++ b/doc/themes/the-things-stack/layouts/_default/list.html
@@ -6,6 +6,9 @@
 {{ with .Params.new_in_version }}
   {{ partial "new-in-version" . }}
 {{ end }}
+{{ with .Params.deprecated_in_version }}
+  {{ partial "deprecated-in-version" .}}
+{{ end }}
 </h1>
 
 <div class="content">

--- a/doc/themes/the-things-stack/layouts/_default/single.html
+++ b/doc/themes/the-things-stack/layouts/_default/single.html
@@ -6,6 +6,9 @@
 {{ with .Params.new_in_version }}
   {{ partial "new-in-version" . }}
 {{ end }}
+{{ with .Params.deprecated_in_version }}
+  {{ partial "deprecated-in-version" .}}
+{{ end }}
 </h1>
 
 <div class="content">

--- a/doc/themes/the-things-stack/layouts/partials/deprecated-in-version.html
+++ b/doc/themes/the-things-stack/layouts/partials/deprecated-in-version.html
@@ -1,0 +1,1 @@
+<span class="deprecated-in-version">Deprecated in {{ . }}</span>

--- a/doc/themes/the-things-stack/layouts/partials/pages-cards.html
+++ b/doc/themes/the-things-stack/layouts/partials/pages-cards.html
@@ -7,6 +7,9 @@
         {{ with .Params.new_in_version }}
           {{ partial "new-in-version" . }}
         {{ end }}
+        {{ with .Params.deprecated_in_version }}
+          {{ partial "deprecated-in-version" .}}
+        {{ end }}
         </h3>
         {{ with .Params.distributions }}
           {{ $distributions := .}}

--- a/doc/themes/the-things-stack/layouts/shortcodes/deprecated-in-version.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/deprecated-in-version.html
@@ -1,0 +1,1 @@
+{{ partial "deprecated-in-version" (.Get 0) }}


### PR DESCRIPTION
#### Summary

BEN:
I'm proposing we use a `{{< deprecated-in-version "3.11" >}}` shortcode and `deprecated_in_version: "3.11"` Front Matter to mark deprecated features, and we write a custom `{{< warning "This feature will be deprecated on Cloud in January` >}} in content if necessary to provide additional information. We might have deprecated features that don't apply to certain distributions, so it's better not to over engineer that warning.

I've pushed commits that produce the following:

Card:
<img width="518" alt="Screenshot 2020-11-25 at 13 57 21" src="https://user-images.githubusercontent.com/6963436/100231604-90881700-2f27-11eb-9287-991d35bb9be1.png">

Content page:
<img width="1054" alt="Screenshot 2020-11-25 at 13 57 31" src="https://user-images.githubusercontent.com/6963436/100231642-9bdb4280-2f27-11eb-8828-bffb0d05c7ba.png">


OLD: 
Proposing short codes for deprecation warning and inline `Deprecated` label. Also labeling Pub/Sub integration as deprecated.
Reference #106 

#### Changes
Examples of usage in the documentation:
![deprecated](https://user-images.githubusercontent.com/65215579/99543321-582a8b00-29b3-11eb-8561-43e5da02066a.png)

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
