### PR TITLE
doc: Fix link to Integrations with MQTT Clients.

### DIFF
--- a/doc/content/integrations/adding-integrations/_index.md
+++ b/doc/content/integrations/adding-integrations/_index.md
@@ -8,7 +8,7 @@ Integrations allow you to process and act on data by triggering events.
 
 <!--more-->
 
-Learn how to set up integrations by following [MQTT Server]({{< ref "/integrations/mqtt" >}}) or [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}) guides. Visit [Integrations with MQTT Clients](({{< ref "/integrations/mqtt/mqtt-clients" >}})) and [Cloud Integrations]({{< ref "/integrations/cloud-integrations" >}}) sections to see the examples of integrating with popular cloud IoT platforms and MQTT clients. 
+Learn how to set up integrations by following [MQTT Server]({{< ref "/integrations/mqtt" >}}) or [HTTP Webhooks]({{< ref "/integrations/webhooks" >}}) guides. Visit [Integrations with MQTT Clients]({{< ref "/integrations/mqtt/mqtt-clients" >}}) and [Cloud Integrations]({{< ref "/integrations/cloud-integrations" >}}) sections to see the examples of integrating with popular cloud IoT platforms and MQTT clients. 
 
 Learn to use the LoRa Cloud integration with the [Visualize LoRa Edge™ Geolocation Data on Ubidots]({{< ref "/integrations/cloud-integrations/ubidots/lora-edge-geolocation" >}}) example.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
The "Integrations with MQTT Clients" link is not working on this page: https://www.thethingsindustries.com/docs/integrations/adding-integrations/

I'm not certain, but believe that this will fix it. The double parenthesis seem like the only difference from the other links on this page and would explain why the redirect is breaking.

...

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

...

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove extra set of parenthesis from link definition.
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
