### PR TITLE
Create new_in_version Front Matter

### DIFF
--- a/doc/archetypes/section-bundle/_index.md
+++ b/doc/archetypes/section-bundle/_index.md
@@ -3,6 +3,7 @@ title: "{{ replace .Name "-" " " | title }}"
 description: ""
 weight: 
 distributions: {{ jsonify (index site.Data "distributions") }}
+new_in_version: "3.8.5"
 ---
 
 Guidelines here are taken from [CONTRIBUTING.md](CONTRIBUTING.md) in this repository, which you should read. This template exists as a copy and paste starting point for new documentation. Remove the `draft`key in the Front Matter to generate the page (otherwise hugo will skip it).
@@ -34,7 +35,9 @@ Available distributions are {{< distributions-list >}} and are stored in `data/d
 
 ## New Features {{< new-in-version "3.8.5">}}
 
-Use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `v3.n`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `v3.n+1` that's the next minor bump, e.g `3.9.0`. Check `tools/bin/mage version:current` for the current version.
+For entire pages dedicated to a feature that is new, use the Front Matter element `new_in_version`.
+
+For an inline tag, use the `{{< new-in-version "3.8.5" >}}` shortcode to tag documentation for features added in a particular version. For documentation that targets `v3.n`, that's the next patch bump, e.g `3.8.x`. For documentation targeting `v3.n+1` that's the next minor bump, e.g `3.9.0`. Check `tools/bin/mage version:current` for the current version.
 
 #### This Is A New Feature Heading {{< new-in-version "3.8.5">}}
 

--- a/doc/content/integrations/storage/_index.md
+++ b/doc/content/integrations/storage/_index.md
@@ -3,9 +3,8 @@ title: Storage Integration
 description: ""
 summary: Persistent storage for upstream messages.
 distributions: ["Cloud", "Dedicated Cloud", "Enterprise", "Marketplace Launcher", "Community"]
+new_in_version: "3.10"
 ---
-
-{{< new-in-version "3.10" >}}
 
 The Storage Integration allows storing received upstream messages in a persistent database, and retrieving them at a later time.
 

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -136,9 +136,7 @@ By default users can create applications, gateways, organizations and OAuth clie
 - `is.user-rights.create-gateways`: Allow non-admin users to create gateways in their user account
 - `is.user-rights.create-organizations`: Allow non-admin users to create organizations in their user account
 
-## Gateway Secrets Encryption Options
-
-{{< new-in-version "3.10" >}}
+## Gateway Secrets Encryption Options {{< new-in-version "3.10" >}}
 
 - `is.gateways.encryption-key-id`: ID of the key used to encrypt gateway secrets at rest.
 

--- a/doc/content/reference/federated-auth/_index.md
+++ b/doc/content/reference/federated-auth/_index.md
@@ -1,9 +1,10 @@
 ---
 title: "Federated Authentication"
 description: ""
+new_in_version: "3.10"
 ---
 
-Federated Authentication {{< new-in-version "3.10" >}} allows network administrators to use the already existing identity providers in order to authenticate users, instead of manually creating and managing the accounts in {{% tts %}}.
+Federated Authentication allows network administrators to use the already existing identity providers in order to authenticate users, instead of manually creating and managing the accounts in {{% tts %}}.
 
 <!--more-->
 

--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -372,6 +372,7 @@ details + blockquote {
 }
 
 .new-in-version, .distribution-inline {
+  font-family: $family-sans-serif;
   vertical-align: super;
   font-size: 60%;
   color: $red;

--- a/doc/themes/the-things-stack/layouts/_default/list.html
+++ b/doc/themes/the-things-stack/layouts/_default/list.html
@@ -2,7 +2,11 @@
 {{ if eq .Page.File.Ext "html" }}
 {{ .Content }}
 {{ else }}
-<h1 class="title is-size-2">{{ .Title }}</h1>
+<h1 class="title is-size-2">{{ .Title }}
+{{ with .Params.new_in_version }}
+  {{ partial "new-in-version" . }}
+{{ end }}
+</h1>
 
 <div class="content">
 {{ with .Params.distributions }}

--- a/doc/themes/the-things-stack/layouts/_default/single.html
+++ b/doc/themes/the-things-stack/layouts/_default/single.html
@@ -2,7 +2,11 @@
 {{ if eq .Page.File.Ext "html" }}
 {{ .Content }}
 {{ else }}
-<h1 class="title is-size-2">{{ .Title }}</h1>
+<h1 class="title is-size-2">{{ .Title }}
+{{ with .Params.new_in_version }}
+  {{ partial "new-in-version" . }}
+{{ end }}
+</h1>
 
 <div class="content">
 {{ with .Params.distributions }}

--- a/doc/themes/the-things-stack/layouts/partials/new-in-version.html
+++ b/doc/themes/the-things-stack/layouts/partials/new-in-version.html
@@ -1,0 +1,1 @@
+<span class="new-in-version">New in {{ . }}</span>

--- a/doc/themes/the-things-stack/layouts/partials/pages-cards.html
+++ b/doc/themes/the-things-stack/layouts/partials/pages-cards.html
@@ -3,15 +3,19 @@
   <div class="column is-half is-flex">
     <div class="card has-radius is-fullwidth">
       <div class="card-content">
-        <h3 class="title is-size-5 is-uppercase"><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
-        {{ with .Params.distributions }}
-        {{ $distributions := .}}
-        {{ if ( not ( reflect.IsSlice . ) ) }}
-          {{ $distributions = slice $distributions }}
+        <h3 class="title is-size-5 is-uppercase"><a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{ with .Params.new_in_version }}
+          {{ partial "new-in-version" . }}
         {{ end }}
-        <p class="subtitle is-size-6 is-uppercase">
-            {{ delimit $distributions ", " " and " }} Only
-        </p>
+        </h3>
+        {{ with .Params.distributions }}
+          {{ $distributions := .}}
+          {{ if ( not ( reflect.IsSlice . ) ) }}
+            {{ $distributions = slice $distributions }}
+          {{ end }}
+          <p class="subtitle is-size-6 is-uppercase">
+              {{ delimit $distributions ", " " and " }} Only
+          </p>
         {{ end }}
         <div class="content has-text-grey">
           {{ .Summary }}

--- a/doc/themes/the-things-stack/layouts/shortcodes/new-in-version.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/new-in-version.html
@@ -1,1 +1,1 @@
-<span class="new-in-version">New in {{ (.Get 0) }}</span>
+{{ partial "new-in-version" (.Get 0) }}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #70 

Add Front Matter to mark entire sections as "New in Version."

Looks like:
<img width="467" alt="Screenshot 2020-11-18 at 17 07 44" src="https://user-images.githubusercontent.com/6963436/99559018-9e3c1a80-29c4-11eb-8d87-86e15c89e479.png">

And automatically marks the title on the content page:
<img width="630" alt="Screenshot 2020-11-18 at 17 09 39" src="https://user-images.githubusercontent.com/6963436/99559045-a85e1900-29c4-11eb-844c-beeaca744d8a.png">

Only problem is that it sometimes wraps
<img width="715" alt="Screenshot 2020-11-18 at 17 29 12" src="https://user-images.githubusercontent.com/6963436/99559118-b7dd6200-29c4-11eb-9be3-e76d5b4fb664.png">

Currently styled exactly like inline distributions (distributions styling will change soon with logos)
<img width="748" alt="Screenshot 2020-11-18 at 17 31 05" src="https://user-images.githubusercontent.com/6963436/99559199-cd528c00-29c4-11eb-9c5d-1e1f82e5e196.png">

@pierrephz @kschiffer any quick feedback?

#### Changes
<!-- What are the changes made in this pull request? -->

- Add Front Matter
- Add documentation
- Clean up existing tags

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
