### PR TITLE
Add note about dev_id constraints in TTS V3

### DIFF
--- a/doc/content/getting-started/migrating/migrating-from-v2.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2.md
@@ -116,4 +116,6 @@ $ ttn-lw-migrate application --verbose --dry-run --source ttnv2 "my-ttn-app" > a
 $ ttn-lw-migrate application --source ttnv2 "my-ttn-app" > all-devices.json
 ```
 
+{{< note >}} In {{% ttnv2 %}}, underscores ( _ ) are allowed in the end device ID but not in {{% tts %}}. You can refer to [ID And EUI Constraints Document]({{< ref "reference/id-eui-constraints" >}}) for more information. The `ttn-lw-migrate` tool replaces an underscore with a dash ( - ) automagically while exporting the devices. {{</ note >}}
+
 After exporting the end devices in to a json file you can refer to [Import End Devices Document]({{< ref "getting-started/migrating/import-devices.md" >}}) in {{% tts %}} for next steps.


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Added a note in the `Migrating from The Things Network Stack V2` document related to the `device ID` constraint comparing `TTI V2` to `TTS V3` and how the migration tool solves this.
Ref: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/262

#### Screenshots

...

#### Notes for Reviewers

...


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.

