### PR TITLE
util: Enable docs sitemap

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -6,7 +6,6 @@ disableKinds = [
   "taxonomy",
   "taxonomyTerm",
   "RSS",
-  "sitemap",
 ]
 
 enableGitInfo = true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Lack of sitemap was breaking search at tti.com/docs. This closes https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/240

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser , was sitemap generation disabled on purpose?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
