### PR TITLE
Add @pierrephz as style/theme codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,8 +8,8 @@
 /.github/workflows @benolayinka @htdvisser @michalborkowski96
 
 # Hugo
-/doc/themes @kschiffer @benolayinka
-/doc/layouts @kschiffer @benolayinka
+/doc/themes @kschiffer @benolayinka @pierrephz
+/doc/layouts @kschiffer @benolayinka @pierrephz
 
 # Subsections
 /doc/devices @laurensslats @benolayinka


### PR DESCRIPTION
#### Summary
This PR adds @pierrephz as codeowner for the theme and style folders of the docs hugo theme.

#### Changes
- Add Pierre as codeowner

#### Notes for Reviewers
As a designer, @pierrephz should sign off or propose changes to styling changes too

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
