### PR TITLE
Add screenshot req to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,13 @@ Closes #0000, References #0000, etc.
 
 ...
 
+#### Screenshots
+<!-- Post a screenshot of your rendered content
+NOTE: This section is optional.
+-->
+
+...
+
 #### Changes
 <!-- What are the changes made in this pull request? -->
 
@@ -33,7 +40,7 @@ implementation proposal in the referenced issues.
 <!-- Make sure that this pull request is complete. -->
 
 - [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
-- [ ] Run Locally: Verified that the docs build using `make server`
+- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
 - [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
 - [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
 - [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Kevin raised a good point that we often don't consider how our rendered Markdown will look -> https://discuss.thethingsindustries.com/t/how-to-improve-images-on-the-documentation-page/387/2?u=benolayinka

This PR adds a check to post a screenshot in the PR template, to encourage contributors to build and preview their work.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
