### PR TITLE
doc: Add note for PowerShell

### DIFF
--- a/doc/content/download.html
+++ b/doc/content/download.html
@@ -61,7 +61,7 @@ menu:
     <a href="https://thethingsindustries.com/deployment/" class="button is-primary is-outlined is-hidden-mobile" target="_blank">See Deployment Options</a>
 
     <h3>
-      The Things Network
+      Community Edition
       <span class="badge-stack">
         <img class="badge" src="{{% rel-url "/img/tts_frames/frame_cloud.svg" %}}"></img>
       </span>

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
@@ -24,7 +24,9 @@ $ export TTNV2_APP_ACCESS_KEY="ttn-v2-application-access-key"
 $ export FREQUENCY_PLAN_ID="EU_863_870_TTN"
 ```
 
-If using Windows OS, replace `export` with `set` and remove the double-quotes in commands above:
+{{< note >}} Change the `FREQUENCY_PLAN_ID` value to the frequency plan you are using. See the list of [supported Frequency Plans]({{< ref "/reference/frequency-plans" >}}). {{</ note >}}
+
+If using Windows OS Command Prompt, replace `export` with `set` and remove the double-quotes in commands above:
 
 ```bash
 $ set TTNV2_APP_ID=ttn-v2-application-ID
@@ -32,7 +34,12 @@ $ set TTNV2_APP_ACCESS_KEY=ttn-v2-application-access-key
 $ set FREQUENCY_PLAN_ID=EU_863_870_TTN
 ```
 
-{{< note >}} Change the `FREQUENCY_PLAN_ID` value to the frequency plan you are using. See the list of [supported Frequency Plans]({{< ref "/reference/frequency-plans" >}}). {{</ note >}}
+{{< note >}} Be aware that setting environmental variables using Windows PowerShell is slightly different. For example, you would set the `TTNV2_APP_ID` variable as follows:
+
+```powershell
+$ $env:TTNV2_APP_ID='ttn-v2-application-ID'
+```
+{{</ note >}}
 
 If you are migrating end devices from a private The Things Industries V2 (SaaS) cluster, you need to configure one extra environmental variable:
 


### PR DESCRIPTION
#### Summary
Adding a note for setting environmental variables using Windows PowerShell, because it's different compared to using Command Prompt. This can be misleading, because people might not notice that using the `set` command in PowerShell doesn't actually set the variable, since it also doesn't report any error (or anything at all). As a consequence, migration tool can't export the device from V2.

+ changed "The Things Network" to "Community Edition" on Downloads page which is closing #298 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
