### PR TITLE
doc: Add search breakpoint for small screens

### DIFF
--- a/doc/themes/the-things-stack/assets/css/header/nav.scss
+++ b/doc/themes/the-things-stack/assets/css/header/nav.scss
@@ -31,14 +31,28 @@ a.navbar-item {
 }
 
 .navbar-search-brand {
-  display: flex;
+  display: none !important;
+}
+
+.navbar-search-menu {
+  display: flex !important;
+}
+
+@media (min-width: $tablet) {
+  .navbar-search-brand {
+    display: flex !important;
+  }
+
+  .navbar-search-menu {
+    display: none !important;
+  }
 }
 
 @media (min-width: $navbar-breakpoint) {
   .navbar-search-brand {
-    display: none;
+    display: none !important;
   }
   .navbar-search-menu {
-    display: flex;
+    display: flex !important;
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Move the search to the dropdown menu on really small screens

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="695" alt="Bildschirmfoto 2021-06-25 um 14 33 31" src="https://user-images.githubusercontent.com/6963436/123425592-9976bf00-d5c2-11eb-8369-39782ab3fe1d.png">
<img width="659" alt="Bildschirmfoto 2021-06-25 um 14 33 22" src="https://user-images.githubusercontent.com/6963436/123425594-9a0f5580-d5c2-11eb-8aad-8d9ccfd2a8eb.png">
<img width="943" alt="Bildschirmfoto 2021-06-25 um 14 33 49" src="https://user-images.githubusercontent.com/6963436/123425589-97146500-d5c2-11eb-9844-9f8d937b3d78.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
