### PR TITLE
doc: Add tenancy config to enterprise config file

### DIFF
--- a/doc/content/getting-started/installation/configuration/_index.md
+++ b/doc/content/getting-started/installation/configuration/_index.md
@@ -133,10 +133,14 @@ You can use Sendgrid or an SMTP server. If you skip setting up an email provider
 
 ### Component URLs
 
-Finally, we also need to configure the URLs for the Web UI and the secret used
+We also need to configure the URLs for the Web UI and the secret used
 by the console client (see the `console` section). These tell {{% tts %}} where all its components are accessible.
 
 >**Note:** Failure to correctly configure component URLs is a common problem that will prevent the stack from starting. Be sure to replace all instances of `thethings.example.com` with your domain name!
+
+### Multi-tenancy {{< distributions-inline "Enterprise" >}}
+
+If running a multi-tenant environment, we need to configure the default tenant ID, and the base domain from which tenant IDs are inferred. See the [`tenancy` configuration reference]({{< ref "/reference/configuration/the-things-stack#multi-tenancy" >}}).
 
 Below is an example `ttn-lw-stack-docker.yml` file for the Enterprise stack:
 

--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
@@ -35,6 +35,10 @@ is:
       is:
         base-url: 'https://thethings.example.com/api/v3'
 
+  # If running a multi-tenant environment, configure tenant admin keys
+  tenancy:
+    admin-keys: ''                  # generate 32 bytes (openssl rand -hex 32)
+
 # HTTP server configuration
 http:
   cookie:
@@ -145,3 +149,8 @@ dcs:
       base-url: 'https://thethings.example.com/api/v3'
     ns:
       base-url: 'https://thethings.example.com/api/v3'
+
+# If running a multi-tenant environment, defaults for "thethings.example.com":
+tenancy:
+  base-domains: 'thethings.example.com'
+  default-id: 'default'

--- a/doc/content/getting-started/installation/running-the-stack.md
+++ b/doc/content/getting-started/installation/running-the-stack.md
@@ -34,7 +34,7 @@ $ docker-compose run --rm stack storage-db init
 $ docker-compose run --rm stack is-db create-tenant
 ```
 
->**Note:** This will take the Tenant ID from the configuration.
+>**Note:** This will take the default Tenant ID from the configuration. See the [`tenancy` configuration reference]({{< ref "/reference/configuration/the-things-stack#multi-tenancy" >}}).
 
 We'll now create an initial `admin` user. Make sure to give it a good password.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add `tenancy` configuration to example `ttn-lw-stack-docker-enterprise` configuration file.

Without this, multi-tenancy doesn't work right as `base-domain` does not match instance url.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
