### PR TITLE
doc: Add instruction for Rx1 on migrated devices

### DIFF
--- a/doc/content/getting-started/migrating/device-json.md
+++ b/doc/content/getting-started/migrating/device-json.md
@@ -5,7 +5,9 @@ weight: 5
 aliases: "/getting-started/migrating-from-networks/device-json"
 ---
 
-{{% tts %}} allows you to import devices from other networks using a JSON file describing those devices. Devices imported this way can be migrated without the need for a rejoin.
+{{% tts %}} allows you to import devices from other networks using a JSON file describing those devices.
+
+Devices imported this way can be migrated without the need for a rejoin, although {{% tts %}} does not yet support this, but will support it in an upcoming release.
 
 Create a `devices.json` file containing a device object, like so:
 
@@ -82,6 +84,10 @@ The linked specification is quite extensive, and contains a lot of fields that a
 ```
 {{</ note >}}
 
+## Migrating Devices with Existing Sessions
+
+Migrating devices with existing sessions is not currently supported in {{% tts %}}, but it will be supported in an upcoming release.
+
 ## Examples
 
 ### Example OTAA Device:
@@ -108,54 +114,3 @@ The linked specification is quite extensive, and contains a lot of fields that a
 }
 ```
 </details></summary>
-
-### Example OTAA device with existing session:
-<summary>
-
-<details>
-
-```json
-{
-  "ids": {
-    "device_id": "device-2",
-    "dev_eui": "0102030405060708",
-    "join_eui": "0102030405060708"
-  },
-  "name": "My Device",
-  "description": "Migrated with existing session from The Things Network",
-  "lorawan_version":"MAC_V1_0_2",
-  "lorawan_phy_version":"PHY_V1_0_2_REV_B",
-  "frequency_plan_id":"EU_863_870_TTN",
-  "supports_join":true,
-  "root_keys":{
-    "app_key":{
-      "key":"01020304050607080102030405060708"
-    }
-  },
-  "mac_settings":{
-    "rx1_delay":{
-      "value":"RX_DELAY_5"
-    },
-    "supports_32_bit_f_cnt": true
-  },
-  "session":{
-    "dev_addr":"01020304",
-    "keys":{
-      "app_s_key":{
-        "key":"01020304050607080102030405060708"
-      },
-      "f_nwk_s_int_key":{
-        "key":"01020304050607080102030405060708"
-      }
-    },
-    "last_f_cnt_up": 32,
-    "last_n_f_cnt_down": 10
-  }
-}
-```
-
-</details></summary>
-
-{{< note >}} For more information on configuring MAC settings, see [Fine-tuning MAC Settings]({{< ref "getting-started/migrating/configure-mac-settings" >}}). {{</ note >}}
-
-<br>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/243

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="456" alt="Screenshot 2021-01-18 at 12 20 10" src="https://user-images.githubusercontent.com/6963436/104902528-857dc000-5987-11eb-8bcb-8466b27dbc53.png">
<img width="458" alt="Screenshot 2021-01-18 at 12 20 02" src="https://user-images.githubusercontent.com/6963436/104902549-8adb0a80-5987-11eb-91a9-67a8afada04e.png">

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@neoaggelos @laurensslats why in the OTAA migration example is the `Rx1 Delay` set as `mac-settings.rx1-delay.value` instead of `mac-settings.rx1-delay` ?

<img width="241" alt="Screenshot 2021-01-18 at 12 23 02" src="https://user-images.githubusercontent.com/6963436/104902863-f02efb80-5987-11eb-93ec-aa4665824933.png">


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
