### PR TITLE
doc: Add CLI note about au1 IS

### DIFF
--- a/doc/content/getting-started/cli/installing-cli/_index.md
+++ b/doc/content/getting-started/cli/installing-cli/_index.md
@@ -61,6 +61,9 @@ For a standard deployment on `thethings.example.com`, all you need is:
 $ ttn-lw-cli use thethings.example.com [--fetch-ca] [--user] [--overwrite]
 ```
 
+{{< warning >}} If configuring `ttn-lw-cli` for {{% tts %}} Cloud, see [Cloud Addresses]({{< ref "getting-started/cloud-hosted/addresses" >}}) for information about endpoints.
+{{</ warning >}}
+
 {{< note >}} On Windows, use `ttn-lw-cli.exe` instead of `ttn-lw-cli`. {{</ note >}}
 
 This will generate and save the required CLI config file. By default, the file is saved on the current directory, use the `--user` to save it under the user config directory.
@@ -87,6 +90,9 @@ device-claiming-server-grpc-address: 'thethings.example.com:8884'
 device-template-converter-grpc-address: 'thethings.example.com:8884'
 qr-code-generator-grpc-address: 'thethings.example.com:8884'
 ```
+
+{{< warning >}} If configuring `ttn-lw-cli` for {{% tts %}} Cloud, see [Cloud Addresses]({{< ref "getting-started/cloud-hosted/addresses" >}}) for information about endpoints.
+{{</ warning >}}
 
 If you are using an `https` port other than `443`, you need to specify that port, e.g.:
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix for https://www.thethingsnetwork.org/forum/t/ttn-cli-au1-v3-cluster-ttn-lw-cli-login-loads-to-blank-webpage-the-things-stack/45403

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
