### PR TITLE
util: Change message proto layout

### DIFF
--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -226,12 +226,13 @@ h1 {
     &:not(.plain) > img {
       box-shadow: $card-shadow;
     }
-
-    table {
-      display: block;
-      overflow: auto;
-    }
   }
+
+  table {
+    display: block;
+    overflow: auto;
+  }
+
 }
 
 .hero.is-primary {

--- a/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
@@ -5,20 +5,21 @@
 <p>{{ . | markdownify }}</p>
 {{- end }}
 
+{{- range .fields }}
 <table>
-  <thead>
-    <tr>
-      <th style="width: 175px">Field</th>
-      <th style="width: 250px">Type</th>
-      <th>Description</th>
-    </tr>
-  </thead>
   <tbody>
-    {{- range .fields }}
     <tr>
+      <th style="width: 150px">
+        Field
+      </th>
       <td>
         <code>{{ .name }}</code>
       </td>
+    </tr>
+    <tr>
+      <th>
+        Type
+      </th>
       <td>
         {{- if and .map_key .map_value -}}
         map of {{ partial "proto/field-type" .map_key }} to {{ partial "proto/field-type" .map_value }}
@@ -28,6 +29,12 @@
         {{- partial "proto/field-type" . -}}
         {{- end -}}
       </td>
+    </tr>
+    {{ if or .comment .rules .repeated }}
+    <tr>
+      <th>
+        Description
+      </th>
       <td>
         {{- with .comment }}
           <p>{{ . | markdownify }}</p>
@@ -42,9 +49,10 @@
         {{ end }}
       </td>
     </tr>
-    {{- end }}
+    {{ end }}
   </tbody>
 </table>
+{{ end }}
 
 {{- if .oneofs }}
 <table>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #90 
Long name and type fields break the message table layout. Proposing breaking out the fields to individual tables, which wastes horizontal space but is the best way I can think of to accomodate for unknown length entries. One issue with this layout is that it's not quite as clear that the fields are all sibling subfields of the same message. If anyone has an idea for making that more semantically clear, suggest it. Maybe something like a vertical line joining the fields.

Before:
<img width="718" alt="Screenshot 2021-01-04 at 12 33 32" src="https://user-images.githubusercontent.com/6963436/103528439-a1179f80-4e8c-11eb-916d-c8e8b240c551.png">

After:
<img width="579" alt="Screenshot 2021-01-04 at 12 58 34" src="https://user-images.githubusercontent.com/6963436/103528417-96f5a100-4e8c-11eb-85ef-867f95434576.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
