### PR TITLE
doc: Note about gateway ID inconsistency

### DIFF
--- a/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
+++ b/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
@@ -49,3 +49,7 @@ $ curl -XGET \
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
+
+{{< note >}} The `global_conf.json` file you download from {{% tts %}} contains the `gateway_ID` field, that has a different value than the **Gateway ID** in {{% tts %}} Console. 
+
+**Gateway ID** in {{% tts %}} Console represents the name of your gateway used to register it, while the `gateway_ID` field in the `global_conf.json` file contains your gateway's EUI. {{</ note >}}


### PR DESCRIPTION
#### Summary
Adding a note about inconsistency of using the term `gateway ID` in the Console and in the `global_conf.json` file. 
Ref: https://github.com/TheThingsNetwork/lorawan-stack/issues/3777

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
