### PR TITLE
doc: Additions to LoRaWAN Best Practices

### DIFF
--- a/doc/content/devices/best-practices/_index.md
+++ b/doc/content/devices/best-practices/_index.md
@@ -12,6 +12,10 @@ LoRaWAN devices should always comply to the [LoRaWAN specification](https://www.
 
 The goal of these best practices is to optimize individual devices (especially for power) and the network as a whole (to reliably and efficiently serve more devices with the same number of gateways).
 
+## LoRaWAN Certified
+
+Use devices which are LoRaWAN Certified to be ensured of proper implementation of the LoRaWAN standard. [Click here](https://lora-alliance.org/showcase/search/?_sfm_lorawan_certified_device=certified) to find an overview of certified LoRaWAN devices.
+
 ## Eliminate Unnecessary Join Requests
 
 The LoRaWAN specification warns specifically against systematic rejoin in case of network failure. A device should keep the result of an activation in permanent storage if the device is expected to be power-cycled during its lifetime.
@@ -103,12 +107,8 @@ In the case of link loss, do the following:
 - Reset to default channels, and try again
 - Send periodic join requests with backoff
 
-## Support force rejoin command or downlink
+## Support Force Rejoin Command or Downlink
 
-The Force Rejoin Command (`ForceRejoinReq`) is part of the LoRaWAN specifications versions 1.1. When using the command, the device to asked to immediately transmit a Rejoin-Request. Force Rejoin Commands enable, among others, end devices to easily switch LoRaWAN networks by initiating a new session with a new Network Server provider.
+The Force Rejoin Command (`ForceRejoinReq`) is part of the LoRaWAN specifications version 1.1. When using this command, the device immediately transmits a Rejoin Request message. Force Rejoin Commands enable end devices to, among other, easily switch LoRaWAN networks by initiating a new session with a new Network Server provider.
 
-When using end devices running LoRaWAN version 1.0.x, the firmware of the end devices should allow the devices to transmit a Rejoin-Request after receiving a predefined downlink message.
-
-## LoRaWAN Certified
-
-Use devices which are LoRaWAN Certified to be ensured of proper implementation of the LoRaWAN standard. [Click here](https://lora-alliance.org/showcase/search/?_sfm_lorawan_certified_device=certified) to find an overview of certified LoRaWAN devices.
+When using end devices running LoRaWAN version 1.0.x, the firmware of the end devices should allow the devices to transmit a Rejoin Request message after receiving a predefined downlink message.

--- a/doc/content/devices/best-practices/_index.md
+++ b/doc/content/devices/best-practices/_index.md
@@ -102,3 +102,13 @@ In the case of link loss, do the following:
 - Decrease data rate step by step, and try again
 - Reset to default channels, and try again
 - Send periodic join requests with backoff
+
+## Support force rejoin command or downlink
+
+The Force Rejoin Command (`ForceRejoinReq`) is part of the LoRaWAN specifications versions 1.1. When using the command, the device to asked to immediately transmit a Rejoin-Request. Force Rejoin Commands enable, among others, end devices to easily switch LoRaWAN networks by initiating a new session with a new Network Server provider.
+
+When using end devices running LoRaWAN version 1.0.x, the firmware of the end devices should allow the devices to transmit a Rejoin-Request after receiving a predefined downlink message.
+
+## LoRaWAN Certified
+
+Use devices which are LoRaWAN Certified to be ensured of proper implementation of the LoRaWAN standard. [Click here](https://lora-alliance.org/showcase/search/?_sfm_lorawan_certified_device=certified) to find an overview of certified LoRaWAN devices.


### PR DESCRIPTION
#### Summary
Adding 2 points to the Device Best Practices:

1. Support force rejoin command or downlink
2. LoRaWAN Certified


#### Screenshots
<img width="1392" alt="Screenshot 2021-07-14 at 16 19 12" src="https://user-images.githubusercontent.com/17290639/125638000-6d4744b5-44fc-4bac-a21a-de011ddfe812.png">


#### Changes
- 2 points, with descriptions added.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
