### PR TITLE
Create docs banner for migration

### DIFF
--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -70,6 +70,8 @@ $tabs-border-bottom-color: $blue;
 
 $content-blockquote-background-color: inherit;
 
+$banner-height: 80px;
+
 // Modular imports broken in bulma 0.9
 // https://github.com/jgthms/bulma/issues/2797
 
@@ -383,5 +385,35 @@ details + blockquote {
 
 table.fixed { table-layout:fixed; }
 table.fixed td { overflow: auto; }
+
+.migration-banner {
+  height: $banner-height;
+  button {
+    color: white;
+    background-color: Transparent;
+    border: 2px solid white !important;
+    margin-left: 10px;
+  }
+  button:hover {
+    color: white;
+  }
+}
+
+.banner-gap {
+  top: $banner-height !important;
+}
+
+.fixed-top {
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: 30;
+  top: 0;
+}
+
+.flex-center-vertically {
+  align-items: center;
+  justify-content: center;
+}
 
 @import "highlight.scss";

--- a/doc/themes/the-things-stack/assets/js/theme.js
+++ b/doc/themes/the-things-stack/assets/js/theme.js
@@ -25,6 +25,30 @@ document.addEventListener('DOMContentLoaded', function() {
     })
   }
 
+  // Migration Banner
+  if(document.querySelectorAll('.migration-banner')[0]){
+    var nav = document.getElementsByTagName("NAV")[0];
+    nav.classList.add("banner-gap");
+
+    function removeBanner(){
+      var migration_banner = document.querySelectorAll('.migration-banner')[0];
+      migration_banner.parentNode.removeChild(migration_banner);
+      nav.classList.remove("banner-gap");
+    }
+
+    if (window.sessionStorage.getItem('bannerClosed') === "true" ) {
+      removeBanner()
+    } else {
+      (document.querySelectorAll('.notification .got-it') || []).forEach(($delete) => {
+        $delete.addEventListener('click', () => {
+          window.sessionStorage.setItem('bannerClosed', true)
+          removeBanner()
+        });
+      });
+    }
+  }
+
+  // Tabs
   const tabs = [...document.querySelectorAll('.tabs li')]
   const tabContent = [...document.querySelectorAll('.tab-content section')]
   const activeClass = 'is-active'

--- a/doc/themes/the-things-stack/layouts/partials/header.html
+++ b/doc/themes/the-things-stack/layouts/partials/header.html
@@ -1,2 +1,3 @@
+{{- partial "migration-banner.html" -}}
 {{- partial "nav.html" . -}}
 {{- partial "search.html" . -}}

--- a/doc/themes/the-things-stack/layouts/partials/migration-banner.html
+++ b/doc/themes/the-things-stack/layouts/partials/migration-banner.html
@@ -1,0 +1,12 @@
+<div class="fixed-top migration-banner">
+    <div class="notification is-primary has-text-centered is-flex">
+    	<div class="container">
+    		<label class="is-flex flex-center-vertically">
+    			<strong>thethingsstack.io&nbsp;</strong> has moved to <strong>&nbsp;thethingsindustries.com/docs</strong>
+    			<button class="button got-it">
+    			Got it
+    			</button>
+    		</label>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #150 . Blocked on docs migration.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="1297" alt="Screenshot 2020-12-09 at 17 41 08" src="https://user-images.githubusercontent.com/6963436/101659071-f0151500-3a45-11eb-86ad-125093348d23.png">


#### Changes
<!-- What are the changes made in this pull request? -->

Added a banner which uses `window.sessionStorage` to stay hidden once it's been clicked.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@kschiffer, using Bulma's `is-primary` button styling broke the button on safari, so I added my own `migration-banner > button` styling. I'd rather use the in-the-box styling, so if you have any insight about why, lmk. To reproduce, just add the `is-primary` class to the button in `doc/themes/layouts/partials/migration-banner.html`

<img width="683" alt="Screenshot 2020-12-09 at 17 37 43" src="https://user-images.githubusercontent.com/6963436/101659455-5d28aa80-3a46-11eb-8746-118540a42c93.png">

disabling padding seems to fix it on Safari (it appears normally on Chrome anyway)

<img width="250" alt="Screenshot 2020-12-09 at 17 37 56" src="https://user-images.githubusercontent.com/6963436/101659495-6ade3000-3a46-11eb-8e5a-09d4aa239800.png">


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
