### PR TITLE
doc: Fix example commands of Preset Frequencies & ADR

### DIFF
--- a/doc/content/devices/mac-settings/_index.md
+++ b/doc/content/devices/mac-settings/_index.md
@@ -74,7 +74,7 @@ Some additional examples are included below. All settings are available at the [
 To tell {{% tts %}} which frequencies are configured in an ABP device, set the `mac-settings.factory-preset-frequencies` parameter. For example, to configure a device using the default EU868 frequencies, use the following command:
 
 ```bash
-$ ttn-lw-cli devices update <device_id> --mac-settings.factory-preset-frequencies 868100000,868300000,868500000,867100000,867300000,867500000,867700000,867900000
+$ ttn-lw-cli devices update <app-id> <device-id> --mac-settings.factory-preset-frequencies 868100000,868300000,868500000,867100000,867300000,867500000,867700000,867900000
 ```
 
 {{< note >}} For ABP devices, `mac-settings.factory-preset-frequencies` should be specified on `device create` or the settings will only take effect after MAC reset. {{</ note >}}
@@ -94,7 +94,7 @@ $ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-max-dut
 To enable ADR, set the `mac-settings.use-adr` parameter
 
 ```bash
-$ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr true 
+$ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr=true 
 ```
 
 ### Set RX1 Delay


### PR DESCRIPTION
#### Summary
- Added `<application_id>` flag in "Configure Factory Preset Frequencies" command for ABP Devices
- Added `=` in the CLI command  to enable/disable ADR

Ref: https://www.thethingsindustries.com/docs/devices/mac-settings/
#### Checklist 
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
