### PR TITLE
Add reference for is.user-registration.enabled config option

### DIFF
--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -112,8 +112,9 @@ It is also possible to disable uploads:
 
 ## User Registration Options
 
-The user registration process can be customized by requiring approval by admin users, requiring email validation or by requiring new users to be invited by existing users.
+By default, users can register their own user accounts. User accounts can also be registered by admin users in the network. The user registration process can be customized by requiring approval by admin users, requiring email validation or by requiring new users to be invited by existing users.
 
+- `is.user-registration.enabled`: Enable user registration. If user registration is disabled, admin users can still create users. {{< new-in-version "3.11" >}}
 - `is.user-registration.admin-approval.required`: Require admin approval for new users
 - `is.user-registration.contact-info-validation.required`: Require contact info validation for new users
 - `is.user-registration.invitation.required`: Require invitations for new users


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the configuration reference for the `is.user-registration.enabled` option added in https://github.com/TheThingsNetwork/lorawan-stack/pull/3676.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is blocked on https://github.com/TheThingsNetwork/lorawan-stack/pull/3676 and after that the v3.11 release.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
