### PR TITLE
doc: Document V3 -> V2 routing, reusing payload (de)coders, TTIG migration

### DIFF
--- a/doc/content/getting-started/migrating/gateway-migration.md
+++ b/doc/content/getting-started/migrating/gateway-migration.md
@@ -6,6 +6,8 @@ aliases: "/getting-started/migrating-from-v2/gateway-migration"
 
 Migrating gateways to {{% tts %}} is an easy, two step process.
 
+{{< info >}} Migrating **The Things Indoor Gateway (TTIG)** from {{% ttnv2 %}} to {{% tts %}} via CLI and Console is now fully supported! [Read more]({{< ref "/gateways/thethingsindoorgateway" >}}) {{</ info >}}
+
 ### Step 1
 
 Add the Gateway in the {{% tts %}}. 

--- a/doc/content/getting-started/migrating/migrating-from-v2/_index.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/_index.md
@@ -9,6 +9,10 @@ This section documents the process of migrating end devices from {{% ttnv2 %}} t
 
 <!--more-->
 
+{{< note >}} As previously announced, on **July 1, 2021** users will no longer be able to add new applications, devices and gateways on {{% ttnv2 %}} deployments, i.e. {{% ttnv2 %}} is going to **read-only** mode.
+
+Make sure to migrate your gateways and devices from {{% ttnv2 %}} to {{% tts %}} as soon as possible, since {{% ttnv2 %}} machines are planned to be completely shut down on **December 31, 2021**. {{</ note >}}
+
 {{< warning >}} We highly recommend to always test the migration on a single end device or a small batch of end devices in order to make sure the migration process goes as expected. {{</ warning >}}
 
 ## Prerequisites
@@ -18,6 +22,8 @@ This section documents the process of migrating end devices from {{% ttnv2 %}} t
 3. User account in {{% tts %}}.
 
 {{< note >}} We **highly recommend** using {{% tts %}} version `3.12.0` or higher. Some of the features (like session migration) from this guide might not be available for prior versions. {{</ note >}}
+
+{{< info >}} Starting from {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. This means that the order of actions of migrating gateways and devices is no longer relevant - you can migrate your devices first and then your gateways, or vice versa. {{</ info >}}
 
 ## Add Application in {{% tts %}}
 
@@ -31,9 +37,32 @@ Since end devices are being created within applications, you first need to add a
 
 After creating an application, you need to add the associated elements like application-level payload formatters and integrations.
 
-{{< note >}} The payload formatters can be uplink and downlink, and they are what was known in {{% ttnv2 %}} as coders and decoders. The format of payload coders and decoders is still supported in {{% tts %}}.
+{{< info >}} The payload formatters can be uplink and downlink, and they are what was known in {{% ttnv2 %}} as encoders and decoders. In {{% tts %}}, it is also possible to add payload formatters per end device, which override application payload formatters. However, before devices are migrated to {{% tts %}} it is only possible to add a payload formatter per application. {{</ info >}}
 
-In {{% tts %}}, it is also possible to add payload formatters per end device, which override application payload formatters. However, before devices are migrated to {{% tts %}} it is only possible to add a payload formatter per application. {{</ note >}}
+{{< note >}} The format of {{% ttnv2 %}} payload encoders and decoders is still supported in {{% tts %}}. You only need to add one additional line to the function code used in {{% ttnv2 %}} to make it fully compatible with {{% tts %}}. For example, if your payload decoder function in {{% ttnv2 %}} was:
+
+```js
+function Decoder(bytes) {
+    var temperature = bytes[0] | bytes[2];  
+    return {
+        temperature: temperature;
+    }
+}
+```
+
+then your uplink payload formatter function in {{% tts %}} should be:
+
+```js
+function decodeUplink(input) {
+    var bytes = input.bytes;
+    var temperature = bytes[0] | bytes[2];
+    return {
+        temperature: temperature;
+    }
+}
+```
+
+{{</ note >}}
 
 > See [Payload Formatters]({{< ref "/integrations/payload-formatters" >}}) guide for detailed instructions on how to add payload formatters and which types are supported by {{% tts %}}. 
 
@@ -49,14 +78,9 @@ If you are using deployments connected to Packet Broker, the traffic from your e
 
 If you are using deployments that are not connected to Packet Broker, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to receive traffic from your end device in {{% tts %}}. {{</ info >}}
 
-{{< note >}} We recommend The Things Network community members to keep their gateways registered on The Things Network V2 for as long as possible (i.e. to migrate their devices via Packet Broker), or to agree on performing coordinated migration to {{% tts %}} together with the local community to ensure reliable LoRaWAN network coverage. {{</ note >}}
+{{< note >}} Starting from {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. {{</ note >}}
 
 There are two approaches for migrating devices, depending on how many end devices you intend to migrate and if you wish to migrate with or without active sessions, described in the following guides:
 
-- [Using {{% tts %}} Console]({{< relref "migrate-using-console" >}}) - this method is convenient only for small number of devices. Migrating active device sessions is not supported.
-- [Using `ttn-lw-migrate` tool]({{< relref "migrate-using-migration-tool" >}}) - this method allows migrating devices in bulk, optionally with active device sessions.
-
-## Migration Decision Tree
-Migrating from V2 to **The Things Stack Cloud** or **The Things Stack Community Edition** (click on the image to enlarge).
-
-[![migration decision tree](migration-decision-tree.jpg "migration decision tree")](migration-decision-tree.jpg)
+- [Using {{% tts %}} Console]({{< relref "migrate-using-console" >}})
+- [Using `ttn-lw-migrate` tool]({{< relref "migrate-using-migration-tool" >}})

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-console.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-console.md
@@ -10,9 +10,13 @@ This section refers to migrating end devices to {{% tts %}} by using [{{% tts %}
 
 Migrating your end devices using {{% tts %}} Console is easy, but it is convenient only if you have an intention of migrating few devices. 
 
-{{< note >}} This method comes down to adding end devices in {{% tts %}} Console one by one, and it is not possible to migrate groups of devices as with using `ttn-lw-migrate` tool. 
+{{< note >}} This method comes down to adding end devices in {{% tts %}} Console one by one, and it is not possible to migrate groups of devices using Console only.
 
-With this method, it is also not possible to migrate active device sessions. Therefore, this section implies migrating devices without active sessions. {{</ note >}}
+It is possible to import groups of devices using {{% tts %}} Console, but that would require the usage of `ttn-lw-migrate` tool to export those devices from {{% ttnv2 %}}, which is already addressed in [Migrate using the Migration Tool]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool"  >}}) guide. {{</ note >}}
+
+{{< note >}} Migrating active sessions using {{% tts %}} Console **only** is not fully achievable. You can migrate the device from {{% ttnv2 %}} to {{% tts %}} using the Console, but you will need `ttn-lw-migrate` tool to export session-related parameters (like session keys, frame counters, etc.) from {{% ttnv2 %}} to a [JSON file]({{< ref "/getting-started/migrating/device-json" >}}). You can later [import this file in {{% tts %}}]({{< ref "/getting-started/migrating/import-devices" >}}) using {{% tts %}} Console, or the CLI. That approach would be a combination of the migration methods described in this documentation, but for the sake of simplicity, and the fact that migrating active sessions is not recommended, we will not devote too much attention to it.
+
+Therefore, this section implies migrating devices without active sessions, as that can be fully achieved with using only {{% tts %}} Console. {{</ note >}}
 
 Follow the steps below to migrate your end device from {{% ttnv2 %}} to {{% tts %}} by using the Console.
 
@@ -40,7 +44,11 @@ If you want to add an OTAA end device manually, follow these steps:
 - Select **Regional Parameters version** `PHY V1.0.2 REV B` (this is the version used in {{% ttnv2 %}})
 - Do not check the boxes **Supports class B/C**
 - Keep the default Advanced settings as OTAA devices commonly negotiate about these with {{% tts %}} Network Server
-- Enter your end device’s **AppKey** (has to match the one in {{% ttnv2 %}}, as this info is provided by the device manufacturer)
+- Enter your end device’s **AppKey** (see the note below)
+
+{{< note >}} The **AppKey** value can match the one used in {{% ttnv2 %}}, as this info is usually provided by the device manufacturer. The **AppKey** can also be generated in the Console as the last step of the OTAA device registration process. If you decide to generate it, do not forget to program your OTAA device to use the new **AppKey** issued by {{% tts %}}.
+
+If you are migrating an active OTAA device session, the **AppKey** must match the one used on {{% ttnv2 %}}, otherwise you can choose to keep one from {{% ttnv2 %}} or not.{{</ note >}}
 
 {{< /tabs/tab >}}
 
@@ -67,11 +75,13 @@ Choose **LoRaWAN version** `MAC V1.0.2` (this is the version used in {{% ttnv2 %
 
 {{< note >}} The **DevAddr** and **RX1 Delay** values depend on your specific use case.
 
-If you want your end device traffic to be routed via Packet Broker to {{% tts %}}, the **DevAddr** must be routable by the Packet Broker and the **RX1 Delay** value must be 5 seconds. Note that the **DevAddr** is routable only if you are using **The Things Industries V2** and migrating to **{{% tts %}} Cloud**, and even that is being achieved only on customer request by contacting [The Things Industries support](mailto:support@thethingsindustries.com).
+If you want your end device traffic to be routed via Packet Broker to {{% tts %}}, the **DevAddr** must be routable by the Packet Broker and the **RX1 Delay** value must be set to 5 seconds. Note that the **DevAddr** is routable only if you are using **The Things Industries V2** and migrating to **{{% tts %}} Cloud**, and even that is being achieved only on customer request by contacting [The Things Industries support](mailto:support@thethingsindustries.com).
 
 If the existing **DevAddr** is not routable by the Packet Broker (i.e. you are not migrating from **The Things Industries V2** to **The Things Stack Cloud**), and/or **RX1 Delay** is different than 5 seconds (for {{% ttnv2 %}} the default is 1 second), you will need to auto-generate new **DevAddr** during device registration on {{% tts %}}, then re-program the device to assign it with that new **DevAddr** and **RX1 Delay** of 5 seconds. Otherwise, the traffic from your device will not be properly routed by the Packet Broker or will never reach your end device in time.
 
-If you do not want your traffic to be routed by the Packet Broker, i.e. you want to migrate your gateway to {{% tts %}} too, you do not have to re-program your device. You can keep the existing **DevAddr** and **RX1 Delay** of 1 second, and use these values when adding the device to {{% tts %}}. Be aware that if you are using a high-latency backhaul, keeping the **RX1 Delay** of 1 second might cause latency issues. {{</ note >}}
+If you do not want your traffic to be routed by the Packet Broker, i.e. you want to migrate your gateway to {{% tts %}} too, you do not have to re-program your device. You can keep the existing **DevAddr** and **RX1 Delay** of 1 second, and use these values when adding the device to {{% tts %}}. Be aware that if you are using a high-latency backhaul, keeping the **RX1 Delay** of 1 second might cause latency issues.
+
+The **NwkSKey** has to match the one used on {{% ttnv2 %}} if you are migrating an active ABP device session. If not, you can choose to keep the one used on {{% ttnv2 %}}, or to generate a new one in {{% tts %}} Console during the device registration process. {{</ note >}}
 
 {{< note >}} Note that re-programming the ABP device to change **DevAddr** to the one issued by {{% tts %}} and **RX1 Delay** to 5 seconds is **recommended**. Re-programming the ABP device to do this might also be a good time to reconsider switching it to OTAA by flashing the firmware and adopting some [best practices]({{< ref "/devices/best-practices" >}}). [Check why using OTAA is recommended]({{< ref "/devices/abp-vs-otaa" >}}). {{</ note >}}
 
@@ -137,4 +147,4 @@ If you want to keep **DevAddr** and **RX1 Delay** as they were in {{% ttnv2 %}},
 
 {{< /tabs/container >}}
 
-{{< note >}} Even if you manage to get your end device traffic routed to {{% tts %}} via Packet Broker, we recommend you get in touch with your local The Things Network community and agree on coordinating the migration of gateways, so you do not loose the LoRaWAN network coverage. See how to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}). {{</ note >}}
+{{< note >}} Starting from {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible. {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
@@ -118,8 +118,6 @@ Since we assume that you have not migrated your gateway from {{% ttnv2 %}} yet, 
 
 Instead, these Join Requests are going to be routed to {{% tts %}} via Packet Broker and {{% tts %}} will accept them. Your OTAA device will negotiate with {{% tts %}} Network Server to obtain a new **DevAddr**, channel settings and other MAC parameters. The traffic from your end device can from now on be routed to {{% tts %}} thanks to the newly assigned **DevAddr** and **RX1 Delay** of 5 seconds, which fulfills the Packet Broker requirements.
 
-{{< note >}} Even if you manage to get your end device traffic routed to {{% tts %}} via Packet Broker, we still recommend you get in touch with your local The Things Network community and coordinate the migration of gateways, so you do not loose the LoRaWAN network coverage. See how to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}). {{</ note >}}
-
 {{< /tabs/tab >}}
 
 {{< tabs/tab "ABP" >}}
@@ -130,4 +128,8 @@ This section implies that you are keeping the **DevAddr** and **RX1 Delay** valu
 
 If you are not migrating from **The Things Industries {{% ttnv2 %}}** to **{{% tts %}} Cloud**, please follow the guide to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to {{% tts %}}. 
 
-{{< note >}} Keep in mind that we advise to keep your gateways on {{% ttnv2 %}} until you get in touch with your local The Things Network community and coordinate the migration of gateways, so you do not loose the LoRaWAN network coverage. {{</ note >}}
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}
+
+{{< note >}} Starting from {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible. {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
@@ -11,7 +11,7 @@ Starting from {{% tts %}} version `3.12.0`, it is possible to migrate end device
 
 {{< warning >}} Active device sessions can be migrated via Packet Broker only from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, and this is achievable only on a customer request. Contact [The Things Industries support](mailto:support@thethingsindustries.com) for more information. 
 
-For all other scenarios, migrating active session is achievable only if you [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too. However, we strongly recommend The Things Network community members to keep their gateways registered on The Things Network V2 for as long as possible, or to agree on performing coordinated migration to {{% tts %}}, as this will ensure the community does not loose their LoRaWAN coverage. {{</ warning >}}
+For all other scenarios, migrating active session is achievable only if you [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too. {{</ warning >}}
 
 {{< info >}} We strongly recommend migrating end devices without persisting active sessions. {{</ info >}}
 
@@ -89,14 +89,14 @@ Migrating your OTAA device from **The Things Industries V2 (SaaS)** to **{{% tts
 
 {{< tabs/tab "ABP" >}}
 
-Migrating your ABP device from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud** with its active session means it will keep its **DevAddr**, channel settings and MAC parameters from {{% ttnv2 %}}. Once properly migrated, the uplink traffic from your end device should automatically show up in {{% tts %}}, because it will be routed via Packet Broker thanks to preserving your device's existing session.
+Migrating your ABP device from {{% ttnv2 %}} to {{% tts %}} with its active session means it will keep its **DevAddr**, channel settings and MAC parameters from {{% ttnv2 %}}, i.e. the existing session will be preserved.
 
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
 
-If you are migrating an end device with its active session via Packet Broker, you will need to set the **RX1 Delay** of the device to 5 seconds by [configuring MAC settings]({{< ref "/getting-started/migrating/configure-mac-settings" >}}), otherwise the traffic might not reach {{% tts %}} in time via Packet Broker. 
+If you are migrating an end device with its active session via Packet Broker (from **The Things Industries V2** to **{{% tts %}} Cloud**), you might need to set the **RX1 Delay** of the device to 5 seconds by [configuring MAC settings]({{< ref "/getting-started/migrating/configure-mac-settings" >}}), otherwise the traffic might not reach {{% tts %}} in time via Packet Broker. 
 
-You can leave the **RX1 Delay** value as is (1 second from {{% ttnv2 %}}), but then you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too - keep in mind that if your gateway has a high-latency backhaul, you could still experience latency issues.
+In any case, you can leave the **RX1 Delay** value as is (1 second from {{% ttnv2 %}}), but then you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too.
 
-{{< note >}} Even if you manage to get your end device traffic routed to {{% tts %}} via Packet Broker, we recommend you get in touch with your local The Things Network community and agree on coordinating the migration of gateways, so you do not loose the LoRaWAN network coverage. See how to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}). {{</ note >}}
+{{< note >}} Starting from {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible. {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2/packet-broker-requirements.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/packet-broker-requirements.md
@@ -17,7 +17,7 @@ When migrating your devices with active sessions, it is in most cases not possib
 | The Things Industries V2 | The Things Stack Community Edition | Only without persisting active device sessions |
 | The Things Industries V2 | The Things Stack Cloud | With and without persisting active device sessions |
 
-{{< note >}} Remember that {{% tts %}} Enterprise and {{% tts %}} Open Source can also be configured to connect to Packet Broker. In that case, end devices can be migrated from {{% ttnv2 %}} via Packet Broker without persisting active sessions. {{</ note >}}
+{{< note >}} Remember that {{% tts %}} Enterprise and {{% tts %}} Open Source can also be configured to connect to Packet Broker. If using those deployments, end devices can be migrated from {{% ttnv2 %}} via Packet Broker without persisting active sessions. {{</ note >}}
 
 ## Devices Address (DevAddr)
 


### PR DESCRIPTION
#### Summary
Closes #369 and #368 + some minor updates

#### Changes
Added the information that gateways can be migrated to The Things Stack Community Edition while still providing uplink and downlink coverage for The Things Network V2, that TTIGs cannot be migrated atm, how to reuse payload (de)coders from V2

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
