### PR TITLE
doc: Update glossary with info on LoRaWAN versions

### DIFF
--- a/doc/data/glossary.yml
+++ b/doc/data/glossary.yml
@@ -110,7 +110,7 @@
     - Mote
 
 - term: LoRaWAN Version
-  description: The LoRaWAN version is the LoRa Alliance LoRaWAN specification your device conforms to, which defines which Media Access Control features it supports. The LoRaWAN version for your device should be provided by the manufacturer in a datasheet as LoRaWAN version or LoRaWAN specification.
+  description: The LoRaWAN version is the LoRa Alliance LoRaWAN specification your device conforms to, which defines which Media Access Control features it supports. The LoRaWAN version for your device should be provided by the manufacturer in a datasheet as LoRaWAN version or LoRaWAN specification. The most commonly used LoRaWAN versions are v1.0.2 and v1.0.3. ({{% ttnv2 %}} uses v1.0.2 by default).
 
 - term: Media Access Control
   description: LoRaWAN media access control protocols, downloadable from the LoRa Alliance. The Media Access Control version for your device should be provided by the manufacturer in a datasheet as LoRaWAN version or LoRaWAN specification.


### PR DESCRIPTION
#### Summary
Small update on the text about LoRaWAN versions

#### Changes

- Explaining v1.0.2 and v1.0.3 are most commonly used.
