### PR TITLE
doc: Fix links to files in lorawan-stack repository

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -24,6 +24,7 @@ pygmentsUseClasses = true
   keywords = []
   github_repository = "https://github.com/TheThingsIndustries/lorawan-stack-docs"
   github_repository_edit = "https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/content"
+  tts_github_repository = "https://github.com/TheThingsNetwork/lorawan-stack"
   version = "v3.10"
 
 [markup]

--- a/doc/content/reference/api/authentication.md
+++ b/doc/content/reference/api/authentication.md
@@ -34,7 +34,7 @@ To use this method, you first need an **OAuth client registration**:
 
 - The **client ID** uniquely identifies the OAuth client. Its restrictions are the same as for any other ID in TTN.
 - The **description** is shown to the user when you request authorization.
-- The **scope** indicates what actions your OAuth client is allowed to perform. This is shown to the user when you request authorization. You can select the actions your OAuth client needs on registration, a full list can also be found in our [source code](https://github.com/TheThingsNetwork/lorawan-stack/blob/default/api/rights.proto).
+- The **scope** indicates what actions your OAuth client is allowed to perform. This is shown to the user when you request authorization. You can select the actions your OAuth client needs on registration, a full list can also be found in our [source code]({{< tts-repo-file-url "blob" "api/rights.proto" >}}).
 - The **redirect URI** is where the user is redirected after authorizing your OAuth client.
 - The **client secret** is issued when your OAuth client Registration is accepted by a network admin.
 

--- a/doc/content/reference/api/gateway_server_mqtt.md
+++ b/doc/content/reference/api/gateway_server_mqtt.md
@@ -19,7 +19,7 @@ The Gateway Server is the MQTT server, and gateways connect to the Gateway Serve
 
 ## Protocol Buffers
 
-To communicate with the MQTT protocol, the Gateway Server and the gateway are exchanging [Protocol Buffers](https://developers.google.com/protocol-buffers). The definitions of the Protocol Buffers can be found at the [GitHub repository](https://github.com/TheThingsNetwork/lorawan-stack) of {{% tts %}}, under [**messages.proto**](https://github.com/TheThingsNetwork/lorawan-stack/blob/default/api/messages.proto) and [**lorawan.proto**](https://github.com/TheThingsNetwork/lorawan-stack/blob/default/api/lorawan.proto).
+To communicate with the MQTT protocol, the Gateway Server and the gateway are exchanging [Protocol Buffers](https://developers.google.com/protocol-buffers). The definitions of the Protocol Buffers can be found at the [GitHub repository](https://github.com/TheThingsNetwork/lorawan-stack) of {{% tts %}}, under [**messages.proto**]({{< tts-repo-file-url "blob" "api/messages.proto" >}}) and [**lorawan.proto**]({{< tts-repo-file-url "blob" "api/lorawan.proto" >}}).
 
 ## Connecting to the Gateway Server
 

--- a/doc/layouts/shortcodes/repo-file-url.html
+++ b/doc/layouts/shortcodes/repo-file-url.html
@@ -1,1 +1,0 @@
-{{ .Site.Params.github_repository }}/{{ .Get 0 }}/{{ .Site.Params.version }}/{{ .Get 1 }}

--- a/doc/layouts/shortcodes/repo.html
+++ b/doc/layouts/shortcodes/repo.html
@@ -1,1 +1,0 @@
-{{ .Site.Params.github_repository }}

--- a/doc/layouts/shortcodes/tts-repo-file-url.html
+++ b/doc/layouts/shortcodes/tts-repo-file-url.html
@@ -1,0 +1,1 @@
+{{ .Site.Params.tts_github_repository }}/{{ .Get 0 }}/{{ .Site.Params.version }}/{{ .Get 1 }}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #113

#### Changes
<!-- What are the changes made in this pull request? -->

- Deleted unused `repo` shortcode
- Renamed `repo-file-url` to `tts-repo-file-url` and make it link to current minor branch of https://github.com/TheThingsNetwork/lorawan-stack.
- Fixed documentation pages that linked to `default` branch

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
