### PR TITLE
util: Migration to thethingsindustries.com/docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DOC_ROOT = doc
 PUBLIC_DEST = ../public # Relative to DOC_ROOT
 INTERNAL_DEST = ../internal # Relative to DOC_ROOT
 ENVIRONMENT ?= gh-pages
-HUGO_BASE_URL ?= https://thethingsstack.io
+HUGO_BASE_URL ?= https://www.thethingsindustries.com/docs
 
 .PHONY: default
 default: server

--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -347,6 +347,32 @@ details + blockquote {
   margin-bottom: 0.4em;
 }
 
+#migration-text {
+  color: $white;
+  font-weight: bold;
+  padding-right: 30px;
+}
+
+#migration-button {
+  border: 1px $white;
+  border-style: solid;
+}
+
+#migration-info {
+  margin: 0 -12.5%;
+  width: 100vw;
+  height: 60px;
+  font-size: 15px;
+  justify-content: center;
+  align-items: center;
+  background-color: $blue;
+  display: none; // or `flex`
+}
+
+.navbar {
+  display: block;
+}
+
 .feedback {
   text-align: center;
   background-color: $white-ter;

--- a/doc/themes/the-things-stack/assets/js/theme.js
+++ b/doc/themes/the-things-stack/assets/js/theme.js
@@ -12,7 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
+  var migrationInfoAccepted = window.localStorage.getItem('migrationInfoAccepted')
+  if(migrationInfoAccepted != 'true') {
+    var migrationBar = document.getElementById('migration-info')
+    migrationBar.style.display = 'flex';
+    var migrationButton = document.getElementById('migration-button')
+    migrationButton.addEventListener('click', function (){
+      window.localStorage.setItem('migrationInfoAccepted', true)
+      migrationBar.style.display = 'none';
+    })
+  }
+
   var $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)
   if ($navbarBurgers.length > 0) {
     $navbarBurgers.forEach(function(el) {

--- a/doc/themes/the-things-stack/layouts/partials/nav.html
+++ b/doc/themes/the-things-stack/layouts/partials/nav.html
@@ -1,4 +1,8 @@
 <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+  <div id="migration-info">
+      <div id="migration-text">thethingsstack.io has moved to thethingsindustries.com/docs</div>
+      <div id="migration-button" class="button is-primary">Got it</div>
+  </div>
   <div class="container">
     <div class="navbar-brand">
       <a class="navbar-item" href="{{ relURL "/" }}">


### PR DESCRIPTION
#### Summary
Migration to thethingsindustries.com/docs

#### Screenshots
![Screenshot 2020-12-09 at 14 17 17](https://user-images.githubusercontent.com/15948821/101634615-4031ae80-3a29-11eb-9a51-676e122316dc.png)


#### Changes
1. Add a banner informing of the change
2. Change `HUGO_BASE_URL` for links on the page
3. Add a JS function that redirects users to `thethingsindustries.com/docs` if they see the webpage from somewhere else. Same pattern is on docs for thethingsnetwork.org.

#### Notes for Reviewers
The biggest difficulty is coordinating changes in a few places so that people wouldn't experience downtime. Therefore the plan is as follows:

1. Deploy to thethingsindustries.com a change that makes /docs connect to github pages (already on preview)
2. Merge this PR
3. Make thethingsstack.io redirect to thethingsindustries.com/docs (so that search engines won't be confused)

One important detail: we do NOT inform github itself about our change. That is, the `CNAME` file will keep pointing to `thethingsstack.io`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
