### PR TITLE
doc: Remove empty sections from What's new in version files

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,6 +16,7 @@ This is a checklist for releases. This is filled in by both the releaser and the
 #### Update Documentation
 
 - [ ] Create a new release in the [`whats-new` section](https://github.com/TheThingsIndustries/lorawan-stack-docs/tree/master/doc/content/whats-new) and copy the release CHANGELOG from [TheThingsIndustries/lorawan-stack](https://github.com/TheThingsIndustries/lorawan-stack). The title is the release version and the date is the release date.
+- Remove empty sections from the created release file.
 - [ ] Update the [documentation version](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/config/_default/config.toml#L28) to match the current minor, if necessary (`v3.${minor}`).
 - [ ] To generate documentation, create a clone of [TheThingsIndustries/lorawan-stack](https://github.com/TheThingsIndustries/lorawan-stack), and **checkout the git tag of the release**.
 - [ ] To generate API documentation, run the following from within the clone of [TheThingsIndustries/lorawan-stack](https://github.com/TheThingsIndustries/lorawan-stack): 

--- a/doc/content/whats-new/3.10.6.md
+++ b/doc/content/whats-new/3.10.6.md
@@ -19,9 +19,3 @@ title: "3.10.6"
 
 - Packet Broker mutual TLS authentication: use OAuth 2.0 client credentials instead; set `pba.authentication-mode` to `oauth2` and configure `pba.oauth2`.
 - Packet Broker forwarder blacklist setting `pba.home-network.blacklist-forwarder` has become ineffective.
-
-### Removed
-
-### Fixed
-
-### Security

--- a/doc/content/whats-new/3.10.7.md
+++ b/doc/content/whats-new/3.10.7.md
@@ -3,16 +3,6 @@ date: 2021-01-14
 title: "3.10.7"
 ---
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - The inability to see individual end devices in the Console due to field mask errors.
-
-### Security

--- a/doc/content/whats-new/3.10.8.md
+++ b/doc/content/whats-new/3.10.8.md
@@ -3,16 +3,6 @@ date: 2021-01-15
 title: "3.10.8"
 ---
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Packet Broker multi-tenancy with a single tenant The Things Stack configuration.
-
-### Security

--- a/doc/content/whats-new/3.11.0.md
+++ b/doc/content/whats-new/3.11.0.md
@@ -42,8 +42,6 @@ title: "3.11.0"
 - Authentication Providers and External Users are now hard deleted by default.
   - This requires a database migration (`ttn-lw-stack is-db migrate`).
 
-### Deprecated
-
 ### Removed
 
 - Application Server linking. The Network Server now pushes data to the cluster Application Server instead.
@@ -59,5 +57,3 @@ title: "3.11.0"
 - Login after user registration leading to dead-end when originally coming from the Console.
 - Frame counter display of end devices on initial page load in the Console.
 - AU915-928 data rate indexes in Regional Parameter specification versions below 1.0.2b.
-
-### Security

--- a/doc/content/whats-new/3.11.1.md
+++ b/doc/content/whats-new/3.11.1.md
@@ -23,12 +23,8 @@ title: "3.11.1"
   - This only affects The Things Stack AWS Launcher customers that use the AWS Marketplace AMI listing.
   - All deployments are now advised to use the AWS IoT Core package that can be configured per application in Application Server.
 
-### Removed
-
 ### Fixed
 
 - Synchronization in Gateway Server scheduler that caused race conditions in scheduling downlink traffic.
 - End device claiming when the source device uses derived root keys.
 - Console link in Account App for multi-tenant deployments.
-
-### Security

--- a/doc/content/whats-new/3.11.2.md
+++ b/doc/content/whats-new/3.11.2.md
@@ -17,10 +17,6 @@ title: "3.11.2"
 -  When multiple base domains are configured, the middleware uses the longest match to extract the Tenant ID.
 - `temp` field of the UDP stats message is now type `float32` (pointer).
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Ocassional race condition in uplink matching with replicated Network Server instances.
@@ -32,5 +28,3 @@ title: "3.11.2"
 - Application uplink queue handling in Network Server.
 - Application Server session desynchronization with the Network Server. The Application Server will now attempt to synchronize the end device session view on downlink queue operational errors. This fixes the `f_cnt_too_low` and `unknown_session` errors reported on downlink queue push and replace.
 - Panic while generating SX1301 config for frequency plans without radio configuration.
-
-### Security

--- a/doc/content/whats-new/3.11.3.md
+++ b/doc/content/whats-new/3.11.3.md
@@ -19,11 +19,7 @@ title: "3.11.3"
 
 - TR005 Draft 2 and 3 QR code formats. Use the final version of the technical recommendation, with ID `tr005`.
 
-### Removed
-
 ### Fixed
 
 - Downlink queue operations on ABP devices not working under specific circumstances.
 - NwkKey handling for end devices in the Console.
-
-### Security

--- a/doc/content/whats-new/3.12.2.md
+++ b/doc/content/whats-new/3.12.2.md
@@ -25,5 +25,3 @@ title: "3.12.2"
 - Backend validation messages for some forms.
 - Gateway downlink message previews not displaying correctly in the event view of the Console.
 - Importing end devices from the Console would occasionally ignore some device MAC settings fields.
-
-### Security

--- a/doc/content/whats-new/3.13.0.md
+++ b/doc/content/whats-new/3.13.0.md
@@ -30,8 +30,6 @@ title: "3.13.0"
   - A maximum cap of 16KB per script is set at the API level.
   - This only prevents setting large payload formatter scripts for new devices and applications; it does not remove payload formatters from existing applications and devices. Scripts sourced from the Device Repository are not affected. See [issue #4053](https://github.com/TheThingsNetwork/lorawan-stack/issues/4053) for more context on this change.
 
-### Deprecated
-
 ### Removed
 
 - The `gs.status.forward` event.
@@ -42,5 +40,3 @@ title: "3.13.0"
 - The CLI now properly returns a non-zero exit status code on invalid commands.
 - Gateway connection requests with zero EUI are rejected.
 - End device payload formatter reset to `FORMATTER_NONE` in the Console.
-
-### Security

--- a/doc/content/whats-new/3.13.1.md
+++ b/doc/content/whats-new/3.13.1.md
@@ -17,10 +17,6 @@ title: "3.13.1"
 - Authenticated users now have access to gateway status and location when those are set to public.
 - Cookies are no longer allowed in cross-origin requests to the HTTP API. Applications must instead use Bearer tokens in the Authorization header.
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Loading event data in (non-historical) event streams.
@@ -28,5 +24,3 @@ title: "3.13.1"
 - End device payload formatter view crashing in the Console.
 - End device overview frequently crashing in the Console.
 - Panic on empty downlink in zero indexed downlink token.
-
-### Security


### PR DESCRIPTION
#### Summary
Removing empty sections from _What's new in version_ files, to make files consistent.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
