### PR TITLE
doc: Add a note about already registered in other tenant

### DIFF
--- a/doc/content/gateways/troubleshooting/_index.md
+++ b/doc/content/gateways/troubleshooting/_index.md
@@ -153,6 +153,8 @@ To solve this, use a different gateway ID. If you are an administrator and wish 
 
 Another gateway is already registered with the same Gateway EUI. This gateway may be registered by another user, but if you are not an administrator (e.g if you are using The Things Stack Community Edition) you will not be able to see gateways registered by other users.
 
+If the gateway is registered with the same EUI in some other tenant, the error will reflect that as well.
+
 First, double check that you have entered the EUI correctly. Then, double check that you have not already registered the gateway. Finally, if you have purchased the gateway secondhand, it is possible someone before you registered the gateway. Contact them to unregister it. If they are unavailable, contact [The Things Industries](mailto:info@thethingsindustries.com).
 
 ## What is Radio Configuration?


### PR DESCRIPTION
#### Summary
Closing https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/544

#### Changes
We already have this point in Troubleshooting and I think the existing documentation is enough, but the fact that the gateway can be registered in some other tenant isn't stated, so this PR is just adding that line.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
