### PR TITLE
Make container wider

### DIFF
--- a/doc/assets/css/common/variables.scss
+++ b/doc/assets/css/common/variables.scss
@@ -3,7 +3,7 @@
 
 $desktop: 1344px;
 $widescreen: 1632px;
-$fullhd: 1920px;
+$fullhd: 1824px;
 
 // Colors
 
@@ -51,7 +51,7 @@ $column-gap: 1.25rem;
 
 $content-padding-top: 2rem;
 $content-padding-side: 2rem;
-$content-max-width: 100%;
+$content-max-width: 960px;
 
 $menu-item-active-color: $grey-dark;
 $menu-item-active-background-color: $blue-bg;

--- a/doc/assets/css/common/variables.scss
+++ b/doc/assets/css/common/variables.scss
@@ -1,3 +1,10 @@
+// Bulma settings
+// See https://bulma.io/documentation/layout/container/
+
+$desktop: 1344px;
+$widescreen: 1632px;
+$fullhd: 1920px;
+
 // Colors
 
 $blue: #0047FF;
@@ -44,7 +51,7 @@ $column-gap: 1.25rem;
 
 $content-padding-top: 2rem;
 $content-padding-side: 2rem;
-$content-max-width: 820px;
+$content-max-width: 100%;
 
 $menu-item-active-color: $grey-dark;
 $menu-item-active-background-color: $blue-bg;

--- a/doc/assets/css/sidebar/sidebar.scss
+++ b/doc/assets/css/sidebar/sidebar.scss
@@ -12,7 +12,7 @@
 .sidebar-right {
   display: none;
   order: 2;
-  @media (min-width: $widescreen) {
+  @media (min-width: $desktop) {
   display: block;
   position: -webkit-sticky;
   position: sticky;

--- a/doc/content/getting-started/installation/configuration/index.md
+++ b/doc/content/getting-started/installation/configuration/index.md
@@ -6,7 +6,7 @@ weight: 2
 
 This guide shows an example of configuring {{% tts %}} using configuration files, with an example domain `thethings.example.com` and TLS certificates from Let's Encrypt.
 
-{{< note >}} If configuring {{% tts %}} as `localhost` on a machine with no public IP or DNS address, see the [Localhost](#running-the-things-stack-as-localhost) section. {{</ note >}}
+{{< note >}} If configuring {{% tts %}} as `localhost` on a machine with no public IP or DNS address, see the [`localhost`](#running-the-things-stack-as-localhost) section. {{</ note >}}
 
 ## Configuration Files
 
@@ -198,7 +198,7 @@ by the console client. These tell {{% tts %}} where all its components are acces
 
 If running a multi-tenant environment, we need to configure the default tenant ID, and the base domain from which tenant IDs are inferred. See the [`tenancy` configuration reference]({{< ref "/reference/configuration/the-things-stack#multi-tenancy" >}}).
 
-## Running The Things Stack As Localhost
+## Running The Things Stack as `localhost`
 
 Follow this section if you are configuring and running {{% tts %}} on a local machine with no public IP or DNS address.
 

--- a/doc/layouts/_default/baseof.html
+++ b/doc/layouts/_default/baseof.html
@@ -13,14 +13,14 @@
 
 {{ if $hasSidebar }}
 <div class="container" role="document">
-  <div class="columns my-0 is-desktop">
-      <div class="column is-3-desktop is-2-widescreen sidebar-left">
+  <div class="columns my-0">
+      <div class="column is-one-fifth-tablet is-one-third sidebar-left">
         {{ partial "sidebar/side-navigation.html" . }}
       </div>
-      <div class="column is-9-desktop is-8-widescreen sidebar-middle">
+      <div class="column sidebar-middle">
         {{- block "main" . }}{{- end }}
       </div>
-      <div class="column is-hidden-touch is-2-desktop sidebar-right">
+      <div class="column is-hidden-touch is-one-quarter is-one-fifth-widescreen sidebar-right">
         {{ partial "sidebar/toc.html" . }}
       </div>
   </div>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This makes the rendered content wider.

I found it increasingly annoying to read things as the content was fixed to max 1344px. I have a 4K screen to use more effective screen space and avoid dense content, but our docs doesn't let me do that.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

Here's what it looks like **before**:

![IMG_4185](https://user-images.githubusercontent.com/13334001/112190905-bf787600-8c05-11eb-805f-1b1081fa1c54.jpg)

And **after**:

![IMG_4186](https://user-images.githubusercontent.com/13334001/112191126-fbabd680-8c05-11eb-9e40-0e06ce78275f.jpg)


#### Changes
<!-- What are the changes made in this pull request? -->

Change the default max that Bulma uses from 1344 to 1920px, and the other widths accordingly with the same factor. The widths are still divisible by 12 and 16 for the grid system (that we don't seem to use really).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
