### PR TITLE
Remove data_rate_index from uplink message examples

### DIFF
--- a/doc/content/integrations/cloud-integrations/aws-iot/application-server-telemetry/_index.md
+++ b/doc/content/integrations/cloud-integrations/aws-iot/application-server-telemetry/_index.md
@@ -79,7 +79,6 @@ The following is an example payload in JSON format:
             "spreading_factor": 7
           }
         },
-        "data_rate_index": 5,
         "coding_rate": "4/5",
         "frequency": "867300000",
         "timestamp": 1453994219

--- a/doc/content/integrations/cloud-integrations/ubidots/_index.md
+++ b/doc/content/integrations/cloud-integrations/ubidots/_index.md
@@ -116,7 +116,6 @@ function decodeUplink(input) {
             "spreading_factor": 7
           }
         },
-        "data_rate_index": 5,
         "coding_rate": "4/5",
         "frequency": "867300000",
         "timestamp": 3940207243,

--- a/doc/content/integrations/mqtt/_index.md
+++ b/doc/content/integrations/mqtt/_index.md
@@ -149,7 +149,6 @@ When a device `dev1` sends an uplink message, that message is being published on
           "spreading_factor": 7
         }
       },
-      "data_rate_index": 5,
       "coding_rate": "4/6",
       "frequency": "868500000",
       "gateway_channel_index": 2,

--- a/doc/content/reference/data-formats/_index.md
+++ b/doc/content/reference/data-formats/_index.md
@@ -122,7 +122,6 @@ The JSON uplink messages use the following format:
           "spreading_factor": 7              // Spreading factor
         }
       },
-      "data_rate_index": 5,                  // LoRaWAN data rate index
       "coding_rate": "4/6",                  // LoRa coding rate
       "frequency": "868300000",              // Frequency (Hz)
     },
@@ -190,7 +189,6 @@ The JSON uplink messages use the following format:
           "spreading_factor" : 7
         }
       },
-      "data_rate_index" : 5,
       "coding_rate" : "4/6",
       "frequency" : "868300000",
       "timestamp" : 2463457000,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove data_rate_index from uplink message examples. Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4869

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `data_rate_index` from examples.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
