### PR TITLE
doc: Remove old new-in-version tags, small fixes

### DIFF
--- a/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
+++ b/doc/content/gateways/semtech-udp-packet-forwarder/_index.md
@@ -22,7 +22,7 @@ An example `global_conf.json` is available in the [{{% udp-pf %}} Github reposit
 
 {{< tabs/tab "Console" >}}
 
-## Download Configuration in the Console {{< new-in-version "3.10" >}} {#download-configuration-in-the-console}
+## Download Configuration in the Console {#download-configuration-in-the-console}
 
 To download a `global_conf.json` file for your gateway, open the Gateway overview page in the console. Click the **Download global_conf.json** button to download the file.
 

--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -88,7 +88,7 @@ It is recommended to have a **Multi-AZ** cluster with automatic failover, in whi
 
 If you are migrating your database from a previous deployment, or if you are upgrading your database, you can fill the name of the database **Snapshot** that should be restored.
 
-## TimescaleDB (optional) {{< new-in-version "3.10" >}} {#timescaledb-optional}
+## TimescaleDB (optional) {#timescaledb-optional}
 
 The template `2-5-db-timescale` is an optional template that creates an EC2 instance that runs [TimescaleDB](https://www.timescale.com/), which is used by the Storage Integration of the Application Server. 
 
@@ -151,7 +151,7 @@ For deployments that connect to Packet Broker, you need to configure your Packet
 
 For multi-tenant deployments that use tenant billing through Stripe (see the [Stripe Billing reference]({{< ref "/reference/stripe" >}})), you need to configure the Stripe API key (starting with `sk_`) and Stripe endpoint secret key (starting with `whsec_`). It is possible to add or update this in the future.
 
-For the **Gateway Secrets Encryption Key Value** parameter {{< new-in-version "3.10" >}}, provide an AES-128 Key in Base64. The following command can be used to randomly generate one:
+For the **Gateway Secrets Encryption Key Value** parameter, provide an AES-128 Key in Base64. The following command can be used to randomly generate one:
 
 ```bash
 $ openssl rand -base64 16

--- a/doc/content/getting-started/migrating/import-devices.md
+++ b/doc/content/getting-started/migrating/import-devices.md
@@ -12,7 +12,7 @@ To import devices, use the `devices.json` file you created in the previous step.
 
 {{< tabs/tab "Console" >}}
 
-### Import devices via the Console {{< new-in-version "3.9.3" >}} {#import-devices-via-the-console}
+### Import devices via the Console {#import-devices-via-the-console}
 
 Open the application you created and click the button **Import end devices**
 

--- a/doc/content/integrations/adding-applications/_index.md
+++ b/doc/content/integrations/adding-applications/_index.md
@@ -25,32 +25,6 @@ Your application will be created and you will be redirected to the application o
 
 {{< figure src="application-overview.png" alt="Application overview" >}}
 
-You can now use the built-in [MQTT Server]({{< ref "/integrations/mqtt" >}}) or [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}) to receive uplink and send downlink traffic. End devices are created within applications (see [Adding Devices]({{< ref "/devices/adding-devices" >}}) section).
-
-### Link application {{< removed-in-version "3.11.0" >}}
-
-If you did not uncheck the **Link automatically** checkbox during creation, your application will be automatically linked to the Application Server. You can skip this section in this case.
-
-In order to send uplinks and receive downlinks from your device, you must link the Application Server to the Network Server. To do this, create an API key for the Application Server by going to **API keys** in the left menu of your application, and then clicking **+ Add API Key**.
-
-In the API Key creation screen, enter a name for your linking API key and select the **Link as Application to a Network Server** right, then press **Create API Key**.  
-
-{{< figure src="api-key-creation.png" alt="Application API Key creation" >}}
-
-You will see a screen that shows your newly created API Key. Copy it in your clipboard by pressing the copy button. After saving the key in a safe place, press **I have copied the key**. 
-
-{{< note >}} You will not be able to see this key again in the future, but if you lose it, you can create a new one to replace it. {{</ note >}}
-
-{{< figure src="api-key-created.png" alt="Application API Key created" >}}
-
-Now go to **Link** in the left menu of the application and enter the API key you've just created. You can leave the Network Server address empty. Press **Save Changes** to save the link settings. 
-
-{{< figure src="application-link-creation.png" alt="Application link creation" >}}
-
-You can now see the status of the linking process appear in the right part of your screen. This also shows the statistics of the link between the Application Server and the Network Server. 
-
-Your application is now linked, so you can proceed with using the MQTT server and webhooks for receiving uplink traffic and sending downlink traffic.
-
 {{< /tabs/tab >}}
 
 {{< tabs/tab "CLI" >}}
@@ -65,31 +39,10 @@ $ ttn-lw-cli applications create app1 --user-id admin
 
 This creates an application `app1` with the `admin` user as collaborator.
 
-End devices are created within applications (see [Adding Devices]({{< ref "/devices/adding-devices" >}}) section).
-
-### Link Application {{< removed-in-version "3.11.0" >}}
-
-In order to send uplinks and receive downlinks from your device, you must link the Application Server to the Network Server. In order to do this, create an API key for the Application Server:
-
-```bash
-$ ttn-lw-cli applications api-keys create \
-  --name link \
-  --application-id app1 \
-  --right-application-link
-```
-
-The CLI will return an API key, such as `NNSXS.VEEBURF3KR77ZR...`. This API key has only link rights and can therefore only be used for linking this application. Make sure to copy the key and save it in a safe place. 
-
-{{< note >}} You will not be able to see this key again in the future, and if you lose it, you can create a new one to replace it in the gateway configuration. {{</ note >}}
-
-You can now link the Application Server to the Network Server:
-
-```bash
-$ ttn-lw-cli applications link set app1 --api-key NNSXS.VEEBURF3KR77ZR..
-```
-
-Your application is now linked, so you can proceed with using the MQTT server and webhooks for receiving uplink traffic and sending downlink traffic.
-
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
+
+Next, see [Adding Integrations]({{< ref "/integrations/adding-integrations" >}}) to proceed with using the built-in [MQTT Server]({{< ref "/integrations/mqtt" >}}) and [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}) for receiving uplink and sending downlink traffic.
+
+End devices are also created within applications. See [Adding Devices]({{< ref "/devices/adding-devices" >}}) for more information.

--- a/doc/content/integrations/aws-iot/default/architecture.md
+++ b/doc/content/integrations/aws-iot/default/architecture.md
@@ -15,12 +15,12 @@ The key resources deployed in your AWS account are:
 - Cross-account role for {{% tts %}} to connect to your AWS IoT Core MQTT endpoint
 - AWS Lambda functions to create the thing type and configure the integration as pub/sub in {{% tts %}}
 - AWS Lambda functions for claiming and creating devices, and for handling uplink and downlink messages
-- Secret with key encryption key (KEK) to leverage LoRaWAN end-to-end encryption {{< new-in-version "3.10.0" >}}
+- Secret with key encryption key (KEK) to leverage LoRaWAN end-to-end encryption
 - IoT Core rules to trigger the Lambda functions based on topics and attributes
 
 This is a serverless deployment: there are no compute resources being deployed. AWS only charges for usage, which is driven by traffic. The only continuous charges are by IoT Core connectivity from {{% tts %}} to your AWS account. All permissions are the minimum permissions for the integration to function.
 
-## End-to-End Encryption {{< new-in-version "3.10.0" >}} {#end-to-end-encryption}
+## End-to-End Encryption {#end-to-end-encryption}
 
 This integration supports true LoRaWAN end-to-end encryption: the application payload is encrypted on the end device with the LoRaWAN AppSKey, and decrypted in your AWS Account. The underlying network infrastructure passes your application payload in the encrypted form - it cannot see your data.
 

--- a/doc/content/integrations/aws-iot/default/deployment-guide.md
+++ b/doc/content/integrations/aws-iot/default/deployment-guide.md
@@ -68,7 +68,7 @@ The parameters configure the integration:
   - When using **The Things Stack Cloud**, go to [The Things Stack Cloud Addresses]({{< relref "/getting-started/cloud-hosted/addresses" >}}) to find your cluster address
   - When using **The Things Stack Enterprise**, enter your cluster address
   - When using **The Things Network**, select the community cluster from the dropdown
-- **Enable End-to-End Encryption** {{< new-in-version "3.10.0" >}} {{< distributions "Cloud" >}}: If enabled, the AppSKey is delivered as encrypted from Join Server to your AWS Account, so the AppSKey will not be exposed to the network layer. Also, your AWS solution needs to handle binary payload as the underlying network cannot run payload encoding and decoding functions.
+- **Enable End-to-End Encryption** {{< distributions "Cloud" >}}: If enabled, the AppSKey is delivered as encrypted from Join Server to your AWS Account, so the AppSKey will not be exposed to the network layer. Also, your AWS solution needs to handle binary payload as the underlying network cannot run payload encoding and decoding functions.
 - **Application ID**: The application ID for which you configure the integration.
 - **Application API Key**: The application API key that you generated before.
 

--- a/doc/content/integrations/pubsub/_index.md
+++ b/doc/content/integrations/pubsub/_index.md
@@ -8,4 +8,4 @@ The Pub/Sub integration allows the Application Server to publish and subscribe t
 
 <!--more-->
 
-{{< warning >}} This feature will be removed in January 5, 2021 for Cloud deployments! {{</ warning >}}
+{{< warning >}} This feature has been removed for Cloud deployments! {{</ warning >}}

--- a/doc/content/integrations/storage/_index.md
+++ b/doc/content/integrations/storage/_index.md
@@ -3,7 +3,6 @@ title: Storage Integration
 description: ""
 summary: Persistent storage for upstream messages.
 distributions: ["Cloud", "Dedicated Cloud", "Enterprise", "AWS Launcher", "Community"]
-new_in_version: "3.10"
 ---
 
 The Storage Integration allows storing received upstream messages in a persistent database, and retrieving them at a later time.

--- a/doc/content/integrations/storage/enable.md
+++ b/doc/content/integrations/storage/enable.md
@@ -9,7 +9,7 @@ The Storage Integration is implemented as an [Application Package]({{< ref "/ref
 
 {{< cli-only >}}
 
-{{< warning >}}The Storage Integration is new in {{% tts %}} 3.10. You may need to update the CLI to use the new features. See instructions in [Installing the CLI]({{< ref "/getting-started/cli/installing-cli" >}})
+{{< warning >}} You may need to update the CLI to use the new features. See instructions in [Installing the CLI]({{< ref "/getting-started/cli/installing-cli" >}}).
 {{</ warning >}}
 
 ## Enable for an Application

--- a/doc/content/integrations/webhooks/webhook-templates/format.md
+++ b/doc/content/integrations/webhooks/webhook-templates/format.md
@@ -51,7 +51,7 @@ The message paths are provided in the `paths` object which can contain the follo
 - `downlink-sent`: The path to which downlink sent will be sent. Can contain template fields.
 - `downlink-failed`: The path to which downlink failures will be sent. Can contain template fields.
 - `downlink-queued`: The path to which downlink queued status will be sent. Can contain template fields.
-- `downlink-queue-invalidated` {{< new-in-version "3.10.0" >}}: The path to which downlink queue invalidated event will be sent. Can contain template fields. This is only used when the upstream platform carries out LoRaWAN `FRMPayload` encryption.
+- `downlink-queue-invalidated`: The path to which downlink queue invalidated event will be sent. Can contain template fields. This is only used when the upstream platform carries out LoRaWAN `FRMPayload` encryption.
 - `location-solved`: The path to which the location of the device will be sent when resolved. Can contain template fields.
 
 {{< note >}} Not all of the messages types must be handled by the service. By omitting the field in the `paths` object, the message type will be disabled in the final webhook and the related messages will not be passed to the endpoint. {{</ note >}}

--- a/doc/content/reference/components/application-server.md
+++ b/doc/content/reference/components/application-server.md
@@ -9,14 +9,6 @@ It hosts an MQTT server for streaming application data, supports HTTP webhooks a
 
 <!--more-->
 
-## Linking to Network Servers {{< removed-in-version "3.11.0" >}}
-
-Application Servers link to Network Servers to receive upstream traffic and write downstream traffic.
-
-Most {{% tts %}} clusters contain an Application Server, but you can also link an external Application Server to a Network Server. This ensures that the application session key (AppSKey) is not available to the network-layer for end-to-end security.
-
-Only one Application Server instance can be linked to a Network Server at a time.
-
 ## Connectivity
 
 Applications can connect to Application Server over multiple protocols and mechanisms.

--- a/doc/content/reference/configuration/application-server.md
+++ b/doc/content/reference/configuration/application-server.md
@@ -3,12 +3,6 @@ title: "Application Server Options"
 description: ""
 ---
 
-## Linking Options {{< removed-in-version "3.11.0" >}}
-
-The Application Server links to a Network Server. The `link-mode` configures how linking occurs.
-
-- `as.link-mode`: Mode to link applications to their Network Server (all, explicit) (default "all")
-
 ## Security Options
 
 - `as.device-kek-label`: Label of KEK used to encrypt device keys at rest

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -139,13 +139,13 @@ By default users can create applications, gateways, organizations and OAuth clie
 - `is.user-rights.create-gateways`: Allow non-admin users to create gateways in their user account
 - `is.user-rights.create-organizations`: Allow non-admin users to create organizations in their user account
 
-## Admin Rights Options {{< new-in-version "3.10.6" >}} {#admin-rights-options}
+## Admin Rights Options {#admin-rights-options}
 
 By default admins are granted _almost_ all rights on all entities in the network. The default configuration does not allow admins to read secrets, such as the root keys of end devices, and the CUPS/LNS secrets of gateways. This also means that admins can not assign those rights to others. The following option can be used to grant admin users all possible rights.
 
 - `is.admin-rights.all`: Grant all rights to admins, including `_KEYS` and `_ALL`
 
-## Gateway Secrets Encryption Options {{< new-in-version "3.10" >}} {#gateway-secrets-encryption-options}
+## Gateway Secrets Encryption Options{#gateway-secrets-encryption-options}
 
 - `is.gateways.encryption-key-id`: ID of the key used to encrypt gateway secrets at rest.
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -67,7 +67,7 @@ When running a cluster in a trusted network, you can allow sending credentials o
 
 If {{% tts %}} is deployed behind a reverse proxy that does not use a private network IP address (in `127.0.0.0/8`, `10.0.0.0/8`, `100.64.0.0/10`, `172.16.0.0/12` or `192.168.0.0/16`), its IP address range needs to be configured in order for {{% tts %}} to trust it.
 
-- `grpc.trusted-proxies`: CIDRs of trusted reverse proxies. {{< new-in-version "3.10.2" >}}
+- `grpc.trusted-proxies`: CIDRs of trusted reverse proxies.
 
 You can suppress log messages for successful gRPC method calls (e.g. to reduce the noise caused by the health checks in a production environment).
 
@@ -302,6 +302,6 @@ Tenants can have custom configuration, such as custom branding or custom user re
 
 - `tenancy.ttl`: TTL of cached tenant configurations {{< distributions "Cloud" "Enterprise" >}}
 
-## Rate Limiting {{< new-in-version "3.12" >}}
+## Rate Limiting {{< new-in-version "3.12.0" >}}
 
 {{% tts %}} supports rate limiting external endpoints. Rate limiting configuration can only be set from the configuration file. See [Rate Limiting]({{< ref "/reference/rate-limiting" >}}) for more details.

--- a/doc/content/reference/federated-auth/_index.md
+++ b/doc/content/reference/federated-auth/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Federated Authentication"
 description: ""
-new_in_version: "3.10"
 ---
 
 Federated Authentication allows network administrators to use the already existing identity providers in order to authenticate users, instead of manually creating and managing the accounts in {{% tts %}}.


### PR DESCRIPTION
#### Summary
Closes #310

#### Notes for Reviewers
Should sections that have been marked as removed in certain version be completely removed from the documentation? Example: application linking -> https://www.thethingsindustries.com/docs/integrations/adding-applications/

Should I leave **Deprecated in version xxx** sections untouched? What does deprecated mean here, that it will be removed in the next version?

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
