### PR TITLE
Add documentation for new deployment information configs

### DIFF
--- a/doc/content/reference/branding/_index.md
+++ b/doc/content/reference/branding/_index.md
@@ -50,3 +50,7 @@ $ convert console-favicon.png \
     console-favicon.ico
 ```
 {{</ note >}}
+
+## Deployment Information and Disclaimers
+
+It is possible to highlight some deployment information and disclaimers in the header of the web UIs. E.g. you can highlight an SLA that applies or a support tier that is connected with the deployment. Please see the respective sections in the [Identity Server configuration reference]({{< ref "/reference/configuration/identity-server#oauth-ui-options" >}}) and [Console configuration reference]({{< ref "/reference/configuration/console#deployment-information-and-disclaimers" >}})

--- a/doc/content/reference/configuration/console.md
+++ b/doc/content/reference/configuration/console.md
@@ -69,3 +69,14 @@ You can control the url of the assets folder that the Console frontend will use,
 - `console.ui.documentation-base-url`: The base URL for generating documentation links
 - `console.ui.theme-color`: The page theme color
 - `console.ui.title`: The page title
+- `console.ui.cluster-picker-url`: A URL to the a cluster picker to enable users to pick the correct cluster of the deployment
+
+### Deployment Information and Disclaimers
+
+It is possible to highlight some deployment information and disclaimers in the header of the Console:
+
+- `console.ui.fair-use-policy-information-url`: A URL with information about the applicable fair use policy of the deployment
+- `console.ui.sla-applies`: The applicable Service Level Agreement of this deployment, e.g. `>99.9%`
+- `console.ui.sla-information-url`: A URL with information about the SLA applicable for this deployment
+- `console.ui.support-plan-applies`: The applicable support plan of this deployment, e.g. `priority`, `24h`
+- `console.ui.support-plan-information-url`: A URL with information about the support plan applicable for this deployment

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -68,6 +68,7 @@ If page assets for the OAuth UI are served from a CDN or on a different path on 
 - `is.oauth.ui.branding-base-url`: The base URL to the branding assets
 - `is.oauth.ui.branding-cluster-id`: The cluster ID to show below the logo {{< distributions "Cloud" "Enterprise" >}}
 - `is.oauth.ui.branding-text`: The branding text to show below the logo {{< distributions "Cloud" "Enterprise" >}}
+- `is.oauth.ui.cluster-picker-url`: A URL to the a cluster picker to enable users to pick the correct cluster of the deployment
 
 The appearance of {{% tts %}} can optionally be customized.
 
@@ -83,6 +84,14 @@ Further customization of the CSS files, JS files and icons is also possible:
 - `is.oauth.ui.css-file`: The names of the CSS files
 - `is.oauth.ui.js-file`: The names of the JS files
 - `is.oauth.ui.icon-prefix`: The prefix to put before the page icons (favicon.ico, touch-icon.png, og-image.png)
+
+It is possible to highlight some deployment information and disclaimers in the header of the Account App:
+
+- `is.oauth.ui.fair-use-policy-information-url`: A URL with information about the applicable fair use policy of the deployment
+- `is.oauth.ui.sla-applies`: The applicable Service Level Agreement of this deployment, e.g. `>99.9%`
+- `is.oauth.ui.sla-information-url`: A URL with information about the SLA applicable for this deployment
+- `is.oauth.ui.support-plan-applies`: The applicable support plan of this deployment, e.g. `priority`, `24h`
+- `is.oauth.ui.support-plan-information-url`: A URL with information about the support plan applicable for this deployment
 
 ## Profile Picture Storage Options
 


### PR DESCRIPTION
#### Summary
This PR adds documentation for the recently added deployment information configs, which are shown in the headers of the web UI.

#### Changes
- Extend config reference for the console
- Extend config reference for the IS
- Extend the branding guide


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
