### PR TITLE
doc: Add configuration entry for version check

### DIFF
--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -317,3 +317,9 @@ Tenants can have custom configuration, such as custom branding or custom user re
 ## Resource Limiting
 
 {{< new-in-version "3.15.0" >}} {{< distributions "Dedicated Cloud" "Enterprise" "AWS Launcher" >}}  {{% tts %}} supports configuring maximum limits for active resources (e.g. number of active application data-plane MQTT connections). Resource limiting configuration can only be set from the configuration file. See [Resource Limiting]({{< ref "/reference/resource-limiting" >}}) for more details.
+
+## Version Check
+
+{{% tts %}} performs a version check upon running by default, and prints a corresponding message if a newer version is available.
+
+- `skip-version-check`: Set to `true` to skip version check


### PR DESCRIPTION
#### Summary
Closes #615 

#### Changes
Adding an entry in version configuration options list that contains info on how to skip version check upon running TTS. 

#### Notes for Reviewers
Not sure what else might be needed here, and since I read that @johanstokking and @michalborkowski96 you worked on this feature, let me know if I need to add something

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
