### PR TITLE
Fix migration docs

### DIFF
--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
@@ -14,9 +14,29 @@ This section only applies to OTAA devices.{{</ note >}}
 
 {{< info >}} We strongly recommend migrating end devices without persisting active sessions {{</ info >}}
 
+{{< tabs/container "OTAA" "ABP" >}}
+
+{{< tabs/tab "OTAA" >}}
+
 When migrating OTAA devices without persisting active sessions, a new join needs to be performed on {{% tts %}} to establish a new session. 
 
 By establishing the new session with {{% tts %}}, an OTAA device gets assigned a new **DevAddr** and default values of some other parameters (like 5 seconds **RX1 Delay**). This ensures that the traffic sent by these end devices can be properly routed by the Packet Broker to and from {{% tts %}}.
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "ABP" >}}
+
+The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you can migrate it to {{% tts %}} without its security keys, network parameters, etc. which basically means you are migrating it without its active session.
+
+Since this means the device will keep its **DevAddr** and **RX1 Delay** from {{% ttnv2 %}}, you will also have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}).
+
+{{< warning >}} Note that this is **not a recommended practice**. 
+
+We advise re-programming the ABP device to change the **DevAddr** to the one issued by The Things Stack and **RX1 Delay** to 5 seconds, even if you do not want your traffic to be routed by Packet Broker. However, to do this, you will have to follow the [Migrate using the Console]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-console" >}}) guide.{{</ warning >}}
+
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}
 
 {{< note >}} Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below. {{</ note >}} 
 
@@ -58,13 +78,31 @@ $ ttn-lw-migrate application --source ttnv2 "ttn-v2-application-ID" --ttnv2.with
 
 Exporting end devices without their active sessions does not clear root and session keys on {{% ttnv2 %}}. Hence, you need to prevent your devices from re-joining the {{% ttnv2 %}} network.
 
+{{< tabs/container "OTAA" "ABP" >}}
+
+{{< tabs/tab "OTAA" >}}
+
 To prevent OTAA device from re-joining the {{% ttnv2 %}} network, the recommended practice is to change the **AppKey** in the {{% ttnv2 %}}. By changing the **AppKey**, the existing session on {{% ttnv2 %}} will not be terminated yet, but the end device will not be able to re-join because the {{% ttnv2 %}} cluster will reject its new Join Requests. 
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "ABP" >}}
+
+For ABP device, you need to completely delete it from V2, especially because this section assumes that you have not re-programmed it for a new **DevAddr**. Having this device registered in V2 and The Things Stack would introduce some serious conflicts. 
+
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}
 
 ## Import End Devices in {{% tts %}} Application
 
 Now that you have exported one or more of your devices to a `devices.json` file, you can continue by importing this file in {{% tts %}} via Console or via CLI. 
 
 > See [Import End Devices in The Things Stack]({{< ref "/getting-started/migrating/import-devices" >}}) for detailed instructions on how to do this.
+
+{{< tabs/container "OTAA" "ABP" >}}
+
+{{< tabs/tab "OTAA" >}}
 
 ## Let the OTAA End Device Join {{% tts %}} Network
 
@@ -83,3 +121,13 @@ Since we assume that you have not migrated your gateway from {{% ttnv2 %}} yet, 
 Instead, these Join Requests are going to be routed to {{% tts %}} via Packet Broker and {{% tts %}} will accept them. Your OTAA device will negotiate with {{% tts %}} Network Server to obtain a new **DevAddr**, channel settings and other MAC parameters. The traffic from your end device can from now on be routed to {{% tts %}} thanks to the newly assigned **DevAddr** and **RX1 Delay** of 5 seconds, which fulfills the Packet Broker requirements.
 
 {{< note >}} Even if you manage to get your end device traffic routed to {{% tts %}} via Packet Broker, we still recommend you get in touch with your local The Things Network community and coordinate the migration of gateways, so you do not loose the LoRaWAN network coverage. See how to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}). {{</ note >}}
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "ABP" >}}
+
+## Next Step - Migrate Gateways
+
+This section implies that you are keeping the **DevAddr** and **RX1 Delay** values from {{% ttnv2 %}}, which means Packet Broker will not be able to route the traffic between your end device and {{% tts %}} neither properly, nor on time. Hence, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) as well. 
+
+{{< note >}} Keep in mind that we advise to keep your gateways on {{% ttnv2 %}} until you get in touch with your local The Things Network community and coordinate the migration of gateways, so you do not loose the LoRaWAN network coverage. {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
@@ -25,7 +25,9 @@ In the case of persisting active sessions during migration, OTAA devices do not 
 
 {{< tabs/tab "ABP" >}}
 
-The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you are basically migrating it to {{% tts %}} with its active session. 
+The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you can migrate it to {{% tts %}} with its active session. 
+
+Be aware that if you are not migrating specifically from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, you will have to either [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to successfully migrate your end device with its active session, or [migrate your end device without active session]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session" >}}). 
 
 {{< /tabs/tab >}}
 


### PR DESCRIPTION
#### Summary
Adding info about migrating ABP device with `ttn-lw-migrate` tool.

#### Notes for Reviewers
@neoaggelos I'm not sure if this can be done. I know that ABP device can be migrated with this tool with active session, but can't it be migrated with the same DevAddr and RX1 Delay using this tool + migrating a gateway?

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
