### PR TITLE
doc: Update migration docs post TTN V2 shutdown

### DIFF
--- a/doc/content/getting-started/migrating/faq.md
+++ b/doc/content/getting-started/migrating/faq.md
@@ -6,17 +6,17 @@ This section answers frequently asked questions regarding migration to {{% tts %
 
 ### Why should I migrate my devices and gateways to {{% tts %}}? 
 
-{{% tts %}} is more scalable, more secure, and supports more of the LoRaWAN specification than {{% ttnv2 %}}. The end of life for {{% ttnv2 %}} environment is planned for December 1, 2021.
+{{% tts %}} is more scalable, more secure, and supports more of the LoRaWAN specification than {{% ttnv2 %}}. The Things Network {{% ttnv2 %}} machines have been completely shut down on **December 8, 2021**. Only private The Things Industries {{% ttnv2 %}} infrastructure is still running, but the associated software will no longer be developed or maintained by The Things Industries.
 
 ### When should I migrate my devices and gateways to {{% tts %}}? 
 
-Start migrating your devices and gateways as soon as possible! {{% ttnv2 %}} is now read-only so you cannot add new gateways, devices and applications anymore, and the final deadline for migrating is December 1, 2021, when {{% ttnv2 %}} will be shut down.
+Start migrating your devices and gateways as soon as possible! V2 software is no longer maintained and there is no official support.
 
 Reading the [complete Migrating to {{% tts %}} guide]({{< ref "/getting-started/migrating" >}}) can help you with the migration process.
 
-### Will I still be able to register my devices and gateways on {{% tts %}} if I do not migrate them from {{% ttnv2 %}} until the migration deadline (December 1, 2021)?
+### Am I still able to migrate my devices and gateways from The Things Network {{% ttnv2 %}} to {{% tts %}}?
 
-Yes, you will be able to normally register devices and gateways on {{% tts %}} after December 1, 2021, but you might lose some data because of the {{% ttnv2 %}} shutdown if you do not migrate on time. Also, keep in mind that after this deadline, you will no longer be able to transfer your devices to {{% tts %}} in bulk, nor to preserve existing device sessions.
+No, you are not able to migrate your devices and gateways from The Things Network {{% ttnv2 %}} but you can still add them to {{% tts %}} from scratch. See [Adding Devices]({{< ref "/devices/adding-devices" >}}) and [Adding Gateways]({{< ref "/gateways/adding-gateways" >}}).
 
 ### What is Packet Broker and what does it have to do with migrating to {{% tts %}}? 
 
@@ -24,9 +24,9 @@ Yes, you will be able to normally register devices and gateways on {{% tts %}} a
 
 See {{% tts %}} [Packet Broker documentation]({{< ref "/getting-started/packet-broker" >}}) for detailed info about connecting {{% tts %}} to Packet Broker.
 
-{{% ttnv2 %}}, {{% tts %}} Community Edition and {{% tts %}} Cloud are connected to Packet Broker by default. {{% tts %}} Open Source and {{% tts %}} Enterprise can also be [connected]({{< ref "/getting-started/packet-broker/connect" >}}) to Packet Broker. Traffic is then automatically exchanged between these networks. See [default Packet Broker routing tables]({{< ref "/reference/pb-routing" >}}).
+{{% tts %}} Community Edition and {{% tts %}} Cloud are connected to Packet Broker by default. {{% tts %}} Open Source and {{% tts %}} Enterprise can also be [connected]({{< ref "/getting-started/packet-broker/connect" >}}) to Packet Broker. The Things Industries {{% ttnv2 %}} can also be connected on a customer request. Traffic is then automatically exchanged between these networks. See [default Packet Broker routing tables]({{< ref "/reference/pb-routing" >}}).
 
-For example, this means that you can migrate an end device from The Things Network V2 to {{% tts %}} Community Edition without immediately (or previously) having to migrate your gateway, because both of these deployments are connected to Packet Broker by default. However, there are certain requirements that need to be fulfilled in order for Packet Broker to route traffic from and to these devices properly and timely. [Read more about DevAddr and RX1 Delay requirements]({{< ref "/getting-started/migrating/migrating-from-v2/packet-broker-requirements" >}}).
+For example, this means that you can migrate an end device from The Things Industries {{% ttnv2 %}} to {{% tts %}} Community Edition without immediately (or previously) having to migrate your gateway, if both of these deployments are connected to Packet Broker. However, there are certain requirements that need to be fulfilled in order for Packet Broker to route traffic from and to these devices properly and timely. [Read more about DevAddr and RX1 Delay requirements]({{< ref "/getting-started/migrating/migrating-from-v2/packet-broker-requirements" >}}).
 
 ### I tried migrating my The Things Indoor Gateway (TTIG) to {{% tts %}}, but the Console shows status `Disconnected`. Does {{% tts %}} support connecting TTIGs?
 
@@ -40,15 +40,15 @@ Yes, you can delete your TTIG from {{% ttnv2 %}}, but keep in mind that you are 
 
 ### Can I migrate my device to {{% tts %}} without having to re-program it or trigger it to perform a new join?
 
-In a special case of migrating devices from The Things Industries V2 (SaaS) environment to {{% tts %}} Cloud, devices can be migrated with their existing session via Packet Broker, i.e. without having to re-program them (ABP) or trigger them to perform a new join (OTAA), and without having to migrate the gateway to {{% tts %}}. For all other migration scenarios, to migrate an active device session you would have to have the gateway migrated to {{% tts %}} as well.
+In a special case of migrating devices from The Things Industries {{% ttnv2 %}} environment to {{% tts %}} Cloud, devices can be migrated with their existing session via Packet Broker, i.e. without having to re-program them (ABP) or trigger them to perform a new join (OTAA), and without having to migrate the gateway to {{% tts %}}. For all other migration scenarios, to migrate an active device session you would have to have the gateway migrated to {{% tts %}} as well.
 
 Learn how to [Migrate Active Sessions]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session" >}}).
 
 {{< note >}} Please keep in mind that migrating active sessions is not recommended. If you cannot access your device to trigger it to perform a new join, you can try contacting your device's manufacturer as the device might have "secret" options to enable remote access. {{</ note >}}
 
-### I cannot access my gateway remotely, so I cannot migrate it to {{% tts %}} at this time. Is there anything I can do so I do not lose data after December 1, 2021?
+### I cannot access my gateway remotely, so I cannot migrate it to {{% tts %}} at this time. Is there anything I can do?
 
-At this time you can make use of Packet Broker to route your data from {{% ttnv2 %}} to {{% tts %}}, but you will have to find a way to access your gateway and migrate it to {{% tts %}} by December 1, 2021.
+At this time you can only make use of Packet Broker to route your data from your private The Things Industries {{% ttnv2 %}} deployment to {{% tts %}}, until you are able to access your gateway and migrate it to {{% tts %}} as well.
 
 ### Can I use the AppKey from {{% ttnv2 %}} when registering an OTAA device on {{% tts %}}?
 

--- a/doc/content/getting-started/migrating/gateway-migration.md
+++ b/doc/content/getting-started/migrating/gateway-migration.md
@@ -22,4 +22,4 @@ Update the server address in the gateway configuration settings.
 
 Once your gateways are migrated, the traffic will be routed directly to {{% tts %}}.
 
-If you migrated your end devices and gateways from {{% ttnv2 %}} (The Things Network V2 or The Things Industries V2 (SaaS), their traffic might still end up in {{% ttnv2 %}}. If this occurs, disable the devices in {{% ttnv2 %}} by deleting their session keys, or deleting the application completely.
+If you migrated your end devices and gateways from The Things Industries {{% ttnv2 %}} (SaaS), their traffic might still end up in {{% ttnv2 %}}. If this occurs, disable the devices in {{% ttnv2 %}} by deleting their session keys, or deleting the application completely.

--- a/doc/content/getting-started/migrating/migrating-from-v2/_index.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/_index.md
@@ -9,11 +9,15 @@ This section documents the process of migrating end devices from {{% ttnv2 %}} t
 
 <!--more-->
 
+The Things Network {{% ttnv2 %}} machines have been completely shut down on **December 8, 2021**, so it is not possible to migrate devices from The Things Network {{% ttnv2 %}} to {{% tts %}} anymore. See [Adding Devices]({{< ref "/devices/adding-devices" >}}) section to start adding devices to {{% tts %}} from scratch.
+
+If your private {{% ttnv2 %}} deployment is still running, this section can guide you through the process of migrating devices from private {{% ttnv2 %}} deployment to {{% tts %}}.
+
 ## Prerequisites
 
-1. User account on The Things Network {{% ttnv2 %}} or The Things Industries {{% ttnv2 %}}.
-2. End device(s) and gateway(s) connected to a {{% ttnv2 %}} network.
-3. User account in {{% tts %}}.
+1. The Things Industries {{% ttnv2 %}} user account.
+2. End device(s) and gateway(s) connected to a private The Things Industries {{% ttnv2 %}} network.
+3. {{% tts %}} user account.
 
 We recommend testing migration on a single end device or a small batch of end devices in order to make sure the migration process goes as expected.
 
@@ -62,13 +66,11 @@ For detailed tutorials on the integrations that are available in {{% tts %}}, se
 
 When you have added your application and elements associated with it, it is time to migrate your end device(s) from {{% ttnv2 %}} to {{% tts %}}.
 
-End devices connected to The Things Network V2 can be migrated to {{% tts %}} Cloud and {{% tts %}} Community Edition without the need for migrating a gateway, thanks to the default connection with [Packet Broker]({{< ref "/getting-started/packet-broker" >}}) which forwards all messages received on {{% ttnv2 %}} to The Things Stack. The Things Industries V2 (SaaS) can also be connected to Packet Broker by contacting [support](mailto:support@thethingsindustries.com), while {{% tts %}} Enterprise or Open Source can be [configured]({{< ref "/getting-started/packet-broker/connect" >}}) manually.
+Thanks to [Packet Broker]({{< ref "/getting-started/packet-broker" >}}), end devices connected to private The Things Industries {{% ttnv2 %}} network can be migrated to {{% tts %}} deployments without migrating gateways. The Things Industries {{% ttnv2 %}} deployments can be connected to Packet Broker on a customer request - please contact [The Things Industries support](mailto:support@thethingsindustries.com). {{% tts %}} Community Edition and {{% tts %}} Cloud are connected to Packet Broker by default, while {{% tts %}} Enterprise and {{% tts %}} Open Source can be [configured]({{< ref "/getting-started/packet-broker/connect" >}}) manually.
 
 If you are using deployments connected to Packet Broker, the traffic from your end device(s) will be routed to {{% tts %}} after migrating your device(s). However, there are certain requirements that your devices need to meet for Packet Broker to route their traffic to {{% tts %}} correctly. See [Packet Broker Requirements for End Device Migration]({{< ref "/getting-started/migrating/migrating-from-v2/packet-broker-requirements" >}}) for detailed information.
 
-If you are using deployments that are not connected to Packet Broker, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to receive traffic from your end device in {{% tts %}}.
-
-Since {{% tts %}} `v3.13.0` release, The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}.
+On the other hand, if you are using deployments that are not connected to Packet Broker, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to receive traffic from your end device in {{% tts %}}.
 
 There are two approaches for migrating devices, depending on how many end devices you intend to migrate and if you wish to migrate with or without active sessions, described in the following guides:
 

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-console.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-console.md
@@ -16,7 +16,9 @@ Follow the steps below to migrate your end device from {{% ttnv2 %}} to {{% tts 
 
 The first step is to add your end device in {{% tts %}}. See [Adding Devices]({{< ref "/devices/adding-devices" >}}) section for more details on adding devices in {{% tts %}}.
 
-There are two ways to add devices in {{% tts %}} Console - **Manually** and via the **LoRaWAN Device Repository**. Configuring settings for end devices depends on their type - OTAA or ABP. We strongly recommend using OTAA over ABP. Read [why using OTAA is better than ABP]({{< ref "/devices/abp-vs-otaa" >}}).
+There are two ways to add devices in {{% tts %}} Console - **Manually** and via the **LoRaWAN Device Repository**.
+
+Configuring settings for end devices depends on their type - OTAA or ABP. We strongly recommend using OTAA over ABP. Read [why using OTAA is better than ABP]({{< ref "/devices/abp-vs-otaa" >}}).
 
 {{< tabs/container "OTAA" "ABP" >}}
 
@@ -35,8 +37,6 @@ If you want to add an OTAA end device manually, follow these steps:
 - Enter your end device’s **AppKey** (see considerations below)
 
 The **AppKey** value can match the one used in {{% ttnv2 %}}, as this info is usually provided by the device manufacturer. The **AppKey** can also be generated in the Console as the last step of the OTAA device registration process. If you decide to generate it, do not forget to program your OTAA device to use the new **AppKey** issued by {{% tts %}}.
-
-If you are migrating an active OTAA device session, the **AppKey** must match the one used on {{% ttnv2 %}}, otherwise you can choose to keep one from {{% ttnv2 %}} or not.
 
 {{< /tabs/tab >}}
 
@@ -63,15 +63,13 @@ Choose **LoRaWAN version** `MAC V1.0.2` (this is the version used in {{% ttnv2 %
 
 The **DevAddr** and **RX1 Delay** values depend on your specific use case.
 
-If you want your end device traffic to be routed via Packet Broker to {{% tts %}}, the **DevAddr** must be routable by the Packet Broker and the **RX1 Delay** value must be set to 5 seconds. Note that the **DevAddr** is routable only if you are using **The Things Industries V2** and migrating to **{{% tts %}} Cloud**, and even that is being achieved only on customer request by contacting [The Things Industries support](mailto:support@thethingsindustries.com).
-
-If the existing **DevAddr** is not routable by the Packet Broker (i.e. you are not migrating from **The Things Industries V2** to **The Things Stack Cloud**), and/or **RX1 Delay** is different than 5 seconds (for {{% ttnv2 %}} the default is 1 second), you will need to auto-generate new **DevAddr** during device registration on {{% tts %}}, then re-program the device to assign it with that new **DevAddr** and **RX1 Delay** of 5 seconds. Otherwise, the traffic from your device will not be properly routed by the Packet Broker or will never reach your end device in time.
+If you want your end device traffic to be routed via Packet Broker to {{% tts %}}, [Packet Broker Requirements for End Device Migration]({{< ref "/getting-started/migrating/migrating-from-v2/packet-broker-requirements" >}}) need to be fulfilled. If you are migrating from **The Things Industries {{% ttnv2 %}}** to **{{% tts %}} Cloud**, you might be able to keep the existing **DevAddr** (please contact [The Things Industries support](mailto:support@thethingsindustries.com)). If the existing **DevAddr** is not routable by the Packet Broker (i.e. you are not migrating from **The Things Industries V2** to **The Things Stack Cloud**), you will need to auto-generate new **DevAddr** during device registration on {{% tts %}}, then re-program the device to assign it with the new **DevAddr**. Note that in both of these cases, you will  have to adjust your device's **RX1 Delay** to 5 seconds using MAC commands, otherwise your device's traffic might not reach {{% tts %}} in time.
 
 Re-programming the ABP device to change **DevAddr** to the one issued by {{% tts %}} and **RX1 Delay** to 5 seconds is **recommended**. Re-programming the ABP device to do this might also be a good time to reconsider switching it to OTAA by flashing the firmware and adopting some [best practices]({{< ref "/devices/best-practices" >}}). [Check why using OTAA is recommended]({{< ref "/devices/abp-vs-otaa" >}}).
 
-If you do not want your traffic to be routed by the Packet Broker, i.e. you want to migrate your gateway to {{% tts %}} too, you do not have to re-program your device. You can keep the existing **DevAddr** and **RX1 Delay** of 1 second, and use these values when adding the device to {{% tts %}}. Be aware that if you are using a high-latency backhaul, keeping the **RX1 Delay** of 1 second might cause latency issues.
+If you do not want your traffic to be routed by the Packet Broker, i.e. you want to migrate your gateway to {{% tts %}} too, you do not have to re-program your device. You can keep the existing **DevAddr** and **RX1 Delay** of 1 second, and use these values when adding the device to {{% tts %}}. Be aware that if you are using a high-latency backhaul, keeping the **RX1 Delay** of 1 second still might cause latency issues, even if you migrate your gateway.
 
-The **NwkSKey** has to match the one used on {{% ttnv2 %}} if you are migrating an active ABP device session. If not, you can choose to keep the one used on {{% ttnv2 %}}, or to generate a new one in {{% tts %}} Console during the device registration process.
+For the **NwkSKey**, you can choose to keep the one used on {{% ttnv2 %}}, or to generate a new one in {{% tts %}} Console during the device registration process.
 
 {{< /tabs/tab >}}
 
@@ -81,7 +79,7 @@ If your end device is a part of the [LoRaWAN Device Repository]({{< ref "/integr
 
 ## Prevent the End Device from Joining {{% ttnv2 %}} Network
 
-When your end device is registered in {{% tts %}}, it is necessary to prevent it from re-joining {{% ttnv2 %}} network. 
+When your end device is registered in {{% tts %}}, it is necessary to prevent it from re-joining the {{% ttnv2 %}} network.
 
 {{< tabs/container "OTAA" "ABP">}}
 
@@ -103,7 +101,7 @@ Some OTAA devices ocasionally perform new joins - with these end devices, you ca
 
 {{< tabs/tab "ABP" >}}
 
-ABP devices must be completely deleted from {{% ttnv2 %}}, especially if you have not re-programmed it for a new **DevAddr**. Having the device registered in both {{% ttnv2 %}} and {{% tts %}}  introduces serious conflicts, including race conditions for Joins and unpredictable, out-of-spec operation.
+ABP devices must be completely deleted from {{% ttnv2 %}}, especially if they are not re-programmed for a new **DevAddr**. Having the device registered in both {{% ttnv2 %}} and {{% tts %}}  introduces serious conflicts, including race conditions for Joins and unpredictable, out-of-spec operation.
 
 {{< /tabs/tab >}}
 
@@ -117,7 +115,7 @@ ABP devices must be completely deleted from {{% ttnv2 %}}, especially if you hav
 
 Since we assume you have not migrated your gateway from {{% ttnv2 %}} yet, new Join Requests sent by your OTAA device are still being received by the {{% ttnv2 %}} network. However, if you have prevented your device from joining {{% ttnv2 %}} network (as recommended above), these Join Requests are not going to be accepted by the {{% ttnv2 %}} Network Server. 
 
-Instead, these Join Requests are going to be routed to {{% tts %}} via Packet Broker and {{% tts %}} will accept them. Your OTAA device will negotiate with {{% tts %}} Network Server to obtain a new **DevAddr**, channel settings and other MAC parameters. The traffic from your end device can from now on be routed to {{% tts %}} thanks to the newly assigned **DevAddr** and **RX1 Delay** of 5 seconds, which fulfills the Packet Broker requirements.
+Instead, if your devices respect the previously mentioned Packet Broker requirements, these Join Requests are going to be routed to {{% tts %}} via Packet Broker and {{% tts %}} will accept them. Upon Join Request acceptance, your OTAA device will negotiate with {{% tts %}} Network Server to obtain a new **DevAddr**, channel settings and other MAC parameters. The traffic from your end device can from now on be routed to {{% tts %}} thanks to the newly assigned **DevAddr** and **RX1 Delay** of 5 seconds.
 
 {{< /tabs/tab >}}
 
@@ -125,14 +123,12 @@ Instead, these Join Requests are going to be routed to {{% tts %}} via Packet Br
 
 ABP devices do not perform the join procedure, so they do not get assigned with a new **DevAddr**, **RX1 Delay** and some other parameters like OTAA devices do. These values must be coded in the device itself. 
 
-If you are not specifically migrating from **The Things Industries V2** to **{{% tts %}} Cloud**, your ABP device's **DevAddr** will not be routable by the Packet Broker. If the **RX1 Delay** of your device is not equal to 5 seconds, the device traffic will probably never reach {{% tts %}}. 
+As previously mentioned, routing traffic from your ABP devices to {{% tts %}} via Packet Broker will be possible only if Packet Broker requirements are met. If you want your traffic to be routed via Packet Broker, you will need to re-program your ABP device to use a **DevAddr** issued by {{% tts %}} and **RX1 Delay** of 5 seconds. Please note that this is a recommended practice. An exception to this rule is the case of migrating from **The Things Industries {{% ttnv2 %}}** to **{{% tts %}} Cloud** deployment - here you might be able to keep your device's **DevAddr**, but you will still have to adjust your device's **RX1 Delay** to 5 seconds.
 
-If you want your traffic to be routed via Packet Broker, you will need to re-program your ABP device to use a **DevAddr** issued by {{% tts %}} and **RX1 Delay** of 5 seconds. 
-
-If you want to keep **DevAddr** and **RX1 Delay** as they were in {{% ttnv2 %}}, you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}).
+If you want to keep **DevAddr** and **RX1 Delay** as they were in {{% ttnv2 %}}, you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}). Please note that this is not a recommended practice, because using an **RX1 Delay** of 1 second in a combination with high latency backhauls might cause your device's traffic to not reach {{% tts %}} in time, even if you migrate your gateway.
 
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
 
-The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we still recommend to migrate your gateways as soon as possible.
+Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we still recommend to migrate your gateways as soon as possible.

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
@@ -38,7 +38,7 @@ Commands are slightly different if using Windows PowerShell, for example you cou
 $ $env:TTNV2_APP_ID='ttn-v2-application-ID'
 ```
 
-If you are migrating end devices from a private The Things Industries V2 (SaaS) cluster, you need to configure one extra environmental variable:
+Since migration is still possible only from a private The Things Industries V2 (SaaS) cluster, you need to configure one extra environmental variable:
 
 ```bash
 $ export TTNV2_DISCOVERY_SERVER_ADDRESS="<instance-id>.thethings.industries:1900"

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
@@ -22,21 +22,21 @@ By establishing the new session with {{% tts %}}, an OTAA device gets assigned a
 
 {{< tabs/tab "ABP" >}}
 
-The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you can migrate it to {{% tts %}} without its security keys, network parameters, etc. which basically means you are migrating it without its active session.
+The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you can migrate it to {{% tts %}} using the migration tool without its security keys, network parameters, etc. without its active session.
 
 If you want your end device traffic to be routed via Packet Broker to {{% tts %}}, the **DevAddr** must be routable by the Packet Broker and the **RX1 Delay** value must be 5 seconds. Note that the **DevAddr** is routable only if you are using **The Things Industries V2 (SaaS)** and migrating to **{{% tts %}} Cloud**, and even that is being achieved only on customer request by contacting [The Things Industries support](mailto:support@thethingsindustries.com).
 
-If you are not migrating from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, Packet Broker will not be able to route your ABP device's traffic properly, so you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to {{% tts %}} too. Be aware that in this case, even if you do migrate your gateway, you could still be experiencing latency issues if your gateway has a high latency backhaul.
+If you are not migrating from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, Packet Broker will not be able to route your ABP device's traffic properly, so you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to {{% tts %}} too. Be aware that in this case the **RX1 Delay** value of 1 second is persisted, and even if you do migrate your gateway, you could still be experiencing latency issues if your gateway has a high latency backhaul.
 
-{{< warning >}} Note that this is **not a recommended practice**. We advise re-programming the ABP device to change the **DevAddr** to the one issued by The Things Stack and **RX1 Delay** to 5 seconds, even if you do not want your traffic to be routed by Packet Broker.
+{{< warning >}} This is **not a recommended practice**. We advise re-programming the ABP device to change the **DevAddr** to the one issued by The Things Stack and **RX1 Delay** to 5 seconds, even if you do not want your traffic to be routed by Packet Broker.
 
-If you re-program the device, you will have to follow the [Migrate using the Console]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-console" >}}) guide. The reason for this is that when you re-program your ABP device, its **DevAddr** and other parameters will no longer match the device description stored in {{% ttnv2 %}}, so you will not be able to export the current device description using the `ttn-lw-migrate` tool. {{</ warning >}}
+In case you are able to re-program your ABP device, you will have to follow the [Migrate using the Console]({{< ref "/getting-started/migrating/migrating-from-v2/migrate-using-console" >}}) guide. The reason for this is that when you re-program your ABP device, its **DevAddr** and other parameters will no longer match the device description stored in {{% ttnv2 %}}, so you will not be able to export the current device description using the `ttn-lw-migrate` tool. {{</ warning >}}
 
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
 
-{{< note >}} Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below. {{</ note >}}
+Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below.
 
 Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with {{% tts %}}. The list of uplink frequencies is inferred from the [Frequency Plan]({{< ref "/reference/frequency-plans" >}}).
 
@@ -88,7 +88,7 @@ To prevent OTAA device from re-joining the {{% ttnv2 %}} network, the recommende
 
 {{< tabs/tab "ABP" >}}
 
-{{< warning >}} For ABP device, you need to completely delete it from V2, especially because this section assumes that you have not re-programmed it for a new **DevAddr**. Having this device registered in V2 and The Things Stack would introduce some serious conflicts. {{</ warning >}}
+ABP devices must be completely deleted from {{% ttnv2 %}}, especially if you have not re-programmed them with a new **DevAddr**. Having a device registered in {{% ttnv2 %}} and {{% tts %}} will cause a race condition and communication issues.
 
 {{< /tabs/tab >}}
 
@@ -132,4 +132,4 @@ If you are not migrating from **The Things Industries {{% ttnv2 %}}** to **{{% t
 
 {{< /tabs/container >}}
 
-The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible.
+Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible.

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
@@ -26,15 +26,15 @@ In the case of persisting active sessions during migration, OTAA devices do not 
 
 The **DevAddr** and some other parameters (like **RX1 Delay**) are hardcoded for ABP devices. If you do not re-program the device to change these values, you can migrate it to {{% tts %}} with its active session. 
 
-Remember that if you are not migrating specifically from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to successfully migrate your end device with its active session.
-
 {{< /tabs/tab >}}
 
 {{< /tabs/container >}}
 
+Remember that if you are not migrating specifically from **The Things Industries V2 (SaaS)** to **{{% tts %}} Cloud**, you will have to [migrate your gateway]({{< ref "/getting-started/migrating/gateway-migration" >}}) to successfully migrate your end device with its active session.
+
 {{< warning >}} Exporting end devices with their active sessions will clear their root and session keys from {{% ttnv2 %}}, so these devices will automatically no longer work on {{% ttnv2 %}}. {{</ warning >}}
 
-{{< note >}} Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below. {{</ note >}}
+Before exporting end devices, you can first test the execution by appending the `--dry-run` and `--verbose` flags to the commands presented in the sections below.
 
 Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset frequencies of the device, so that it can keep working with {{% tts %}}. The list of uplink frequencies is inferred from the [Frequency Plan]({{< ref "/reference/frequency-plans" >}}).
 
@@ -98,8 +98,8 @@ Migrating your ABP device from {{% ttnv2 %}} to {{% tts %}} with its active sess
 
 If you are migrating an end device with its active session via Packet Broker (from **The Things Industries V2** to **{{% tts %}} Cloud**), you might need to set the **RX1 Delay** of the device to 5 seconds by [configuring MAC settings]({{< ref "/getting-started/migrating/configure-mac-settings" >}}), otherwise the traffic might not reach {{% tts %}} in time via Packet Broker. 
 
-In any case, you can leave the **RX1 Delay** value as is (1 second from {{% ttnv2 %}}), but then you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too.
+In case you want to leave the **RX1 Delay** value as is (1 second from {{% ttnv2 %}}), you will need to [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}) too.
 
-The Things Network community members can freely migrate their gateways from The Things Network {{% ttnv2 %}} to {{% tts %}} Community Edition, while still providing uplink and downlink coverage to The Things Network {{% ttnv2 %}}. Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible.
+Even if you manage to get your end device traffic routed to {{% tts %}} by Packet Broker, we recommend to migrate your gateways as soon as possible.
 
 {{< note >}} If you have migrated your device from {{% ttnv2 %}} to {{% tts %}} with an active session but cannot see any uplinks from the device on {{% tts %}}, see [Troubleshooting Devices]({{< ref "/devices/troubleshooting#i-can-see-some-received-uplinks-in-gateway-live-data-events-but-i-do-not-see-them-in-device-events" >}}). {{</ note >}}

--- a/doc/content/getting-started/migrating/migrating-from-v2/packet-broker-requirements.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/packet-broker-requirements.md
@@ -12,8 +12,6 @@ When migrating your devices with active sessions, it is in most cases not possib
 
 | Migrate from  | Migrate to | Possibility to use Packet Broker |
 | ------------- |:-------------| :-----|
-| The Things Network V2 | The Things Stack Community Edition | Only without persisting active device sessions |
-| The Things Network V2 | The Things Stack Cloud | Only without persisting active device sessions |
 | The Things Industries V2 | The Things Stack Community Edition | Only without persisting active device sessions |
 | The Things Industries V2 | The Things Stack Cloud | With and without persisting active device sessions |
 
@@ -27,7 +25,7 @@ OTAA devices migrated without an active session will acquire a new **DevAddr** f
 
 When registering ABP devices on {{% tts %}}, it is possible to auto-generate new **DevAddr** which can be routed by Packet Broker. ABP devices can be re-programmed to use this new **DevAddr**. This implies breaking their existing session on {{% ttnv2 %}}.
 
-Migrating OTAA and ABP devices with their active sessions implies keeping their **DevAddr** values from {{% ttnv2 %}}. Packet Broker will be able to route traffic for these **DevAddr** values only if these devices were registered on **The Things Industries V2 (SaaS)** and you are migrating them to **{{% tts %}} Cloud**. If you are not using these deployments and you still want your traffic to be routed by Packet Broker, end devices can only be migrated without their active sessions.
+Migrating OTAA and ABP devices with their active sessions implies keeping their **DevAddr** values from {{% ttnv2 %}}. Packet Broker will be able to route traffic for these **DevAddr** values only if these devices were registered on **The Things Industries V2 (SaaS)** and you are migrating them to **{{% tts %}} Cloud**. If you are not using these deployments and you still want your traffic to be routed by Packet Broker, end devices can only be migrated without their active sessions. The alternative option is to migrate your gateway instead of using Packet Broker.
 
 ## RX1 Delay 
 
@@ -37,10 +35,8 @@ The RX1 delay of OTAA devices migrated without their active session will be auto
 
 However, this needs to be manually set for OTAA devices migrated with an active session by [configuring their MAC settings]({{< ref "/getting-started/migrating/configure-mac-settings" >}}). It is also possible to re-program ABP devices to enforce the **RX1 Delay** of 5 seconds (this basically implies starting a new ABP session, i.e. migrating ABP devices without their active session from {{% ttnv2 %}}).
 
-If devices keep on using an **RX1 Delay** of 1 second, downlinks routed via the Packet Broker will probably never reach the end device in time. The solution to enable downlinks is to migrate your gateway to {{% tts %}} too. Even if you migrate your gateways to {{% tts %}}, you might still experience issues if you are using a high-latency backhaul.
+If devices keep on using an **RX1 Delay** of 1 second, downlinks routed via the Packet Broker will probably never reach the end device in time. The alternative solution to enable downlinks is to migrate your gateway to {{% tts %}} too. Remember that even if you migrate your gateways to {{% tts %}}, you might still experience issues if you are using a high-latency backhaul in a combination with an **RX1 Delay** of 1 second.
 
 If DevAddr and RX1 Delay conditions stated above are not met, it is likely that you will experience difficulties in communication between your end device and {{% tts %}} via Packet Broker. If you are using deployments that are not connected to Packet Broker, you will have to migrate your devices as well as [your gateways]({{< ref "/getting-started/migrating/gateway-migration" >}}) in order to receive the traffic from your end device on {{% tts %}}.
 
-{{< warning >}} It is possible to migrate active device sessions from The Things Network V2 (public community network) to any {{% tts %}} deployment. But, this is achievable only if you [migrate your gateway to {{% tts %}}]({{< ref "/getting-started/migrating/gateway-migration" >}}), as Packet Broker cannot route this traffic properly.
-
-We strongly recommend to migrate devices without their active sessions, to make sure Packet Broker can route the traffic properly and that it reaches {{% tts %}} in time. {{</ warning >}}
+{{< warning >}} We strongly recommend to migrate devices without their active sessions, to make sure Packet Broker can route the traffic properly and that it reaches {{% tts %}} in time. {{</ warning >}}

--- a/doc/content/reference/pb-routing/_index.md
+++ b/doc/content/reference/pb-routing/_index.md
@@ -6,13 +6,12 @@ This reference contains default Packet Broker routing tables.
 
 <!--more-->
 
-The following table explains which Forwarder Networks and Home Networks are configured by default in {{% tts %}}. To configure custom routing policies for your deployment, see the [Configure Packet Broker]({{< ref "getting-started/packet-broker/configure" >}}) section.
+The following table explains which Forwarder Networks and Home Networks are configured by default in {{% tts %}}.
+
+To configure custom routing policies for your deployment, see the [Configure Packet Broker]({{< ref "getting-started/packet-broker/configure" >}}) section.
 
 |Forwarder Network | Home Network | Status|
 |--- | --- | ---|
-|TTN V2 | TTS Cloud | Enabled|
-|TTN V2 | TTS Community Edition | Enabled|
 |TTS Community Edition | TTS Cloud | Enabled|
-|TTS Community Edition | TTN V2 | Not Enabled|
 |TTS Cloud | TTS Community Edition | Not Enabled|
 |TTS Cloud <TENANT X> | TTS Cloud <TENANT Y> | Not Enabled|


### PR DESCRIPTION
#### Summary
Closes #671 

#### Changes
I removed all info related to TTN V2 from migration docs, left only what's relevant for TTI V2 (private instances). 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
