### PR TITLE
Remove @kschiffer from Hugo codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,9 +8,9 @@
 /.github/workflows @benolayinka @htdvisser @michalborkowski96
 
 # Hugo
-/doc/assets/css @kschiffer @benolayinka @pierrephz
-/doc/assets/js @kschiffer @benolayinka
-/doc/layouts @kschiffer @benolayinka @pierrephz
+/doc/assets/css @benolayinka @pierrephz
+/doc/assets/js @benolayinka
+/doc/layouts @benolayinka @pierrephz
 
 # Subsections
 /doc/content/integrations @adriansmares @nejraselimovic @neoaggelos


### PR DESCRIPTION
#### Summary
Quickfix to remove me as codeowner of the hugo package.

#### Changes
- Remove me as codeowner of the hugo package

#### Notes for Reviewers
Unfortunately, I don't have time to codeown this anymore and I think me being listed there only drags everything

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
