### PR TITLE
Fix example configuration

### DIFF
--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
@@ -91,6 +91,8 @@ console:
       base-url: 'https://thethings.example.com/api/v3'
     gs:
       base-url: 'https://thethings.example.com/api/v3'
+    gcs:
+      base-url: 'https://thethings.example.com/api/v3'
     ns:
       base-url: 'https://thethings.example.com/api/v3'
     as:
@@ -125,8 +127,8 @@ as:
         insert-batch-size: 1024     # batch size for INSERT operations
         select-batch-size: 1024     # batch size for SELECT operations
   mqtt:
-    public-address: 'https://thethings.example.com:1883'
-    public-tls-address: 'https://thethings.example.com:8883'
+    public-address: 'thethings.example.com:1883'
+    public-tls-address: 'thethings.example.com:8883'
   webhooks:
     downlink:
       public-address: 'thethings.example.com:1885/api/v3'

--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-open-source.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-open-source.yml
@@ -80,6 +80,8 @@ console:
       base-url: 'https://thethings.example.com/api/v3'
     gs:
       base-url: 'https://thethings.example.com/api/v3'
+    gcs:
+      base-url: 'https://thethings.example.com/api/v3'
     ns:
       base-url: 'https://thethings.example.com/api/v3'
     as:
@@ -101,8 +103,8 @@ console:
 # If Application Server enabled, defaults for "thethings.example.com":
 as:
   mqtt:
-    public-address: 'https://thethings.example.com:1883'
-    public-tls-address: 'https://thethings.example.com:8883'
+    public-address: 'thethings.example.com:1883'
+    public-tls-address: 'thethings.example.com:8883'
   webhooks:
     downlink:
       public-address: 'thethings.example.com:1885/api/v3'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small Pull Request that fixes the example configuration.

- The GCS API endpoint was missing
- The public MQTT addresses contained `https://`
