### PR TITLE
Add "Accept: text/event-stream" header to events API example curl command

### DIFF
--- a/doc/content/getting-started/events/_index.md
+++ b/doc/content/getting-started/events/_index.md
@@ -34,6 +34,7 @@ With the created API key:
 $ curl https://thethings.example.com/api/v3/events \
   -X POST \
   -H "Authorization: Bearer NNSXS.BR55PTYILPPVXY.." \
+  -H "Accept: text/event-stream" \
   --data '{"identifiers":[{"application_ids":{"application_id":"app1"}},{"gateway_ids":{"gateway_id":"gtw1"}}]}'
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, add `Accept: text/event-stream` header to example curl command for streaming events.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
