### PR TITLE
Document changes in MAC command handling from V2

### DIFF
--- a/doc/content/getting-started/migrating/major-changes.md
+++ b/doc/content/getting-started/migrating/major-changes.md
@@ -25,7 +25,8 @@ Devices imported from {{% ttnv2 %}} are configured with an `Rx1Delay` of 1 secon
 
 ## MAC Commands
 
-{{% tts %}} expects that all end devices comply to the LoRaWAN spec, which means that the end devices should properly respond to all MAC commands requests issued by the Network Server. If a device fails to forward a response to MAC Command in a timely manner, there may be disruptions to the device uplink or downlink traffic. As mentioned in the LoRaWAN spec, the Network Server of {{% tts %}} will always prioritize MAC commands over device traffic.
+{{% tts %}} expects that all end devices comply with the LoRaWAN specification by default, which means that the end devices should respond to Network Server MAC command requests accordingly. If a device fails to answer a MAC Command in a timely manner, there may be disruptions to the device uplink or downlink traffic. As mentioned in the LoRaWAN specification, the Network Server of {{% tts %}} will always prioritize MAC commands over application payloads on downlink.
+Note, that in case a device is not fully compliant with the specification - it can still work on {{% tts %}}, but it may require custom MAC settings configuration.
 
 ### DevStatusReq
 

--- a/doc/content/getting-started/migrating/major-changes.md
+++ b/doc/content/getting-started/migrating/major-changes.md
@@ -23,6 +23,18 @@ Furthermore, {{% tts %}} brings full support for all LoRaWAN versions, as well a
 
 Devices imported from {{% ttnv2 %}} are configured with an `Rx1Delay` of 1 second, by default. In {{% tts %}} we recommend using an `Rx1Delay` of 5 seconds to accommodate for high latency backhauls and/or [peering with Packet Broker]({{< ref "/reference/packet-broker" >}}). See the [MAC settings guide]({{< ref "/devices/mac-settings" >}}) for more information and instructions about configuring `Rx1Delay`.
 
+## MAC Commands
+
+{{% tts %}} expects that all end devices comply to the LoRaWAN spec, which means that the end devices should properly respond to all MAC commands requests issued by the Network Server. If a device fails to forward a response to MAC Command in a timely manner, there may be disruptions to the device uplink or downlink traffic. As mentioned in the LoRaWAN spec, the Network Server of {{% tts %}} will always prioritize MAC commands over device traffic.
+
+### DevStatusReq
+
+The `DevStatusReq` MAC command is sent by the Network Server periodically to check the current status of the end device. Devices are expected to send a `DevStatusAns` reply.
+
+For end devices that ignore this MAC command, make sure to configure the `StatusTimePeriodicity` (time duration after which a `DevStatusReq` is issued by the Network Server) and `StatusCountPeriodicity` (number of frames after which a `DevStatusReq` is issued) of the device explicitly to `0`. Same as with `Rx1Delay`, see the [MAC settings guide]({{< ref "/devices/mac-settings" >}}) for more information.
+
+If you follow the [Migrating from The Things Network Stack V2]({{< ref "/getting-started/migrating/migrating-from-v2" >}}) guide, devices exported with the `ttn-lw-migrate` tool have these MAC settings set to `0` by default.
+
 ## Gateway Coverage
 
 Packet Broker enables peering between networks, so traffic received by one network (e.g. the Public Community Network) but intended for a different network ({{% tts %}}) can be forwarded to and from that network. See the [Peering Guide]({{< ref "/reference/packet-broker" >}}) for details on Packet Broker and how to enable it for your network.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Document changes in MAC command handling

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![image](https://user-images.githubusercontent.com/1888650/113066679-9e92c080-91c3-11eb-9bd7-00666d4c40f8.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Add a note that The Things Stack expects the end device to always comply with the LoRaWAN spec.
- Document how to disable NS sending `DevStatusReq` commands periodically. 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@rvolosatovs Any other changes that are important to document?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [X] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
