### PR TITLE
doc: Clarify type of uplink_message.rx_metadata.snr

### DIFF
--- a/doc/content/reference/data-formats/_index.md
+++ b/doc/content/reference/data-formats/_index.md
@@ -103,7 +103,7 @@ The JSON uplink messages use the following format:
       "timestamp": 2463457000,               // Timestamp of the gateway concentrator when the message has been received
       "rssi": -35,                           // Received signal strength indicator (dBm)
       "channel_rssi": -35,                   // Received signal strength indicator of the channel (dBm)
-      "snr": 5,                              // Signal-to-noise ratio (dB)
+      "snr": 5.2,                            // Signal-to-noise ratio (dB)
       "uplink_token": "ChIKEA...",           // Uplink token injected by gateway, Gateway Server or fNS
       "channel_index": 2                     // Index of the gateway channel that received the message
       "location": {                          // Gateway location metadata (only for gateways with location set to public)


### PR DESCRIPTION
#### Summary
uplink_message.rx_metadata.snr is documented as 5 (integer) but is a double (5.2).

#### Changes
Changed to double format to indicated correct type.

#### Notes for Reviewers
none

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
