### PR TITLE
Mark storage config as enterprise only

### DIFF
--- a/doc/content/integrations/storage/configuration.md
+++ b/doc/content/integrations/storage/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: ""
 weight: 10
-distributions: Cloud
+distributions: Enterprise
 ---
 
 >**Note**: On Cloud distributions, the following configuration options are automatically enabled. See the [Enable]({{< relref "enable" >}}) and [Retrieve]({{< relref "retrieve" >}}) sections to learn to enable and use the integration for Applications and End Devices.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Configuration for storage integration should be Enterprise only. Cloud is automatically configured.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
