### PR TITLE
Document using ttn-lw-migrate to migrate from v2

### DIFF
--- a/doc/content/getting-started/migrating/_index.md
+++ b/doc/content/getting-started/migrating/_index.md
@@ -5,7 +5,7 @@ weight: -1
 aliases: "/getting-started/migrating-from-networks"
 ---
 
-This guide documents the process of migrating end devices to {{% tts %}} in bulk, without the need for devices to initiate a rejoin.
+This guide documents the process of migrating end devices and gateways to {{% tts %}}.
 
 <!--more-->
 

--- a/doc/content/getting-started/migrating/device-json.md
+++ b/doc/content/getting-started/migrating/device-json.md
@@ -84,8 +84,6 @@ The linked specification is quite extensive, and contains a lot of fields that a
 
 ## Examples
 
-{{< note >}} For more information on configuring MAC settings, see [Fine-tuning MAC Settings]({{< ref "getting-started/migrating/configure-mac-settings" >}}). {{</ note >}}
-
 ### Example OTAA Device:
 <summary><details>
 
@@ -157,5 +155,7 @@ The linked specification is quite extensive, and contains a lot of fields that a
 ```
 
 </details></summary>
+
+{{< note >}} For more information on configuring MAC settings, see [Fine-tuning MAC Settings]({{< ref "getting-started/migrating/configure-mac-settings" >}}). {{</ note >}}
 
 <br>

--- a/doc/content/getting-started/migrating/gateway-migration.md
+++ b/doc/content/getting-started/migrating/gateway-migration.md
@@ -4,9 +4,17 @@ weight: 2
 aliases: "/getting-started/migrating-from-v2/gateway-migration"
 ---
 
-For instructions on adding gateways to {{% tts %}} using the CLI or Console, see [Adding Gateways]({{< ref "gateways/adding-gateways" >}}).
+Migrating gateway is a two step process.
 
-When using the Semtech UDP Packet Forwarder, make sure to update the `server_address` in the gateway configuration settings to the address of the Gateway Server (e.g. `my-tts-network.nam1.cloud.thethings.industries`).
+### Step 1
+
+Add the Gateway in the {{% tts %}}. For instructions on adding gateways to {{% tts %}} using the CLI or Console, see [Adding Gateways]({{< ref "gateways/adding-gateways" >}}).
+
+### Step 2
+
+Update the server address in the gateway configuration settings.
+- When using the Semtech UDP Packet Forwarder, make sure to update the `server_address` in the gateway configuration settings to the address of the ateway Server (e.g. `my-tts-network.nam1.cloud.thethings.industries`).
+- When using the LoRa Basics Station protocol refer [LoRa Basics Station document]({{< ref "gateways/lora-basics-station" >}})
 
 Once your gateways are migrated, data will be routed to {{% tts %}}.
 

--- a/doc/content/getting-started/migrating/gateway-migration.md
+++ b/doc/content/getting-started/migrating/gateway-migration.md
@@ -4,7 +4,7 @@ weight: 2
 aliases: "/getting-started/migrating-from-v2/gateway-migration"
 ---
 
-Migrating gateway is a two step process.
+Migrating gateways is a two step process.
 
 ### Step 1
 
@@ -14,7 +14,7 @@ Add the Gateway in the {{% tts %}}. For instructions on adding gateways to {{% t
 
 Update the server address in the gateway configuration settings.
 - When using the Semtech UDP Packet Forwarder, make sure to update the `server_address` in the gateway configuration settings to the address of the ateway Server (e.g. `my-tts-network.nam1.cloud.thethings.industries`).
-- When using the LoRa Basics Station protocol refer [LoRa Basics Station document]({{< ref "gateways/lora-basics-station" >}})
+- When using the LoRa Basics Station protocol refer to [LoRa Basics Station document]({{< ref "gateways/lora-basics-station" >}})
 
 Once your gateways are migrated, data will be routed to {{% tts %}}.
 

--- a/doc/content/getting-started/migrating/major-changes.md
+++ b/doc/content/getting-started/migrating/major-changes.md
@@ -6,7 +6,6 @@ aliases: ["/getting-started/migrating-from-v2/major-changes", "/getting-started/
 
 Before getting started, we will discuss major breaking changes between {{% ttnv2 %}} and {{% tts %}}, along with some guidelines to make the migration process easier to manage.
 
-See the [API comparison](#api-comparison) for a table of differences between V2 and V3.
 
 ## Architecture
 
@@ -74,9 +73,10 @@ Read more on [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}).
 
 #### Storage Integration
 
-{{% tts %}} does not currently support a Storage integration similar to {{% ttnv2 %}}. This feature will be added in a future release.
+{{% tts %}} does support a Storage integration similar to {{% ttnv2 %}}. Refer [Storage Integration]({{< ref "/integrations/storage" >}}).
 
 ## API Comparison
+{{% tts %}} provides multiple APIs. Refer [APIs Documentation]({{< ref "/reference/api" >}}). For example, MQTT API Comparison is given below.
 
 ### MQTT Connection Details
 

--- a/doc/content/getting-started/migrating/major-changes.md
+++ b/doc/content/getting-started/migrating/major-changes.md
@@ -73,10 +73,10 @@ Read more on [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}).
 
 #### Storage Integration
 
-{{% tts %}} does support a Storage integration similar to {{% ttnv2 %}}. Refer [Storage Integration]({{< ref "/integrations/storage" >}}).
+{{% tts %}} does support a Storage integration similar to {{% ttnv2 %}}. Refer to [Storage Integration]({{< ref "/integrations/storage" >}}).
 
 ## API Comparison
-{{% tts %}} provides multiple APIs. Refer [APIs Documentation]({{< ref "/reference/api" >}}). For example, MQTT API Comparison is given below.
+{{% tts %}} provides multiple APIs. Refer to [APIs Documentation]({{< ref "/reference/api" >}}). For example, MQTT API Comparison is given below.
 
 ### MQTT Connection Details
 

--- a/doc/content/getting-started/migrating/migrate-from-chirpstack.md
+++ b/doc/content/getting-started/migrating/migrate-from-chirpstack.md
@@ -9,7 +9,9 @@ This section contains instructions on how to migrate end devices from ChirpStack
 
 <!--more-->
 
-End devices and applications can easily be migrated from ChirpStack to {{% tts %}} with the `ttn-lw-migrate` tool. This tool is used for exporting end devices and applications to a [JSON file]({{< ref "getting-started/migrating/device-json.md" >}}) containing their description. This file can later be imported in {{% tts %}} as described in the [Import End Devices in The Things Stack]({{< ref "getting-started/migrating/import-devices.md" >}}) section.
+## Configure ttn-lw-migrate
+
+End devices and applications can easily be migrated from ChirpStack to {{% tts %}} with the [`ttn-lw-migrate`](https://github.com/TheThingsNetwork/lorawan-stack-migrate) tool. This tool is used for exporting end devices and applications to a [JSON file]({{< ref "getting-started/migrating/device-json.md" >}}) containing their description. This file can later be imported in {{% tts %}} as described in the [Import End Devices in The Things Stack]({{< ref "getting-started/migrating/import-devices.md" >}}) section.
 
 First, configure the environment with the following variables modified according to your setup:
 

--- a/doc/content/getting-started/migrating/migrate-from-chirpstack.md
+++ b/doc/content/getting-started/migrating/migrate-from-chirpstack.md
@@ -73,7 +73,11 @@ $ ttn-lw-migrate --source chirpstack application < applications.txt > applicatio
 ```
 
 {{< note >}} 
-- ABP end devices without an active session can be exported from ChirpStack, but cannot be imported in {{% tts %}}.
-- `MaxEIRP` parameter may not be always set properly.
-- ChirpStack `variables` parameter related to payload formatting will always be converted to `null` when the end device is imported to {{% tts %}}.
+ABP end devices without an active session can be exported from ChirpStack, but cannot be imported in {{% tts %}}.
+{{</ note >}}
+{{< note >}}
+`MaxEIRP` parameter may not be always set properly.
+{{</ note >}}
+{{< note >}}
+ChirpStack `variables` parameter related to payload formatting will always be converted to `null` when the end device is imported to {{% tts %}}.
 {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -25,11 +25,24 @@ When migrating devices from the public {{< ttnv2 >}} to {{< tts >}} Cloud, you m
 
 When migrating from a private {{% ttnv2 %}}, devices that are outside of the DevAddr address block supported by {{% tts %}} Cloud will have to rejoin the network, otherwise {{% tts %}} will be unable to route their uplink and downlink traffic.
 
-## Configure ttn-lw-migrate
+{{< warning >}} Migrating device sessions will not work on {{% tts %}} v3.10 or older versions. {{</ warning >}}
+
+## Pre-requisites
+
+1. User account in V2.
+2. User account in V3.
+3. Install [LoRaWAN stack migrate](#ttn-lw-migrate-tool) tool.
+
+## `ttn-lw-migrate` Tool
 
 End devices and applications can easily be migrated from {{% ttnv2 %}} to {{% tts %}} with the [`ttn-lw-migrate`](https://github.com/TheThingsNetwork/lorawan-stack-migrate) tool. This tool is used for exporting end devices and applications to a [JSON file]({{< ref "getting-started/migrating/device-json.md" >}}) containing their description. This file can later be imported in {{% tts %}} as described in the [Import End Devices in The Things Stack]({{< ref "getting-started/migrating/import-devices.md" >}}) section.
 
-First, configure the environment with the following variables modified according to your setup:
+### Installation
+Binaries are available on [GitHub](https://github.com/TheThingsNetwork/lorawan-stack-migrate/releases). Download the latest version asset according to your OS.
+
+### Configuration
+
+Configure the environment with the following variables modified according to your setup:
 
 ```bash
 $ export TTNV2_APP_ID="my-ttn-app"                    # TTN App ID
@@ -39,12 +52,19 @@ $ export FREQUENCY_PLAN_ID="EU_863_870_TTN"           # Frequency Plan ID for ex
 
 See [Frequency Plans]({{< ref src="/reference/frequency-plans" >}}) for the list of frequency plans available on {{% tts %}}. Make sure to specify the correct Frequency Plan ID. For example, the ID `EU_863_870_TTN` corresponds to the **Europe 863-870 MHz (SF9 for RX2 - recommended)** frequency plan.
 
-### Private {{% ttnv2 %}} deployments
+{{< note >}} For Windows OS, while configuring the app_id, app_access_key, frequency_plan_id replace `export` with `set`  and remove double-quotes as shown below. {{</ note >}}
+```bash
+$ set TTNV2_APP_ID=my-ttn-app                    # TTN App ID
+$ set TTNV2_APP_ACCESS_KEY=ttn-account-v2.a...   # TTN App Access Key (needs `devices` permissions)
+$ set FREQUENCY_PLAN_ID=EU_863_870_TTN           # Frequency Plan ID for exported devices
+```
+
+### Configuration for {{% ttnv2 %}} private deployments
 
 Private {{% ttnv2 %}} deployments are also supported, and require extra configuration. See `ttn-lw-migrate device --help` for more details. For most cases, it is enough to configure `ttn-lw-migrate` to use the Discovery Server of your installation, by setting the following environment variables:
 
 ```bash
-$ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.<tenant>.thethings.industries:1900"
+$ export TTNV2_DISCOVERY_SERVER_ADDRESS="<instance-id>.thethings.industries:1900"
 ```
 
 {{< note >}} If the Discovery Server is not using TLS, you will need to use the `--ttnv2.discovery-server-insecure` flag when running the `ttn-lw-migrate` commands below. {{</ note >}}
@@ -64,7 +84,7 @@ $ ttn-lw-migrate devices --dry-run --verbose --source ttnv2 "mydevice" > devices
 $ ttn-lw-migrate device --source ttnv2 "mydevice" > devices.json
 ```
 
-{{< warning >}} The export process will clear the device root keys (**AppKey**) and session (**AppSKey**, **NwkSKey**, **DevAddr**, **FCntUp** and **FCntDown**) from {{% ttnv2 %}}. Execute any commands with the `--dry-run` first, which will do everything except delete the device keys from {{% ttnv2 %}}. {{</ warning >}}
+{{< warning >}} The export process will clear the device root keys (**AppKey**) and session (**AppSKey**, **NwkSKey**, **DevAddr**, **FCntUp** and **FCntDown**) from {{% ttnv2 %}} by default. You can disable this by using the  `--ttnv2.with-session=false` flag. {{</ warning >}}
 
 {{< note >}} The export process will halt if any error occurs. {{</ note >}}
 
@@ -83,7 +103,7 @@ And then export with:
 ```bash
 # dry run first, verify that no errors occur
 $ ttn-lw-migrate devices --verbose --dry-run --source ttnv2 < device_ids.txt > devices.json
-# export device
+# export devices
 $ ttn-lw-migrate devices --source ttnv2 < device_ids.txt > devices.json
 ```
 
@@ -92,8 +112,9 @@ Alternatively, you can export all the end devices associated with your applicati
 ```bash
 # dry run first, verify that no errors occur
 $ ttn-lw-migrate application --verbose --dry-run --source ttnv2 "my-ttn-app" > all-devices.json
-# export device
+# export devices
 $ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
 ```
 
-{{< warning >}} Migrating device sessions will not work on {{% tts %}} v3.10 or older versions. {{</ warning >}}
+After exporting the end devices in to a json file you can refer [Import End Devices Document]({{< ref "getting-started/migrating/import-devices.md" >}}) in {{% tts %}} for next steps.
+

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -11,6 +11,14 @@ This section documents the process of migrating end devices from {{% ttnv2 %}} t
 
 For a breakdown of differences between {{% ttnv2 %}} and {{% tts %}}, see the [Major Changes]({{< relref "major-changes" >}}) section.
 
+>**Note**: 
+>
+>When migrating devices from the Public Community Network to {{< tts >}} Cloud, you may choose to transfer the active device sessions as well, which means that your devices will continue to work with {{% tts %}}. 
+>
+>When migrating from a private {{% ttnv2 %}}, devices that are outside of the DevAddr address block supported by {{% tts %}} Cloud will have to rejoin the network, otherwise {{% tts %}} will be unable to route their uplink and downlink traffic. 
+>
+>{{% tts %}} Dedicated Cloud, Enterprise and Marketplace Launcher deployments are not affected by this issue.
+
 ## Suggested Migration Process
 
 **First**: Update applications to support the {{% tts %}} data format. If you are using payload formatters, make sure to set them correctly from the Application settings page.

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -33,11 +33,15 @@ $ export FREQUENCY_PLAN_ID="EU_863_870_TTN"           # Frequency Plan ID for ex
 
 See [Frequency Plans]({{< ref src="/reference/frequency-plans" >}}) for the list of frequency plans available on {{% tts %}}. Make sure to specify the correct Frequency Plan ID. For example, the ID `EU_863_870_TTN` corresponds to the **Europe 863-870 MHz (SF9 for RX2 - recommended)** frequency plan.
 
-Private The Things Network Stack V2 deployments are also supported, and require extra configuration. See `ttn-lw-migrate device --help` for more details. For example, to override the discovery server address:
+### Private {{% ttnv2 %}} deployments
+
+Private {{% ttnv2 %}} deployments are also supported, and require extra configuration. See `ttn-lw-migrate device --help` for more details. For most cases, it is enough to configure ttn-lw-migrate to use the Discovery Server of your installation, by setting the following environment variables:
 
 ```bash
-$ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.thethings.network:1900"
+$ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.<tenant>.thethings.industries:1900"
 ```
+
+>**Note:**: If the Discovery Server is not using TLS, you will need to use the `--ttnv2.discovery-server-insecure` flag when running the `ttn-lw-migrate` commands below.
 
 ## Export End Devices from {{% ttnv2 %}}
 

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -81,28 +81,32 @@ In order to export a single device, use the following command. The device will b
 $ ttnctl devices export "device-id" --frequency-plan-id EU_863_870 > device.json
 ```
 
-Alternatively, you can export all the end devices with a single command and save them in `all-devices.json`.
+{{< note >}} Payload formatters are not exported. See [Payload Formatters](https://thethingsstack.io/integrations/payload-formatters/). {{</ note >}}
 
-```bash
-$ ttnctl devices export-all --frequency-plan-id EU_863_870 > all-devices.json
+{{< warning >}} Active device sessions are exported by default. You can disable this by using the `--ttnv2.with-session=false` flag. It is recommended that you do not export session keys for devices that can instead re-join on The Things Stack. {{</ warning >}}
+
+In order to export a large number of devices, create a file named `device_ids.txt` with one device ID per line:
+
+```
+mydevice
+otherdevice
+device3
+device4
+device5
 ```
 
-{{< note >}} Change `EU_863_870` frequency plan from the command above to the frequency plan corresponding to your region. See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) for a list of supported Frequency Plans and their respective IDs. {{</ note >}}
+And then export with:
 
-{{< note >}} Keep in mind that an end device can only be registered in one Network Server at a time. After importing an end device to {{% tts %}}, you should remove it from {{% ttnv2 %}}. For OTAA devices, it is enough to simply change the AppKey, so the device can no longer join but the existing session is preserved. Next time the device joins, the activation will be handled by {{% tts %}}. {{</ note >}}
+```bash
+$ ttn-lw-migrate devices --source ttnv2 < device_ids.txt > devices.json
+```
+
+Alternatively, you can export all the end devices associated with your application, and save them in `all-devices.json`.
+
+```bash
+$ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
+```
 
 ### Disable Exported End Devices on V2
 
-After exporting, make sure to clear the AppKey of your OTAA devices. This can be achieved with the following command:
-
-```bash
-$ ttnctl devices convert-to-abp "device-id" --save-to-attribute "original-app-key"
-```
-
-There is also a convenience command to clear all of your devices at once:
-
-```bash
-$ ttnctl devices convert-all-to-abp --save-to-attribute "original-app-key"
-```
-
-{{< note >}} The AppKey of each device will be printed on the standard output, and stored as a device attribute (with name `original-app-key`). You can retrieve the device attributes with `ttnctl devices info "device-id"`. {{</ note >}}
+An end device can only be registered in one Network Server at a time. After importing an end device to {{% tts %}}, you should remove it from {{% ttnv2 %}}. For OTAA devices, it is enough to simply change the AppKey, so the device can no longer join but the existing session is preserved. Next time the device joins, the activation will be handled by {{% tts %}}.

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -19,13 +19,74 @@ For a breakdown of differences between {{% ttnv2 %}} and {{% tts %}}, see the [M
 
 **Finally**: Once you are confident that your end devices are working properly, migrate the rest of your devices and gateways to {{% tts %}}.
 
-## Configure V2 CLI
+## Configure ttn-lw-migrate
 
-For using `ttnctl` with **The Things Network**, follow [these instructions](https://www.thethingsnetwork.org/docs/network/cli/quick-start.html). 
+End devices and applications can easily be migrated from {{% ttnv2 %}} to {{% tts %}} with the [`ttn-lw-migrate`](https://github.com/TheThingsNetwork/lorawan-stack-migrate) tool. This tool is used for exporting end devices and applications to a [JSON file]({{< ref "getting-started/migrating/device-json.md" >}}) containing their description. This file can later be imported in {{% tts %}} as described in the [Import End Devices in The Things Stack]({{< ref "getting-started/migrating/import-devices.md" >}}) section.
+
+First, configure the environment with the following variables modified according to your setup:
+
+```bash
+$ export TTNV2_APP_ID="my-ttn-app"                    # TTN App ID
+$ export TTNV2_APP_ACCESS_KEY="ttn-account-v2.a..."   # TTN App Access Key (needs `devices` permissions)
+$ export FREQUENCY_PLAN_ID="EU_863_870_TTN"           # Frequency Plan ID for exported devices
+```
+
+See [Frequency Plans]({{< ref src="/reference/frequency-plans" >}}) for the list of frequency plans available on {{% tts %}}. Make sure to specify the correct Frequency Plan ID. For example, the ID `EU_863_870_TTN` corresponds to the **Europe 863-870 MHz (SF9 for RX2 - recommended)** frequency plan.
+
+Private The Things Network Stack V2 deployments are also supported, and require extra configuration. See `ttn-lw-migrate device --help` for more details. For example, to override the discovery server address:
+
+```bash
+$ export TTNV2_DISCOVERY_SERVER_ADDRESS="discovery.thethings.network:1900"
+```
+
+## Export End Devices from {{% ttnv2 %}}
+
+In order to export a single device, use the following command. The device with ID `mydevice` will exported and saved to `device.json`.
+
+```bash
+$ ttn-lw-migrate devices --source ttnv2 "mydevice" > devices.json
+```
+
+>**Notes:**:
+>- Payload formatters are not exported. See [Payload Formatters](https://thethingsstack.io/integrations/payload-formatters/).
+>- Active device sessions are exported by default. You can disable this by using the `--ttnv2.with-session=false` flag. It is recommended that you do not export session keys for devices that can instead re-join on The Things Stack.
+
+In order to export a large number of devices, create a file named `device_ids.txt` with one device ID per line:
+
+```
+mydevice
+otherdevice
+device3
+device4
+device5
+```
+
+And then export with:
+
+```bash
+$ ttn-lw-migrate devices --source ttnv2 < device_ids.txt > devices.json
+```
+
+Alternatively, you can export all the end devices associated with your application, and save them in `all-devices.json`.
+
+```bash
+$ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
+```
+
+>**Note:** Keep in mind that an end device can only be registered in one Network Server at a time. After importing an end device to {{% tts %}}, you should remove it from {{% ttnv2 %}}. For OTAA devices, it is enough to simply change the AppKey, so the device can no longer join but the existing session is preserved. Next time the device joins, the activation will be handled by {{% tts %}}.
+
+## Disable Exported End Devices on V2
+
+It is important that you unset the `AppKey` property of your exported devices, so that they are able to join properly on {{% tts %}}. This can be done from
+the {{% ttnv2 %}} Console. If you are migrating a large number of devices, you can automate the process with `ttnctl`, the CLI for {{% ttnv2 %}}.
+
+### Configure V2 CLI
+
+For using `ttnctl` with **The Things Network**, follow [these instructions](https://www.thethingsnetwork.org/docs/network/cli/quick-start.html).
 
 When using a **private V2 network server**, provided by The Things Industries, go through the following steps:
 
-1. [Download](https://www.thethingsnetwork.org/docs/network/cli/quick-start.html) `ttnctl` for your operating system. 
+1. [Download](https://www.thethingsnetwork.org/docs/network/cli/quick-start.html) `ttnctl` for your operating system.
 2. Update `ttnctl` to the latest version by running:
     ```bash
     $ ttnctl selfupdate
@@ -40,26 +101,20 @@ When using a **private V2 network server**, provided by The Things Industries, g
     handler-id: <domain_id>-handler
     discovery-address: <domain_id>.thethings.industries:1900
     ```
-    
-    **For windows users** make sure to use the `--config` flag with the full path to the configuration file: 
+
+    **For windows users** make sure to use the `--config` flag with the full path to the configuration file:
     ```
     ttnctl.exe --config fullpath/config.yml
     ```
 4. Get the access code needed for logging in: `https://<domain_id>.thethings.industries/users/authorize?client_id=ttnctl&redirect_uri=/oauth/callback/ttnctl&response_type=code`
-5. Login: 
+5. Login:
     ```bash
     $ ttnctl user login <access_code>
     ```
 6. You are now logged in your private network, you should now see a folder named `/.ttnctl` in your home directory with private files.
-    
+
     > Optional: define an alias on ttnctl --config /home/<user_name>/.ttnctl/community.yml to go faster
 
-
-## Export End Devices from V2
-
-In this step, the end devices from {{% ttnv2 %}} will be exported in a JSON format that can then be parsed and imported by {{% tts %}}.
-
-The exported end devices contain the device name, description, location data, activation mode (ABP/OTAA), root keys and the AppEUI. They also contain the session keys, so your OTAA devices can simply keep working with {{% tts %}}.
 
 To get started, select the **AppID** and **AppEUI** of the application you want to export your end devices from:
 
@@ -67,35 +122,7 @@ To get started, select the **AppID** and **AppEUI** of the application you want 
 $ ttnctl applications select
 ```
 
-After selecting the application, make sure that you can list the available end devices:
-
-```bash
-$ ttnctl devices list
-```
-
-### Exporting Devices
-
-In order to export a single device, use the following command. The device will be saved to `device.json`.
-
-```bash
-$ ttnctl devices export "device-id" --frequency-plan-id EU_863_870 > device.json
-```
-
-{{< note >}} Payload formatters are not exported. See [Payload Formatters](https://thethingsstack.io/integrations/payload-formatters/). {{</ note >}}
-
-{{< warning >}} Active device sessions are exported by default. You can disable this by using the `--ttnv2.with-session=false` flag. It is recommended that you do not export session keys for devices that can instead re-join on The Things Stack. {{</ warning >}}
-
-In order to export a large number of devices, create a file named `device_ids.txt` with one device ID per line:
-
-```
-mydevice
-otherdevice
-device3
-device4
-device5
-```
-
-And then export with:
+To clear the AppKey of an OTAA device, use the following command:
 
 ```bash
 $ ttn-lw-migrate devices --source ttnv2 < device_ids.txt > devices.json

--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -29,8 +29,8 @@ When migrating from a private {{% ttnv2 %}}, devices that are outside of the Dev
 
 ## Pre-requisites
 
-1. User account in V2.
-2. User account in V3.
+1. User account in {{% ttnv2 %}}.
+2. User account in {{% tts %}} V3.
 3. Install [LoRaWAN stack migrate](#ttn-lw-migrate-tool) tool.
 
 ## `ttn-lw-migrate` Tool
@@ -116,5 +116,5 @@ $ ttn-lw-migrate application --verbose --dry-run --source ttnv2 "my-ttn-app" > a
 $ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
 ```
 
-After exporting the end devices in to a json file you can refer [Import End Devices Document]({{< ref "getting-started/migrating/import-devices.md" >}}) in {{% tts %}} for next steps.
+After exporting the end devices in to a json file you can refer to [Import End Devices Document]({{< ref "getting-started/migrating/import-devices.md" >}}) in {{% tts %}} for next steps.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Update documentation to use [ttn-lw-migrate](https://github.com/TheThingsNetwork/lorawan-stack-migrate) instead of `ttnctl` for migrating from v2 to v3.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
