### PR TITLE
doc: Remove global_conf warning from docs

### DIFF
--- a/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
+++ b/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
@@ -24,8 +24,6 @@ An example `global_conf.json` is available in the [{{% udp-pf %}} Github reposit
 
 ## Download Configuration in the Console {{< new-in-version "3.10" >}}
 
-{{< warning >}} A bug in {{% tts %}} 3.10.0 prevents downloading `global_conf.json` in the Console. Please follow the instructions for the CLI. This is fixed in 3.10.1. {{</ warning >}}
-
 To download a `global_conf.json` file for your gateway, open the Gateway overview page in the console. Click the **Download global_conf.json** button to download the file.
 
 {{< figure src="conf.png" alt="Download global_conf.json" >}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove global_conf bug warning

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
