### PR TITLE
doc: Fix migration tool flag-related notes

### DIFF
--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
@@ -30,8 +30,6 @@ If you are not migrating from **The Things Industries V2 (SaaS)** to **{{% tts %
 
 {{< warning >}} Note that this is **not a recommended practice**. We advise re-programming the ABP device to change the **DevAddr** to the one issued by The Things Stack and **RX1 Delay** to 5 seconds, even if you do not want your traffic to be routed by Packet Broker.
 
-{{< note >}} Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with The Things Stack. The list of uplink frequencies is inferred from the Frequency Plan. {{</ note >}}
-
 If you re-program the device, you will have to follow the [Migrate using the Console]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-console" >}}) guide. The reason for this is that when you re-program your ABP device, its **DevAddr** and other parameters will no longer match the device description stored in {{% ttnv2 %}}, so you will not be able to export the current device description using the `ttn-lw-migrate` tool. {{</ warning >}}
 
 {{< /tabs/tab >}}
@@ -39,6 +37,8 @@ If you re-program the device, you will have to follow the [Migrate using the Con
 {{< /tabs/container >}}
 
 {{< note >}} Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below. {{</ note >}}
+
+{{< note >}} Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with {{% tts %}}. The list of uplink frequencies is inferred from the [Frequency Plan]({{< ref "/reference/frequency-plans" >}}). {{</ note >}}
 
 ### Export a Single End Device
 

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
@@ -37,6 +37,8 @@ Remember that if you are not migrating specifically from **The Things Industries
 
 {{< note >}} Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below. {{</ note >}}
 
+{{< note >}} Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with {{% tts %}}. The list of uplink frequencies is inferred from the [Frequency Plan]({{< ref "/reference/frequency-plans" >}}). {{</ note >}}
+
 ### Export a Single End Device
 
 To export a single end device from {{% ttnv2 %}} and clear its security keys:


### PR DESCRIPTION
#### Summary
Closes #481 
Fixing and re-positioning notes on using the `--ttnv2.resets-to-frequency-plan` migration tool flag.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
