### PR TITLE
doc: Rename the configuration template

### DIFF
--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -161,9 +161,9 @@ $ openssl rand -base64 16
 
 ## Configuration
 
-The `4-2-configuration` template creates several configuration parameters in AWS Systems Manager Parameter Store.
+The `4-2a-configuration` template creates several configuration parameters in AWS Systems Manager Parameter Store.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/4-2-configuration.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/4-2a-configuration.gen.template (replace `3.x` with the current minor version).
 
 As with the other templates, this one also asks for the re-used parameters from the [Prerequisites]({{< relref "../prerequisites" >}}). Next to these parameters, this template has some notable parameters:
 


### PR DESCRIPTION
#### Summary
`4-2-configuration` is called `4-2a-configuration` ever since rate limiting has been introduced

#### Changes
Renamed `4-2-configuration` to `4-2a-configuration`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
