### PR TITLE
Update API doc styling

### DIFF
--- a/doc/assets/css/common/global.scss
+++ b/doc/assets/css/common/global.scss
@@ -286,3 +286,19 @@ h2, h3, h4, h5, h6 {
     visibility: visible
   }
 }
+
+table.api {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 4px solid #ececec;
+  border-top: 4px solid #ececec;
+  td,th {border:none;}
+  th {text-align:right!important;}
+}
+
+table.api + table.api {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}

--- a/doc/assets/css/common/global.scss
+++ b/doc/assets/css/common/global.scss
@@ -291,8 +291,8 @@ table.api {
   margin-top: 2rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 4px solid #ececec;
-  border-top: 4px solid #ececec;
+  border-bottom: 2px solid #ececec;
+  border-top: 2px solid #ececec;
   td,th {border:none;}
   th {text-align:right!important;}
 }

--- a/doc/layouts/shortcodes/proto/enum.html
+++ b/doc/layouts/shortcodes/proto/enum.html
@@ -4,7 +4,7 @@
 {{- with .comment }}
 <p>{{ . | markdownify }}</p>
 {{- end }}
-<table>
+<table class="api">
   <thead>
     <tr>
       <th>Name</th>

--- a/doc/layouts/shortcodes/proto/message.html
+++ b/doc/layouts/shortcodes/proto/message.html
@@ -6,7 +6,7 @@
 {{- end }}
 
 {{- range .fields }}
-<table>
+<table class="api">
   <tbody>
     <tr>
       <th style="width: 150px">
@@ -65,7 +65,7 @@
 {{ end }}
 
 {{- if .oneofs }}
-<table>
+<table class="api">
   <thead>
     <th>Restrictions</th>
   </thead>

--- a/doc/layouts/shortcodes/proto/message.html
+++ b/doc/layouts/shortcodes/proto/message.html
@@ -5,6 +5,24 @@
 <p>{{ . | markdownify }}</p>
 {{- end }}
 
+{{- if .oneofs }}
+<b>Restrictions:</b>
+{{- range .oneofs }}
+<ul>
+  <li>Only one of {{ range $i, $name := .field_names }}{{ if gt $i 0 }}, {{ end }}<code>{{ $name }}</code>{{ end}} can be set.</li>
+</ul>
+{{- end }}
+{{- end }}
+
+<details><summary>Show object example</summary>
+<pre><code>{
+{{- range .fields }}
+  "{{ .name }}": {{ .default | jsonify }},
+{{- end }}
+}</code></pre>
+</details>
+
+<p><b>Fields:</b></p>
 {{- range .fields }}
 <table class="api">
   <tbody>
@@ -63,31 +81,6 @@
   </tbody>
 </table>
 {{ end }}
-
-{{- if .oneofs }}
-<table class="api">
-  <thead>
-    <th>Restrictions</th>
-  </thead>
-  <tbody>
-    {{- range .oneofs }}
-    <tr>
-      <td>
-        Only one of {{ range $i, $name := .field_names }}{{ if gt $i 0 }}, {{ end }}<code>{{ $name }}</code>{{ end}} can be set.
-      </td>
-    </tr>
-    {{- end }}
-  </tbody>
-</table>
-{{- end }}
-
-<details><summary>Show object example</summary>
-<pre><code>{
-{{- range .fields }}
-  "{{ .name }}": {{ .default | jsonify }},
-{{- end }}
-}</code></pre>
-</details>
 
 {{- else -}}
 {{ errorf "message %s of package %s not found: %s" $message $package .Position }}

--- a/doc/layouts/shortcodes/proto/method.html
+++ b/doc/layouts/shortcodes/proto/method.html
@@ -1,7 +1,7 @@
 {{ $package := or (.Get "package") "ttn.lorawan.v3" }}{{ $service := .Get "service" }}{{ $method := .Get "method" }}
 {{ with index .Site.Data "api" $package "services" $service "methods" $method -}}
 
-<table>
+<table class="api">
   <tbody>
     <tr>
       <th style="width: 150px">


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #371 

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="701" alt="Bildschirmfoto 2021-06-08 um 12 03 52" src="https://user-images.githubusercontent.com/6963436/121167040-dd8f6300-c851-11eb-830c-d883f75c984b.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Add border between tables
- Remove borders inside tables
- Right align headers

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
