### PR TITLE
Fix rendering of key-value rules in API reference

### DIFF
--- a/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
@@ -40,6 +40,16 @@
             <p><code>{{ $rule }}</code>{{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
           {{- end }}
         {{ end }}
+        {{- if .map_key }}
+          {{- range $rule, $value := .map_key.rules }}
+            <p><code>{{ $rule }}</code> (key){{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
+          {{- end }}
+        {{ end }}
+        {{- if .map_value }}
+          {{- range $rule, $value := .map_value.rules }}
+            <p><code>{{ $rule }}</code> (value){{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
+          {{- end }}
+        {{ end }}
       </td>
     </tr>
     {{- end }}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This fixes rendering of key-value validation rules, which were previously not rendered.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/263

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="908" alt="Screenshot 2020-12-28 at 14 48 46" src="https://user-images.githubusercontent.com/181308/103218621-cb60de80-491b-11eb-9ed1-10e5c49be9d4.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
