### PR TITLE
doc: Set fixed width middle column

### DIFF
--- a/doc/layouts/_default/list.html
+++ b/doc/layouts/_default/list.html
@@ -5,11 +5,11 @@
 <div class="container" role="document">
   <div class="columns my-0 {{ if not $hasSidebar }}is-desktop{{ end }}">
       {{ if $hasSidebar }}
-      <div class="column is-one-fifth-tablet is-one-third sidebar-left">
+      <div class="column is-3 is-2-desktop sidebar-left">
         {{ partial "sidebar/side-navigation.html" . }}
       </div>
       {{ end }}
-      <div class="column sidebar-middle">
+      <div class="column is-9 is-8-desktop sidebar-middle">
         <div class="docs-content">
         <h1 class="title is-size-2">{{ .Title }}
           {{ $context := . }}
@@ -39,7 +39,7 @@
         </div>
       </div>
       {{ if $hasSidebar }}
-      <div class="column is-hidden-touch is-one-quarter is-one-fifth-widescreen sidebar-right">
+      <div class="column is-hidden-touch is-2-desktop sidebar-right">
         {{ partial "sidebar/toc.html" . }}
       </div>
       {{ end }}

--- a/doc/layouts/_default/single.html
+++ b/doc/layouts/_default/single.html
@@ -5,11 +5,11 @@
 <div class="container" role="document">
   <div class="columns my-0 {{ if not $hasSidebar }}is-desktop{{ end }}">
       {{ if $hasSidebar }}
-      <div class="column is-one-fifth-tablet is-one-third sidebar-left">
+      <div class="column is-3 is-2-desktop sidebar-left">
         {{ partial "sidebar/side-navigation.html" . }}
       </div>
       {{ end }}
-      <div class="column sidebar-middle">
+      <div class="column is-9 is-8-desktop sidebar-middle">
         <div class="docs-content">
         <h1 class="title is-size-2">{{ .Title }}
           {{ $context := . }}
@@ -36,7 +36,7 @@
         </div>
       </div>
       {{ if $hasSidebar }}
-      <div class="column is-hidden-touch is-one-quarter is-one-fifth-widescreen sidebar-right">
+      <div class="column is-hidden-touch is-2-desktop sidebar-right">
         {{ partial "sidebar/toc.html" . }}
       </div>
       {{ end }}

--- a/doc/layouts/whats-new/list.html
+++ b/doc/layouts/whats-new/list.html
@@ -2,10 +2,10 @@
 
 <div class="container" role="document">
   <div class="columns my-0">
-      <div class="column is-one-fifth-tablet is-one-third sidebar-left">
+      <div class="column is-3 is-2-desktop sidebar-left">
         {{ partial "sidebar/side-navigation.html" . }}
       </div>
-      <div class="column sidebar-middle">
+      <div class="column is-9 is-8-desktop sidebar-middle">
         <div class="docs-content">
         <h1 class="title is-size-2">{{ .Title }}
         </h1>
@@ -19,7 +19,7 @@
         {{ partial "feedback" . }}
         </div>
       </div>
-      <div class="column is-hidden-touch is-one-quarter is-one-fifth-widescreen sidebar-right">
+      <div class="column is-hidden-touch is-2-desktop sidebar-right">
         {{ partial "sidebar/toc.html" . }}
       </div>
   </div>

--- a/doc/layouts/whats-new/single.html
+++ b/doc/layouts/whats-new/single.html
@@ -2,10 +2,10 @@
 
 <div class="container" role="document">
   <div class="columns my-0">
-      <div class="column is-one-fifth-tablet is-one-third sidebar-left">
+      <div class="column is-3 is-2-desktop sidebar-left">
         {{ partial "sidebar/side-navigation.html" . }}
       </div>
-      <div class="column sidebar-middle">
+      <div class="column is-9 is-8-desktop sidebar-middle">
         <div class="docs-content">
         <h1 class="title is-size-2">{{ .Title }}
         </h1>
@@ -17,7 +17,7 @@
         {{ partial "feedback" . }}
         </div>
       </div>
-      <div class="column is-hidden-touch is-one-quarter is-one-fifth-widescreen sidebar-right">
+      <div class="column is-hidden-touch is-2-desktop sidebar-right">
         {{ partial "sidebar/toc.html" . }}
       </div>
   </div>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Switch to 12-grid system and set fixed width on middle column to prevent overflow (see https://www.thethingsindustries.com/docs/getting-started/installation/configuration/ for example of overflow with horizontal scrolling)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
