### PR TITLE
Quickfix for inline shortcodes breaking headings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ Mark documentation that applies only to a specific distribution in one of the fo
 - Use the Front Matter `distributions` element to add a list of distributions, i.e `distribution: ["Enterprise", "Cloud"]`. This will mark the page in the parent's table of contents, and will produce a notification on the page
 - Use the `{{< distribution "Enterprise" "Cloud" >}}` shortcode to produce a notification on the page
 - Use the `{{< distributions-inline "Enterprise" >}}` shortcode to produce an inline notification. This is especially useful for tables and lists
+- Note that if you use the `{{< distributions-inline >}}` shortcode in a heading, Hugo will not correctly generate the ID element for it. [Manually add the heading](https://gohugo.io/content-management/cross-references/#heading-ids), i.e `## Cloud Specific Section {{< distributions-inline "Cloud" >}} {#cloud-specific-section}`
 
 ## Style Guidelines
 

--- a/doc/archetypes/section-bundle/_index.md
+++ b/doc/archetypes/section-bundle/_index.md
@@ -23,13 +23,15 @@ Use a requirements subheading to list requirements/prerequisites.
 
 Use the `ref` shortcode. For example, [this is a link to the component reference]({{< ref "reference/components" >}}).
 
-## Distributions
+## Distributions {{< distributions-inline "Cloud", "Enterprise" >}} {#distributions}
 
 To mark a document as applicable to only one or more distributions, there are three options:
 
 1. Add an array of titles to a `distributions` front matter element. This will mark the page in the parent's table of contents, and will produce a notification on the page
 2. Use the {{< distributions "Enterprise" "Cloud" >}} shortcode to produce a notification on the page
 3. Use the {{< distributions-inline "Enterprise" >}} shortcode to produce an inline notification. This is especially useful for tables and lists
+
+Note that if you use the `{{< distributions-inline >}}` shortcode in a heading, Hugo will not correctly generate the ID element for it. [Manually add the heading](https://gohugo.io/content-management/cross-references/#heading-ids), i.e `## Cloud Specific Section {{< distributions-inline "Cloud" >}} {#cloud-specific-section}`
 
 Available distributions are {{< distributions-list >}} and are stored in `data/distributions.yml`.
 

--- a/doc/content/getting-started/installation/configuration/_index.md
+++ b/doc/content/getting-started/installation/configuration/_index.md
@@ -108,7 +108,7 @@ Here is an example `stack` configuration from the Enterprise version of `docker-
 
 Once Docker starts {{% tts %}}, we need to specify configuration options for running {{% tts %}} in the `ttn-lw-stack-docker.yml` file. Let's have a look at the configuration options which are required.
 
-### License {{< distributions-inline "Enterprise" >}}
+### License {{< distributions-inline "Enterprise" >}} {#license}
 
 First is a license file. {{% tts %}} Enterprise requires a license, which can be purchased at the [products page](https://thethingsindustries.com/technology/pricing). This is specified in the `license` field, and can be either a `key` string, or a `file`path. See the [License Configuration Reference]({{< ref "/reference/configuration/the-things-stack" >}}) for more information.
 
@@ -138,7 +138,7 @@ by the console client (see the `console` section). These tell {{% tts %}} where 
 
 {{< warning >}} Failure to correctly configure component URLs is a common problem that will prevent the stack from starting. Be sure to replace all instances of `thethings.example.com` with your domain name! {{</ warning >}}
 
-### Multi-tenancy {{< distributions-inline "Enterprise" >}}
+### Multi-tenancy {{< distributions-inline "Enterprise" >}} {#multi-tenancy}
 
 If running a multi-tenant environment, we need to configure the default tenant ID, and the base domain from which tenant IDs are inferred. See the [`tenancy` configuration reference]({{< ref "/reference/configuration/the-things-stack#multi-tenancy" >}}).
 

--- a/doc/content/integrations/aws-iot/_index.md
+++ b/doc/content/integrations/aws-iot/_index.md
@@ -12,17 +12,17 @@ You can also configure {{% tts %}} to connect to your AWS IoT Core endpoint via 
 
 Finally, when running {{% tts %}} in your AWS account, you can publish Application Server telemetry to your IoT Core endpoint.
 
-## Default Integration {{< distributions-inline "Cloud" "Dedicated Cloud" "Enterprise" >}}
+## Default Integration {{< distributions-inline "Cloud" "Dedicated Cloud" "Enterprise" >}} {#default-integration}
 
 The recommended way to integrate with AWS IoT is by using the **Default Integration** for {{% tts %}}. This integration is the most feature rich and supports all deployments of {{% tts %}}. The Default Integration comes with a AWS CloudFormation template to deploy in your AWS account.
 
 [Learn how to set up the default AWS IoT integration]({{< relref default >}})
 
-## Custom IoT Core Settings {{< distributions-inline "Cloud" "Dedicated Cloud" "Enterprise" >}}
+## Custom IoT Core Settings {{< distributions-inline "Cloud" "Dedicated Cloud" "Enterprise" >}} {#custom-iot-core-settings}
 
 Apart from the default integration which comes with a AWS CloudFormation template, you can also just let {{% tts %}} publish uplink messages and subscribe to downlink messages to AWS IoT Core. You can configure any AWS IoT Core endpoint, AWS access key, provide role-based access control (RBAC), configure the AWS IoT Core MQTT topic structure and which messages to publish.
 
-## Application Server Telemetry {{< distributions-inline "Marketplace Launcher" >}}
+## Application Server Telemetry {{< distributions-inline "Marketplace Launcher" >}} {#application-server-telemetry}
 
 This is a simple integration that only supports publishing uplink messages and requires {{% tts %}} to run in your AWS account. This is typically only used for [AWS Marketplace AMI]({{< ref "/getting-started/aws/ami" >}}) deployments.
 

--- a/doc/content/reference/configuration/application-server.md
+++ b/doc/content/reference/configuration/application-server.md
@@ -61,7 +61,7 @@ Application Server can fetch information stored in the Identity Server. For exam
 - `as.fetcher.cache.size`: Number of cache entries. In case the cache is full, the Least Frequently Used entry will be evicted. Set to `0` to disable.
 - `as.fetcher.cache.ttl`: Time-To-Live for cache entries.
 
-## Storage Integration Options {{< distributions-inline "Enterprise" "Marketplace Launcher" "Dedicated Cloud" >}}
+## Storage Integration Options {{< distributions-inline "Enterprise" "Marketplace Launcher" "Dedicated Cloud" >}} {#storage-integration-options}
 
 The Storage Integration requires a database for storing upstream messages.
 

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -140,7 +140,7 @@ By default users can create applications, gateways, organizations and OAuth clie
 
 - `is.gateways.encryption-key-id`: ID of the key used to encrypt gateway secrets at rest.
 
-## Tenant Administration Options {{< distributions-inline "Cloud" "Enterprise" >}}
+## Tenant Administration Options {{< distributions-inline "Cloud" "Enterprise" >}} {#tenant-administration-options}
 
 In multi-tenant deployments, tenants are managed with "tenant admin keys". These keys need to be configured in the Identity Server.
 

--- a/doc/content/reference/configuration/network-server.md
+++ b/doc/content/reference/configuration/network-server.md
@@ -46,7 +46,7 @@ The `ns.interop` options configure how Network Server performs interoperability 
 - `ns.interop.directory`: OS filesystem directory, which contains interoperability client configuration
 - `ns.interop.url`: URL, which contains interoperability client configuration
 
-## Peering {{< distributions-inline "Cloud" "Enterprise" >}}
+## Peering {{< distributions-inline "Cloud" "Enterprise" >}} {#peering}
 
 In multi-tenant deployments, the Network Server maintains strict isolation of traffic for different tenants. When it also has peering configured, the Packet Broker is typically configured with the correct tenant ID for the DevAddr ranges of each tenant. It is also possible to accept traffic from the Packet Broker without a tenant ID, and let the Network Server match devices without strict tenant isolation.
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -10,14 +10,14 @@ Under normal circumstances, only `info`, `warn` and `error` logs are printed to 
 
 - `log.level`: The minimum level log messages must have to be shown (default "info")
 
-## License {{< distributions-inline "Cloud" "Enterprise" >}}
+## License {{< distributions-inline "Cloud" "Enterprise" >}} {#license}
 
 {{% tts %}} requires a license key for production use. For development purposes, it will work for a limited time on `localhost` without a license key.
 
 - `license.file`: Location of the license file
 - `license.key`: Contents of the license key
 
-## Key Vault {{< distributions-inline "Cloud" "Enterprise" >}}
+## Key Vault {{< distributions-inline "Cloud" "Enterprise" >}} {#key-vault}
 
 The key vault is used to store secrets, such as TLS certificates and the keys for encrypting LoRaWAN root keys in the database. {{% tts %}} supports keys stored in AWS Secrets Manager, or static configuration for development purposes.
 
@@ -291,7 +291,7 @@ When using the `redis` backend, the global [Redis configuration]({{< ref "#redis
 - `cache.redis.namespace`: Namespace for Redis keys
 - `cache.redis.pool-size`: The maximum size of the connection pool
 
-## Multi-Tenancy {{< distributions-inline "Cloud" "Enterprise" >}}
+## Multi-Tenancy {{< distributions-inline "Cloud" "Enterprise" >}} {#multi-tenancy}
 
 In multi-tenant deployments, some additional configuration is required.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes #139 until we find a better solution

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="367" alt="Screenshot 2020-12-16 at 12 21 11" src="https://user-images.githubusercontent.com/6963436/102342220-37952700-3f99-11eb-83f2-693dbed6a264.png">
<img width="403" alt="Screenshot 2020-12-16 at 12 21 05" src="https://user-images.githubusercontent.com/6963436/102342226-39f78100-3f99-11eb-95bd-127128f342dc.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Add CONTRIBUTING note about manually fixing headings with inline shortcodes
- Fix existing headings with inline shortcodes

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
