### PR TITLE
Fix typo in TTIG gateway doc

### DIFF
--- a/doc/content/gateways/thethingsindoorgateway/_index.md
+++ b/doc/content/gateways/thethingsindoorgateway/_index.md
@@ -16,7 +16,7 @@ This page guides you to connect {{% ttig %}} to {{% tts %}}.
 ## Prerequisites
 
 1. User account on {{% tts %}} with rights to create Gateways and API Keys.
-2. The gateway EUI. The EUI of the gateway is **not** the WiFi MAC address printed on the back of the gateway, but is derived from the first number that typically is of the form **58A0CBxxxxxx**, printed on the top of the sticker below the QR code. For example, if that number is **5BA0CB800BE7**, insert **FFFE** after the first 6 characters to make it a 16 character Gateway EUI (e.g. 5BA0CBFFFE800BE7).
+2. The gateway EUI. The EUI of the gateway is **not** the WiFi MAC address printed on the back of the gateway, but is derived from the first number that typically is of the form **58A0CBxxxxxx**, printed on the top of the sticker below the QR code. For example, if that number is **58A0CB800BE7**, insert **FFFE** after the first 6 characters to make it a 16 character Gateway EUI (e.g. 58A0CBFFFE800BE7).
 
 {{< note >}} The gateway EUI can later be found at the bottom in the WiFi setup screen. {{</ note >}}
 {{< figure src="TTIG_EUI.png" alt="{{% ttig %}} EUI" >}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Issue #462

5BA0CB should be 58A0CB in 2 places.

...

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

...

#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
