### PR TITLE
Prepare release checklist for v3.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -25,12 +25,14 @@ This is a checklist for releases. This is filled in by both the releaser and the
 $ tools/bin/mage ttiProto:hugoData
 ```
 
-- [ ] Copy generated files to `lorawan-stack-docs` with the following command:
+- [ ] Copy generated files to `lorawan-stack-docs` by running the following commands in `lorawan-stack-docs`:
 
 ```bash
-$ cp api/ttn.lorawan.v3/*.yml /path/to/lorawan-stack-docs/doc/data/api/ttn.lorawan.v3/
-$ cp api/tti.lorawan.v3/*.yml /path/to/lorawan-stack-docs/doc/data/api/tti.lorawan.v3/
+$ rsync --recursive --delete --remove-source-files ../lorawan-stack/api/ttn.lorawan.v3/ ./doc/data/api/ttn.lorawan.v3/
+$ rsync --recursive --delete --remove-source-files ../lorawan-stack/api/tti.lorawan.v3/ ./doc/data/api/tti.lorawan.v3/
 ```
+
+> NOTE: This assumes that the parent directory of `lorawan-stack-docs` also contains `lorawan-stack`. If not, you'll need to adjust the commands accordingly.
 
 - [ ] To generate and export CLI documentation from within the clone of [TheThingsIndustries/lorawan-stack](https://github.com/TheThingsIndustries/lorawan-stack), first run the following command to build the CLI:
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This prepares the release checklist for changes coming to v3.14.

#### Changes
<!-- What are the changes made in this pull request? -->

V3.14 will use new proto generators. The Hugo data generator will then also work on arm64 (cc: @benolayinka), but the output is also going to be a bit different. To Hugo it should all look the same, but instead of having huge `enums.yaml`, `messages.yaml` and `services.yaml` files, it will now generate files for each enum, message and service individually.

This pull request updates the instructions in the release template so that those files will get synced correctly to the data dir.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
