### PR TITLE
doc: Fix broken download link

### DIFF
--- a/doc/themes/the-things-stack/layouts/_default/list.html
+++ b/doc/themes/the-things-stack/layouts/_default/list.html
@@ -12,12 +12,13 @@
 </h1>
 
 <div class="content">
+{{ $context := . }}
 {{ with .Params.distributions }}
   {{ $distributions := . }}
   {{ if ( not ( reflect.IsSlice . ) ) }}
     {{ $distributions = slice $distributions }}
   {{ end }}
-  {{ partial "distributions" (dict "distributions" $distributions) }}
+  {{ partial "distributions" (dict "context" $context "distributions" $distributions) }}
 {{ end }}
 {{ .Content }}
 </div>

--- a/doc/themes/the-things-stack/layouts/_default/single.html
+++ b/doc/themes/the-things-stack/layouts/_default/single.html
@@ -12,12 +12,13 @@
 </h1>
 
 <div class="content">
+{{ $context := . }}
 {{ with .Params.distributions }}
   {{ $distributions := .}}
   {{ if ( not ( reflect.IsSlice . ) ) }}
     {{ $distributions = slice $distributions }}
   {{ end }}
-  {{ partial "distributions" (dict "distributions" $distributions) }}
+  {{ partial "distributions" (dict "context" $context  "distributions" $distributions) }}
 {{ end }}
 {{ .Content }}
 </div>

--- a/doc/themes/the-things-stack/layouts/partials/distributions.html
+++ b/doc/themes/the-things-stack/layouts/partials/distributions.html
@@ -1,3 +1,4 @@
+{{ $context := .context }}
 {{ $distributions := .distributions }}
 {{ $distributions_all := index site.Data "distributions" }}
 {{ range $distributions }}
@@ -10,6 +11,6 @@
 {{ else }}
 <div class="notification is-primary">
   <h3 class="has-text-light">{{ delimit $distributions ", " " and " }} Only</h3>
-  <p>The following instructions apply to {{ delimit $distributions ", " " and " }} distributions. See the <a href="/download">downloads page</a> for a feature breakdown of distributions of The Things Stack.</p>
+  <p>The following instructions apply to {{ delimit $distributions ", " " and " }} distributions. See the <a href={{ ref $context "/download" }}>downloads page</a> for a feature breakdown of distributions of The Things Stack.</p>
 </div>
 {{ end }}

--- a/doc/themes/the-things-stack/layouts/shortcodes/distributions-inline.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/distributions-inline.html
@@ -1,2 +1,2 @@
 {{ $distributions := .Params }}
-{{ partial "distributions" (dict "distributions" $distributions "inline" true) }}
+{{ partial "distributions" (dict "context" . "distributions" $distributions "inline" true) }}

--- a/doc/themes/the-things-stack/layouts/shortcodes/distributions.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/distributions.html
@@ -1,2 +1,2 @@
 {{ $distributions := .Params }}
-{{ partial "distributions" (dict "distributions" $distributions) }}
+{{ partial "distributions" (dict "context" . "distributions" $distributions) }}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Replace hardcoded link with hugo ref to downloads page (it broke when docs went to thethingsindustries.com/docs)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
