### PR TITLE
doc: Fix content overflow

### DIFF
--- a/doc/assets/css/sidebar/sidebar.scss
+++ b/doc/assets/css/sidebar/sidebar.scss
@@ -23,6 +23,7 @@
 
 .sidebar-middle {
   order: 1;
+  overflow: hidden;
 }
 
 .docs-content {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Some pages currently overflow the column, pushing the nav to the side. See https://www.thethingsindustries.com/docs/devices/mac-settings/

and the underlying bug in Bulma - https://github.com/jgthms/bulma/issues/1540

This PR fixes that

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

Before:
<img width="1416" alt="Bildschirmfoto 2021-04-19 um 19 23 47" src="https://user-images.githubusercontent.com/6963436/115246621-c67f9f00-a145-11eb-95ee-cf065b76bfaf.png">

After:
<img width="1415" alt="Bildschirmfoto 2021-04-19 um 19 23 22" src="https://user-images.githubusercontent.com/6963436/115246646-cc758000-a145-11eb-89d9-368f33600338.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
