### PR TITLE
Fix anchor link navbar offset

### DIFF
--- a/doc/assets/css/common/variables.scss
+++ b/doc/assets/css/common/variables.scss
@@ -57,3 +57,5 @@ $menu-item-active-color: $grey-dark;
 $menu-item-active-background-color: $blue-bg;
 
 $banner-height: 4rem;
+
+$anchor-offset: $navbar-height + 1rem;

--- a/doc/assets/css/header/nav.scss
+++ b/doc/assets/css/header/nav.scss
@@ -35,5 +35,14 @@ a.navbar-item {
 }
 
 .has-navbar-banner-top {
-  padding-top: $navbar-height + $banner-height!important;
+  padding-top: $navbar-height + $banner-height !important;
+}
+
+// Offset anchorlinks for navbar.
+[id]::before {
+  content: '';
+  display: block;
+  height: $anchor-offset;
+  margin-top: $anchor-offset * -1;
+  visibility: hidden;
 }


### PR DESCRIPTION
#### Summary
This quickfix fixes selected content being not visible behind the navbar e.g. for glossary items. This happened when linking glossary items directly e.g. as the Console does.

#### Changes
Add CSS to add an offset to selected anchor links.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
