### PR TITLE
doc: Remove $ character from code blocks

### DIFF
--- a/doc/content/devices/adding-devices/_index.md
+++ b/doc/content/devices/adding-devices/_index.md
@@ -174,27 +174,42 @@ The end device location can be manually set by pinning on the map widget, or ent
 First, list the available frequency plans and LoRaWAN versions:
 
 ```bash
-$ ttn-lw-cli end-devices list-frequency-plans
-$ ttn-lw-cli end-devices create --help
+ttn-lw-cli end-devices list-frequency-plans
+ttn-lw-cli end-devices create --help
 ```
 
 ### Over-The-Air-Activation (OTAA) Device
+
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+DEV_EUI="0004A30B001C0530"
+APP_EUI="800000000000000C"
+APP_KEY="752BAEC23EAE7964AF27C325F4C23C9A"
+```
+
+Make sure to modify these according to your setup.
 
 **LoRaWAN 1.0.x:**
 
 To create an end device using over-the-air-activation (OTAA):
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev1 \
-  --dev-eui 0004A30B001C0530 \
-  --app-eui 800000000000000C \
-  --frequency-plan-id EU_863_870 \
-  --root-keys.app-key.key 752BAEC23EAE7964AF27C325F4C23C9A \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --dev-eui $DEV_EUI \
+  --app-eui $APP_EUI \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --root-keys.app-key.key $APP_KEY \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a
 ```
 
-This will create a LoRaWAN 1.0.3 end device `dev1` in application `app1` with the `EU_863_870` frequency plan. Please note that the `AppEUI` is returned as `join_eui` ({{% tts %}} uses LoRaWAN 1.1 terminology).
+This will create an end device `dev1` in application `app1` with the `EU_863_870` frequency plan, that uses LoRaWAN 1.0.3 MAC version and 1.0.3-a PHY versions. Make sure to replace the LoRaWAN MAC and PHY versions according to your setup.
+
+Please note that the `AppEUI` is returned as `join_eui` ({{% tts %}} uses LoRaWAN 1.1 terminology).
 
 {{< note >}} If you do not have a `JoinEUI` or `AppEUI`, you could use `0000000000000000`. 
 
@@ -211,17 +226,18 @@ The end device should now be able to join the private network.
 To create an end device using over-the-air-activation (OTAA):
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev1 \
-  --dev-eui 0004A30B001C0530 \
-  --app-eui 800000000000000C \
-  --frequency-plan-id EU_863_870 \
-  --root-keys.app-key.key 752BAEC23EAE7964AF27C325F4C23C9A \
-  --root-keys.nwk-key.key 01020304050607080102030405060708 \
+NWK_KEY="01020304050607080102030405060708"
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --dev-eui $DEV_EUI \
+  --app-eui $APP_EUI \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --root-keys.app-key.key $APP_KEY \
+  --root-keys.nwk-key.key $NWK_KEY \
   --lorawan-version 1.1.0 \
   --lorawan-phy-version 1.1.0-b
 ```
 
-This will create a LoRaWAN 1.1.0 end device `dev1` in application `app1` with the `EU_863_870` frequency plan.
+This will create an end device `dev1` in application `app1` with the `EU_863_870` frequency plan, that uses LoRaWAN 1.1.0 MAC and 1.1.0-b PHY versions. Make sure you replace these versions according to your setup.
 
 {{< note >}} If you do not have a `JoinEUI` or `AppEUI`, you could use `0000000000000000`. 
 
@@ -235,20 +251,35 @@ The end device should now be able to join the private network.
 
 ### Activation By Personalization (ABP) Device
 
+For adding ABP devices, we can define the following parameters:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+DEV_ADDR="00E4304D"
+APP_SESSION_KEY="A0CAD5A30036DBE03096EB67CA975BAA"
+NWK_SESSION_KEY="B7F3E161BC9D4388E6C788A0C547F255"
+```
+
+Make sure you modify these according to your setup.
+
 **LoRaWAN 1.0.x:**
 
 It is also possible to register an ABP activated device using the `--abp` flag as follows:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev2 \
-  --frequency-plan-id EU_863_870 \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \
   --abp \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY
 ```
+
+This will create an end device `dev1` in application `app1` with the `EU_863_870` frequency plan, that uses LoRaWAN 1.0.3 MAC and 1.0.3-a PHY versions. Make sure you replace these versions according to your setup.
 
 Please note that the `NwkSKey` is returned as `f_nwk_s_int_key` ({{% tts %}} uses LoRaWAN 1.1 terminology).
 
@@ -259,18 +290,23 @@ You can also pass `--with-session` to have a session generated.
 To register a LoRaWAN 1.1.x end device using ABP:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev2 \
-  --frequency-plan-id EU_863_870 \
+F_NWK_SESSION_INT_KEY="01020304050607080102030405060708"
+S_NWK_SESSION_INT_KEY="01020304050607080102030405060708"
+NWK_SESSION_ENC_KEY="01020304050607080102030405060708"
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
   --lorawan-version 1.1.0 \
   --lorawan-phy-version 1.1.0-b \
   --abp \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255
-  --session.keys.f-nwk-s-int-key.key 01020304050607080102030405060708 \
-  --session.keys.s-nwk-s-int-key.key 01020304050607080102030405060708 \
-  --session.keys.nwk-s-enc-key.key 01020304050607080102030405060708
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY
+  --session.keys.f-nwk-s-int-key.key $F_NWK_SESSION_INT_KEY \
+  --session.keys.s-nwk-s-int-key.key $S_NWK_SESSION_INT_KEY \
+  --session.keys.nwk-s-enc-key.key $NWK_SESSION_ENC_KEY
 ```
+
+This will create an end device `dev1` in application `app1` with the `EU_863_870` frequency plan, that uses LoRaWAN 1.1.0 MAC and 1.1.0-b PHY versions. Make sure you replace these versions according to your setup.
 
 You can also pass `--with-session` to have a session generated.
 
@@ -281,17 +317,18 @@ Once you have added your end device to {{% tts %}}, you can also set its locatio
 Set your end device's location with:
 
 ```bash
-$ APP_ID="your-application-id" 
-$ DEVICE_ID="your-device-id"
-$ ttn-lw-cli end-devices set $APP_ID $DEVICE_ID \
-  --location.latitude 43.84 \
-  --location.longitude 18.32 \
-  --location.altitude 500 \
+LAT="43.84"
+LONG="18.32"
+ALT="500"
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID \
+  --location.latitude $LAT \
+  --location.longitude $LONG \
+  --location.altitude $ALT \
 ```
 
 You can also set the end device location to be updated from various sources with the `--location.source` flag.
 
-The source of the location data can be the registry, GPS data, results of the LoRa RSSI geolocation, etc. Use `ttn-lw-cli end-devices set app1 dev1 --help` command to see the full list of the available location sources and other relatable info. If you set the alternative location source, the location settings you manually set will be overwritten by the automatic updates from that source.
+The source of the location data can be the registry, GPS data, results of the LoRa RSSI geolocation, etc. Use `ttn-lw-cli end-devices set $APP_ID $DEVICE_ID --help` command to see the full list of the available location sources and other relatable info. If you set the alternative location source, the location settings you manually set will be overwritten by the automatic updates from that source.
 
 The CLI will return something like:
 

--- a/doc/content/devices/class-b/index.md
+++ b/doc/content/devices/class-b/index.md
@@ -10,6 +10,21 @@ Class B end devices listen for downlink messages during ping slots. This allows 
 
 Read more about device classes in [The Things Network LoRaWAN documentation](https://www.thethingsnetwork.org/docs/lorawan/classes/).
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_ADDR="00E4304D"
+APP_SESSION_KEY="A0CAD5A30036DBE03096EB67CA975BAA"
+NWK_SESSION_KEY="B7F3E161BC9D4388E6C788A0C547F255"
+```
+
+Make sure to modify these according to your setup.
+
 ## Enabling and Disabling Class B
 
 In order to send Class B downlink messages to a single device, enable Class B support for the end device when creating or updating it with the `--supports-class-b` flag.
@@ -17,7 +32,7 @@ In order to send Class B downlink messages to a single device, enable Class B su
 For example, when enabling Class B for an existing device:
 
 ```bash
-$ ttn-lw-cli end-devices set app1 dev1 --supports-class-b
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID --supports-class-b
 ```
 
 This will enable the Class B downlink scheduling of the device. Downlink messages are now scheduled during the next available ping slot.
@@ -45,13 +60,13 @@ The time to transmit is an absolute timestamp in ISO 8601 format to send the mes
 First, create a Class B device:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev1 \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255 \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY \
   --supports-class-b
 ```
 

--- a/doc/content/devices/class-c/_index.md
+++ b/doc/content/devices/class-c/_index.md
@@ -12,6 +12,21 @@ This guide shows how to enable or disable Class C for an and device, and how to 
 
 Read more about device classes in [The Things Network LoRaWAN documentation]](https://www.thethingsnetwork.org/docs/lorawan/classes/).
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_ADDR="00E4304D"
+APP_SESSION_KEY="A0CAD5A30036DBE03096EB67CA975BAA"
+NWK_SESSION_KEY="B7F3E161BC9D4388E6C788A0C547F255"
+```
+
+Make sure to modify these according to your setup.
+
 ## Enabling and Disabling Class C
 
 In order to send Class C downlink messages to a single device, enable Class C support for the end device when creating or updating it with the `--supports-class-c` flag.
@@ -19,7 +34,7 @@ In order to send Class C downlink messages to a single device, enable Class C su
 For example, when enabling Class C for an existing device:
 
 ```bash
-$ ttn-lw-cli end-devices set app1 dev1 --supports-class-c
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID --supports-class-c
 ```
 
 This will enable the Class C downlink scheduling of the device. That's it! Downlink messages are now scheduled as soon as possible.
@@ -47,13 +62,13 @@ The time to transmit is an absolute timestamp in ISO 8601 format to send the mes
 First, create a Class C device:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev1 \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255 \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY \
   --supports-class-c
 ```
 

--- a/doc/content/devices/device-claiming/make-device-claimable.md
+++ b/doc/content/devices/device-claiming/make-device-claimable.md
@@ -22,13 +22,13 @@ In order for anyone to claim devices that are registered in your application, yo
 Replace `<app-id>` with the **Application ID** of the application that you created in prerequisites, and run the following command in the CLI:
 
 ```bash
-$ ttn-lw-cli applications claim authorize <app-id>
+ttn-lw-cli applications claim authorize <app-id>
 ```
 
 To undo the action:
 
 ```bash
-$ ttn-lw-cli application claim unauthorize <app-id>
+ttn-lw-cli application claim unauthorize <app-id>
 ```
 
 ## Register Device
@@ -68,7 +68,8 @@ To disallow claiming, click **Delete claim authentication code**.
 To configure claiming using the CLI, use the following command:
 
 ```bash
-$ ttn-lw-cli end-device set <app-id> <device-id> --claim-authentication-code.value ABCD \
+CLAIM_AUTHENTICATION_CODE="ABCD"
+ttn-lw-cli end-device set <app-id> <device-id> --claim-authentication-code.value $CLAIM_AUTHENTICATION_CODE \
   --claim-authentication-code.valid-from 2021-03-01T00:00:00Z \
   --claim-authentication-code.valid-from 2021-03-31T23:59:59Z
 ```

--- a/doc/content/devices/downlink-queue-ops/_index.md
+++ b/doc/content/devices/downlink-queue-ops/_index.md
@@ -6,27 +6,39 @@ weight: 7
 
 {{% tts %}} keeps a queue of downlink messages per device. Applications can keep pushing downlink messages or replace the queue with a list of downlink messages.
 
+<!--more-->
+
 You can schedule a downlink using the CLI, MQTT or HTTP webhooks.
 
 To schedule downlinks using MQTT, see [MQTT Server]({{< ref "integrations/mqtt" >}}). To schedule downlinks using webhooks, see [Scheduling Downlinks with Webhooks]({{< ref "integrations/webhooks/scheduling-downlinks" >}}).
 
 This guide shows how to interact with the downlink queue from the command-line interface (CLI).
 
-<!--more-->
-
 {{< cli-only >}}
 
 If there are more application downlink messages in the queue, the Network Server sets the LoRaWAN `FPending` bit to indicate end devices that there is more downlinks available. In class A downlink, this typically triggers the device to send an uplink message to receive the downlink message. In class C, the Network Server automatically transmits all queued downlink messages.
+
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+PAYLOAD="01020304"
+PRIORITY="NORMAL"
+F_PORT="42"
+```
+
+Make sure to modify these according to your setup.
 
 ## Push and replace downlink queue
 
 To push downlink to the end of the queue:
 
 ```bash
-$ ttn-lw-cli end-devices downlink push app1 dev1 \
-  --frm-payload 01020304 \
-  --priority NORMAL \
-  --f-port 42
+ttn-lw-cli end-devices downlink push $APP_ID $DEVICE_ID \
+  --frm-payload $PAYLOAD \
+  --priority $PRIORITY \
+  --f-port $F_PORT
 ```
 
 You must pass an `FPort` with the `--f-port` flag. Confirmed downlinks can be set using `--confirmed`.
@@ -34,10 +46,10 @@ You must pass an `FPort` with the `--f-port` flag. Confirmed downlinks can be se
 To replace the existing queue with a new item:
 
 ```bash
-$ ttn-lw-cli end-devices downlink replace app1 dev1 \
-  --frm-payload 01020304 \
-  --priority NORMAL \
-  --f-port 42
+ttn-lw-cli end-devices downlink replace $APP_ID $DEVICE_ID \
+  --frm-payload $PAYLOAD \
+  --priority $PRIORITY \
+  --f-port $F_PORT
 ```
 
 {{% tts %}} limits the application downlink queue on 10k messages per end device. When this limit is reached, no more scheduled downlinks can be placed in the queue and {{% tts %}} will drop them. In order to avoid hitting the application downlink queue limit and loosing downlinks, we advise scheduling downlink messages in batches.
@@ -47,7 +59,7 @@ $ ttn-lw-cli end-devices downlink replace app1 dev1 \
 To see currently scheduled downlink messages:
 
 ```bash
-$ ttn-lw-cli end-devices downlink list app1 dev1
+ttn-lw-cli end-devices downlink list $APP_ID $DEVICE_ID
 ```
 
 ## Clear queue
@@ -55,5 +67,5 @@ $ ttn-lw-cli end-devices downlink list app1 dev1
 To clear scheduled downlink messages:
 
 ```bash
-$ ttn-lw-cli end-devices downlink clear app1 dev1
+ttn-lw-cli end-devices downlink clear $APP_ID $DEVICE_ID
 ```

--- a/doc/content/devices/end-device-templates/assigning-euis.md
+++ b/doc/content/devices/end-device-templates/assigning-euis.md
@@ -23,21 +23,35 @@ If you intend to operate your own LoRaWAN Join Server, use a `JoinEUI` from your
 
 This example illustrates creating a device profile template, assigning 5 `DevEUI`s and creating them in your {{% tts %}} application.
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="test-app" 
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_EUI="70b3d57ed0000000"
+JOIN_EUI="70b3d57ed0000001"
+COUNT="5"
+```
+
+Make sure to modify these according to your setup.
+
 First, create a mapping file with a device profile in `profile.json`:
 
 ```bash
-$ ttn-lw-cli end-devices template extend \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
+ttn-lw-cli end-devices template extend \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
   --supports-join > profile.json
 ```
 
 Second, assign the EUIs. The first argument is the `JoinEUI`, the second argument is the first `DevEUI`.
 
 ```bash
-$ cat profile.json \
-  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 --count 5 > devices.json
+cat profile.json \
+  | ttn-lw-cli end-devices template assign-euis $JOIN_EUI $DEV_EUI --count $COUNT > devices.json
 ```
 
 <details><summary>Show output</summary>
@@ -204,7 +218,7 @@ $ cat profile.json \
 Finally, you can create these devices in your {{% tts %}} application `test-app`, see [Executing Templates]({{< relref "executing.md" >}}).
 
 ```bash
-$ cat devices.json \
+cat devices.json \
   | ttn-lw-cli end-devices template execute \
-  | ttn-lw-cli end-devices create --application-id test-app
+  | ttn-lw-cli end-devices create --application-id $APP_ID
 ```

--- a/doc/content/devices/end-device-templates/converting.md
+++ b/doc/content/devices/end-device-templates/converting.md
@@ -11,7 +11,7 @@ You can convert data in various formats to device templates using formats suppor
 Start with listing the supported formats:
 
 ```bash
-$ ttn-lw-cli end-devices template list-formats
+ttn-lw-cli end-devices template list-formats
 ```
 
 This gives the supported formats, for example:
@@ -34,7 +34,7 @@ Given input data, you can use the `end-device template from-data` command to get
 This example uses a **Microchip ATECC608A-MAHTN-T Manifest File**. This file contains provisioning data for The Things Join Server. You can download the example file [here](../microchip-atecc608a-mahtn-t-example.json).
 
 ```bash
-$ ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json
+ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json
 ```
 
 <details><summary>Output</summary>

--- a/doc/content/devices/end-device-templates/creating.md
+++ b/doc/content/devices/end-device-templates/creating.md
@@ -8,6 +8,18 @@ weight: 2
 
 You can create a device template from an existing device or extend an existing device template. You can also create a new template from scratch.
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+```
+
+Make sure to modify these according to your setup.
+
 ## Create from existing device
 
 You can use the `end-device template create` command to create a template from an existing device.
@@ -19,9 +31,9 @@ You can include the end device identifiers by passing the concerning flags: `--a
 Pipe the output from getting a device to create a template, for example:
 
 ```bash
-$ ttn-lw-cli end-devices get test-app test-dev \
-  --lorawan-version \
-  --lorawan-phy-version \
+ttn-lw-cli end-devices get $APP_ID $DEVICE_ID \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
   | ttn-lw-cli end-devices template create > template.json
 ```
 
@@ -55,9 +67,9 @@ $ ttn-lw-cli end-devices get test-app test-dev \
 Use the `end-device template extend` command to extend a template:
 
 ```bash
-$ cat template.json \
+cat template.json \
   | ttn-lw-cli end-devices template extend \
-  --frequency-plan-id EU_863_870
+  --frequency-plan-id $FREQUENCY_PLAN
 ```
 
 <details><summary>Output</summary>
@@ -89,7 +101,7 @@ $ cat template.json \
 ```
 </details>
 
-See `$ ttn-lw-cli end-devices template extend --help` for all the fields that can be set.
+See `ttn-lw-cli end-devices template extend --help` for all the fields that can be set.
 
 ## Create from scratch
 
@@ -98,10 +110,10 @@ The `end-device template extend` can also be used to create a new template from 
 For example, create a new template from scratch:
 
 ```bash
-$ ttn-lw-cli end-devices template extend \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --frequency-plan-id EU_863_870
+ttn-lw-cli end-devices template extend \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --frequency-plan-id $FREQUENCY_PLAN
 ```
 
 <details><summary>Output</summary>

--- a/doc/content/devices/end-device-templates/executing.md
+++ b/doc/content/devices/end-device-templates/executing.md
@@ -8,18 +8,31 @@ weight: 4
 
 Once you created or converted a template, you can execute the template with the `end-device templates execute` command to obtain an end device that can be created.
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="test-app" 
+FREQUENCY_PLAN="US_902_928"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_EUI="70b3d57ed0000000"
+JOIN_EUI="70b3d57ed0000001"
+```
+
+Make sure to modify these according to your setup.
+
 ```bash
 # The examples use a template that has been created as follows:
-$ ttn-lw-cli end-devices template extend \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --frequency-plan-id US_902_928 > example.json
+ttn-lw-cli end-devices template extend \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --frequency-plan-id $FREQUENCY_PLAN > example.json
 ```
 
 You can execute an end device as follows:
 
 ```bash
-$ cat example.json | ttn-lw-cli end-devices template execute
+cat example.json | ttn-lw-cli end-devices template execute
 ```
 
 <details><summary>Output</summary>
@@ -43,10 +56,10 @@ $ cat example.json | ttn-lw-cli end-devices template execute
 The `end-device template execute` command **does not actually create** the end device. You can, however, easily pipe the output of `end-device template execute` to create the device. But first, you need to personalize the devices by assigning EUIs since this is a generic device template - see [Assigning EUIs]({{< relref "assigning-euis.md" >}}).
 
 ```bash
-$ cat example.json \
-  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 \
+cat example.json \
+  | ttn-lw-cli end-devices template assign-euis $JOIN_EUI $DEV_EUI \
   | ttn-lw-cli end-devices template execute \
-  | ttn-lw-cli end-devices create --application-id test-app
+  | ttn-lw-cli end-devices create --application-id $APP_ID
 ```
 
 <details><summary>Output</summary>

--- a/doc/content/devices/end-device-templates/mapping.md
+++ b/doc/content/devices/end-device-templates/mapping.md
@@ -21,19 +21,36 @@ This example shows creating a generic device profile that is mapped with provisi
 
 This example uses a **Microchip ATECC608A-MAHTN-T Manifest File**. This file contains provisioning data for The Things Join Server. You can download the example file [here](../microchip-atecc608a-mahtn-t-example.json).
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="test-app" 
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_EUI="70b3d57ed0000000"
+JOIN_EUI="70b3d57ed0000001"
+DEVICE_BRAND_ID="thethingsproducts"
+DEVICE_MODEL_ID="genericnode"
+DEVICE_HARDWARE_VERSION="1.0"
+DEVICE_FIRMWARE_VERSION="1.0"
+```
+
+Make sure to modify these according to your setup.
+
 First, create a mapping file with a device profile:
 
 ```bash
-$ ttn-lw-cli end-devices template extend \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
+ttn-lw-cli end-devices template extend \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
   --supports-join \
   --supports-class-c \
-  --version-ids.brand-id "thethingsproducts" \
-  --version-ids.model-id "genericnode" \
-  --version-ids.hardware-version "1.0" \
-  --version-ids.firmware-version "1.0" > profile.json
+  --version-ids.brand-id $DEVICE_BRAND_ID \
+  --version-ids.model-id $DEVICE_MODEL_ID \
+  --version-ids.hardware-version $DEVICE_HARDWARE_VERSION \
+  --version-ids.firmware-version $DEVICE_FIRMWARE_VERSION > profile.json
 ```
 
 The mapping file `profile.json` contains the following entries (omitting empty fields).
@@ -75,13 +92,13 @@ The mapping file `profile.json` contains the following entries (omitting empty f
 Second, convert the provisioning data to a device templates file to `provisioningdata.json`.
 
 ```bash
-$ ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json > provisioningdata.json
+ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json > provisioningdata.json
 ```
 
 Third, map the two files to `templates.json`:
 
 ```bash
-$ cat provisioningdata.json \
+cat provisioningdata.json \
   | ttn-lw-cli end-devices template map --mapping-local-file profile.json > templates.json
 ```
 
@@ -202,8 +219,8 @@ This returns the device templates with provisioning data and device profile comb
 Fourth, you can personalize these devices by assigning the `JoinEUI` and `DevEUI` to `devices.json`, see [Assigning EUIs]({{< relref "assigning-euis.md" >}}):
 
 ```bash
-$ cat templates.json \
-  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 > devices.json
+cat templates.json \
+  | ttn-lw-cli end-devices template assign-euis $JOIN_EUI $DEV_EUI > devices.json
 ```
 
 <details><summary>Show output</summary>
@@ -333,7 +350,7 @@ $ cat templates.json \
 Finally, you can create these devices in your {{% tts %}} application `test-app`, see [Executing Templates]({{< relref "executing.md" >}}).
 
 ```bash
-$ cat devices.json \
+cat devices.json \
   | ttn-lw-cli end-devices template execute \
-  | ttn-lw-cli end-devices create --application-id test-app
+  | ttn-lw-cli end-devices create --application-id $APP_ID
 ```

--- a/doc/content/devices/generate-qr-code/_index.md
+++ b/doc/content/devices/generate-qr-code/_index.md
@@ -16,7 +16,7 @@ This guide shows how to list QR code formats and generate QR codes with the CLI.
 To show supported QR code formats for end devices:
 
 ```bash
-$ ttn-lw-cli end-devices list-qr-formats
+ttn-lw-cli end-devices list-qr-formats
 ```
 
 <details><summary>Output</summary>
@@ -47,10 +47,10 @@ The formats show the fields of the end device that are used in the QR code.
 To generate a QR code for identification:
 
 ```
-$ ttn-lw-cli end-devices generate-qr app1 dev1 --format-id tr005
+ttn-lw-cli end-devices generate-qr <application-id> <device-id> --format-id <qr-code-format>
 ```
 
-<details><summary>Example</summary>
+<details><summary>Example of a generated identification QR code</summary>
 
 {{< figure src="qr-identification.png" alt="Device QR Code for Identification" >}}
 
@@ -65,10 +65,10 @@ Device claiming is a mechanism to transfer devices securely from one application
 When a device is claimable (it contains a claim authentication code), you can use the same command as above to generate a QR code:
 
 ```bash
-$ ttn-lw-cli end-devices generate-qr app1 dev1 --format-id tr005
+ttn-lw-cli end-devices generate-qr <application-id> <device-id> --format-id <qr-code-format>
 ```
 
-<details><summary>Example</summary>
+<details><summary>Example of a generated claiming QR code</summary>
 
 {{< figure src="qr-claiming.png" alt="Device QR Code for Claiming" >}}
 

--- a/doc/content/devices/mac-settings/_index.md
+++ b/doc/content/devices/mac-settings/_index.md
@@ -31,7 +31,7 @@ If no settings are provided on device creation or unset, defaults are first take
 Run the following command to get a list of all available MAC settings and available parameter values:
 
 ```bash
-$ ttn-lw-cli end-devices set --help
+ttn-lw-cli end-devices set --help
 ```
 
 You can also refer to the [End Device API Reference page]({{< ref "reference/api/end_device#message:MACSettings" >}}) for documentation on the available MAC settings and MAC state parameters.
@@ -75,7 +75,7 @@ Some additional examples are included below. All settings are available at the [
 To tell {{% tts %}} which frequencies are configured in an ABP device, set the `mac-settings.factory-preset-frequencies` parameter. For example, to configure a device using the default EU868 frequencies, use the following command:
 
 ```bash
-$ ttn-lw-cli devices update <app-id> <device-id> --mac-settings.factory-preset-frequencies 868100000,868300000,868500000,867100000,867300000,867500000,867700000,867900000
+ttn-lw-cli devices update <app-id> <device-id> --mac-settings.factory-preset-frequencies 868100000,868300000,868500000,867100000,867300000,867500000,867700000,867900000
 ```
 
 {{< note >}} For ABP devices, `mac-settings.factory-preset-frequencies` should be specified on `device create` or the settings will only take effect after MAC reset. {{</ note >}}
@@ -85,7 +85,7 @@ $ ttn-lw-cli devices update <app-id> <device-id> --mac-settings.factory-preset-f
 To change the duty cycle, set the `desired-max-duty-cycle` parameter. For example, to set the duty cycle to 0.098%, use the following command:
 
 ```bash
-$ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-max-duty-cycle DUTY_CYCLE_1024
+ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-max-duty-cycle DUTY_CYCLE_1024
 ```
 
 See the [End Device API Reference]({{< ref "reference/api/end_device#message:MACSettings" >}}) for available fields and definitions of constants. `DUTY_CYCLE_1024` represents 1/1024 ≈ 0.098%.
@@ -95,7 +95,7 @@ See the [End Device API Reference]({{< ref "reference/api/end_device#message:MAC
 To enable ADR, set the `mac-settings.use-adr` parameter
 
 ```bash
-$ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr=true 
+ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr=true 
 ```
 
 ### Set RX1 Delay
@@ -103,7 +103,7 @@ $ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr=true
 The RX1 delay of end devices is set to 5 second by default. To change it, set the `desired-rx1-delay` parameter:
 
 ```bash
-$ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-rx1-delay RX_DELAY_5
+ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-rx1-delay RX_DELAY_5
 ```
 
 ### Unset MAC settings
@@ -111,5 +111,5 @@ $ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-rx1-del
 The CLI can also be used to unset MAC settings (so that the default ones are used):
 
 ```bash
-$ ttn-lw-cli end-devices set <app-id> <device-id> --unset mac-settings.rx1-delay
+ttn-lw-cli end-devices set <app-id> <device-id> --unset mac-settings.rx1-delay
 ```

--- a/doc/content/devices/multicast/index.md
+++ b/doc/content/devices/multicast/index.md
@@ -9,6 +9,21 @@ It is also possible to create a [Class B]({{< ref "devices/class-b" >}}) or [Cla
 
 <!--more-->
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+DEVICE_ID="dev1"
+FREQUENCY_PLAN="EU_863_870"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+DEV_ADDR="00E4304D"
+APP_SESSION_KEY="A0CAD5A30036DBE03096EB67CA975BAA"
+NWK_SESSION_KEY="B7F3E161BC9D4388E6C788A0C547F255"
+```
+
+Make sure to modify these according to your setup.
+
 ## Class B and Multicast
 
 Since there are no uplinks in multicast groups, there is no MAC layer communication between the end device and {{% tts %}}. Therefore, it is necessary to specify the ping slot periodicity by setting the following parameter:
@@ -24,13 +39,13 @@ When creating a device, you can specify in the Console and CLI whether it's a mu
 CLI example:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 mc1 \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255 \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY \
   --multicast \
   --supports-class-c # or --supports-class-b
 ```
@@ -46,13 +61,13 @@ Please note that a multicast group cannot be converted to a normal unicast devic
 First, create a multicast group:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 mc1 \
-  --frequency-plan-id EU_863_870 \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
-  --session.dev-addr 00E4304D \
-  --session.keys.app-s-key.key A0CAD5A30036DBE03096EB67CA975BAA \
-  --session.keys.nwk-s-key.key B7F3E161BC9D4388E6C788A0C547F255 \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
+  --session.dev-addr $DEV_ADDR \
+  --session.keys.app-s-key.key $APP_SESSION_KEY \
+  --session.keys.nwk-s-key.key $NWK_SESSION_KEY \
   --multicast \
   --supports-class-c
 ```

--- a/doc/content/devices/the-things-uno/_index.md
+++ b/doc/content/devices/the-things-uno/_index.md
@@ -6,6 +6,10 @@ weight:
 
 {{< figure src="TheThingsUno.png" alt="The Things Uno" class="float plain" >}}
 
+This section will help you get started with using The Things Uno on {{% tts %}}.
+
+<!--more-->
+
 **The Things Uno** is based on the [Arduino Leonardo](https://store.arduino.cc/usa/leonardo) (not the Arduino Uno) with an added Microchip LoRaWAN module ([RN2483](https://www.microchip.com/wwwproducts/en/RN2483) or [RN2903](https://www.microchip.com/wwwproducts/en/RN2903)). 
 
 The Things Uno is fully compatible with the Arduino software also known as the Arduino Integrated Development Environment (IDE) and the existing Arduino shields.

--- a/doc/content/gateways/adding-gateways/_index.md
+++ b/doc/content/gateways/adding-gateways/_index.md
@@ -71,19 +71,30 @@ You can also check the **Update from status messages** box if you want to update
 
 ## Adding Gateways using the CLI
 
+We define some user parameters that will be used below:
+
+```bash
+GTW_ID="gtw1" 
+FREQUENCY_PLAN="EU_863_870"
+GTW_EUI="00800000A00009EF"
+USER_ID="admin"
+```
+
+Make sure to modify these according to your setup.
+
 First, list the available frequency plans:
 
 ```bash
-$ ttn-lw-cli gateways list-frequency-plans
+ttn-lw-cli gateways list-frequency-plans
 ```
 
 Then, create the first gateway with the chosen frequency plan:
 
 ```bash
-$ ttn-lw-cli gateways create gtw1 \
-  --user-id admin \
-  --frequency-plan-id EU_863_870 \
-  --gateway-eui 00800000A00009EF \
+ttn-lw-cli gateways create $GTW_ID \
+  --user-id $USER_ID \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --gateway-eui $GTW_EUI \
   --enforce-duty-cycle
 ```
 
@@ -96,9 +107,10 @@ Some gateways require an API Key with Link Gateway Rights to be able to connect 
 Create an API key for the gateway:
 
 ```bash
-$ ttn-lw-cli gateways api-keys create \
-  --name link \
-  --gateway-id gtw1 \
+API_KEY_NAME="API key for connecting my gateway"
+ttn-lw-cli gateways api-keys create \
+  --name $API_KEY_NAME \
+  --gateway-id $GTW_ID \
   --right-gateway-link
 ```
 
@@ -111,11 +123,13 @@ Once you have added your gateway to {{% tts %}}, you can also set the locations 
 Add an antenna and set its location  with:
 
 ```bash
-$ GTW_ID="your-gateway-id"
-$ ttn-lw-cli gateways set $GTW_ID \
-  --antenna.location.latitude 43.84 \
-  --antenna.location.longitude 18.32 \
-  --antenna.location.altitude 500 \
+LAT="43.84"
+LONG="18.32"
+ALT="500"
+ttn-lw-cli gateways set $GTW_ID \
+  --antenna.location.latitude $LAT \
+  --antenna.location.longitude $LONG \
+  --antenna.location.altitude $ALT \
   --antenna.add \
 ```
 
@@ -123,7 +137,7 @@ If you do not mind your gateway's location to be publicly displayed, append the 
 
 You can also set the gateway location to be updated from various sources with the `--antenna.location.source` flag. The source of the location data can be the registry, GPS data, results of the LoRa RSSI geolocation, etc.
 
-Use `ttn-lw-cli gateways set gtw1 --help` command to see the full list of the available location sources and other relatable info. Keep in mind that if you set the alternative location source, the location settings you manually set will be overwritten by the automatic updates from that source.
+Use `ttn-lw-cli gateways set $GTW_ID --help` command to see the full list of the available location sources and other relatable info. Keep in mind that if you set the alternative location source, the location settings you manually set will be overwritten by the automatic updates from that source.
 
 The CLI will return something like:
 
@@ -163,7 +177,8 @@ Keep in mind that if you change the physical location of your gateway, the locat
 A preffered way for adjusting a downlink path gain is setting the gateway antenna gain, instead of changing the gateway Tx power. The following command will set the gateway antenna gain to 3 dB:
 
 ```bash
-$ ttn-lw-cli gateways set $GTW_ID --antenna.gain 3
+GAIN="3"
+ttn-lw-cli gateways set $GTW_ID --antenna.gain $GAIN
 ```
 
 The CLI output will be similar to:

--- a/doc/content/gateways/ciscowirelessgateway/_index.md
+++ b/doc/content/gateways/ciscowirelessgateway/_index.md
@@ -32,13 +32,13 @@ Plug the RJ45 end of the cable in the Console port at the side of the gateway, a
 If you are using MacOS or Linux, connect to the Gateway by opening a terminal and a executing the following commands:
 
 ```bash
-$ ls /dev/tty.usb*
+ls /dev/tty.usb*
 ```
 
 This will display the list of available USB serial devices. Once you have found the one matching the Cisco console, connect using the following command:
 
 ```bash
-$ screen /dev/tty.usbserial-AO001X6M 115200
+screen /dev/tty.usbserial-AO001X6M 115200
 ```
 
 Use PuTTy if you are using Windows.

--- a/doc/content/gateways/gateway-claiming/claim-gateways.md
+++ b/doc/content/gateways/gateway-claiming/claim-gateways.md
@@ -43,7 +43,7 @@ The additional fields that need to be set are
 Replace `<gateway-id>` with the **Gateway ID** of the gateway that you created in prerequisites, and run the following command in the CLI:
 
 ```bash
-$ ttn-lw-cli gateways claim <gateway-eui> --authentication-code <claim-authentication-code> --user-id <user-id> --target-gateway-id [target-gateway-id] --target-cups-uri <target-cups-uri> --current-gateway-key <current-cups-key>
+ttn-lw-cli gateways claim <gateway-eui> --authentication-code <claim-authentication-code> --user-id <user-id> --target-gateway-id [target-gateway-id] --target-cups-uri <target-cups-uri> --current-gateway-key <current-cups-key>
 ```
 
 ### Claim a Gateway (non LoRa Basics Station)
@@ -51,5 +51,5 @@ $ ttn-lw-cli gateways claim <gateway-eui> --authentication-code <claim-authentic
 Replace `<gateway-id>` with the **Gateway ID** of the gateway that you created in prerequisites, and run the following command in the CLI:
 
 ```bash
-$ ttn-lw-cli gateways claim <gateway-eui> --authentication-code <claim-authentication-code> --user-id <user-id> --target-gateway-id [target-gateway-id]
+ttn-lw-cli gateways claim <gateway-eui> --authentication-code <claim-authentication-code> --user-id <user-id> --target-gateway-id [target-gateway-id]
 ```

--- a/doc/content/gateways/gateway-claiming/make-gateways-claimable.md
+++ b/doc/content/gateways/gateway-claiming/make-gateways-claimable.md
@@ -22,13 +22,13 @@ In order for anyone to claim a gateway that is owned by you, you need to authori
 Replace `<gateway-id>` with the **Gateway ID** of the gateway that you created in prerequisites, and run the following command in the CLI:
 
 ```bash
-$ ttn-lw-cli gateways claim authorize <gateway-id>
+ttn-lw-cli gateways claim authorize <gateway-id>
 ```
 
 To undo the action:
 
 ```bash
-$ ttn-lw-cli gateways claim unauthorize <gateway-id>
+ttn-lw-cli gateways claim unauthorize <gateway-id>
 ```
 
 ## Claiming Settings
@@ -40,9 +40,9 @@ This is comprised of a claim authentication code and a validity window. The clai
 The claim authentication code value should be in hex while updating the gateway. Refer to the following example.
 
 ```bash
-$ CAC=ABCD
-$ CAC_IN_HEX=$(echo -n "$CAC" | xxd -ps -u -c 8192)
-$ ttn-lw-cli gateways update <gateway-id> --claim-authentication-code.secret.value $CAC_IN_HEX \
+CAC=ABCD
+CAC_IN_HEX=$(echo -n "$CAC" | xxd -ps -u -c 8192)
+ttn-lw-cli gateways update <gateway-id> --claim-authentication-code.secret.value $CAC_IN_HEX \
   --claim-authentication-code.valid-from 2021-03-01T00:00:00Z \
   --claim-authentication-code.valid-from 2021-03-31T23:59:59Z
 ```

--- a/doc/content/gateways/kerlinkwirnetistation/_index.md
+++ b/doc/content/gateways/kerlinkwirnetistation/_index.md
@@ -22,7 +22,7 @@ Before registering a gateway in {{% tts %}}, you also need to find out the gatew
 To print the gateway's EUI, use the following command: 
 
 ```bash 
-$ grep EUI /tmp/board_info.json
+grep EUI /tmp/board_info.json
 ```
 
 ## Registration
@@ -42,7 +42,7 @@ In order to ease the process of connecting Wirnet iStation to {{% tts %}}, we pr
 To provision the iStation gateway at `<gateway-ip>` to use the configuration of `<gateway-id>` provided by {{% tts %}} deployed at `<server-address>`, execute: 
 
 ```bash
-$ curl -sL 'https://raw.githubusercontent.com/TheThingsNetwork/kerlink-wirnet-firmware/v0.0.3/provision.sh' | bash -s -- <gateway-model> <gateway-ip> <server-address> <gateway-id> <gateway-api-key>
+curl -sL 'https://raw.githubusercontent.com/TheThingsNetwork/kerlink-wirnet-firmware/v0.0.3/provision.sh' | bash -s -- <gateway-model> <gateway-ip> <server-address> <gateway-id> <gateway-api-key>
 ```
 
 To avoid being prompted for `root` user password several times, you may add your SSH public key as authorized for `root` user on the gateway, for example, by `ssh-copy-id root@192.168.4.155`.

--- a/doc/content/gateways/kerlinkwirnetstation/_index.md
+++ b/doc/content/gateways/kerlinkwirnetstation/_index.md
@@ -39,7 +39,7 @@ In case the CPF (Common Packet Forwarder) is not installed on the Wirnet Station
 To provision the Wirnet Station gateway at `<gateway-ip>` to use the configuration of `<gateway-id>` provided by {{% tts %}} deployed at `<server-address>`, execute: 
 
 ```bash
-$ curl -sL 'https://raw.githubusercontent.com/TheThingsNetwork/kerlink-wirnet-firmware/v0.0.3/provision.sh' | bash -s -- <gateway-model> <gateway-ip> <server-address> <gateway-id> <gateway-api-key>
+curl -sL 'https://raw.githubusercontent.com/TheThingsNetwork/kerlink-wirnet-firmware/v0.0.3/provision.sh' | bash -s -- <gateway-model> <gateway-ip> <server-address> <gateway-id> <gateway-api-key>
 ```
 
 To avoid being prompted for `root` user password several times, you may add your SSH public key as authorized for `root` user on the gateway, for example, by `ssh-copy-id root@192.168.4.155`.

--- a/doc/content/gateways/lora-basics-station/cups.md
+++ b/doc/content/gateways/lora-basics-station/cups.md
@@ -62,10 +62,10 @@ Press **Save Changes** to update the gateway settings. When your gateway connect
 We need to configure CUPS in {{% tts %}} to transmit the LNS API key when a gateway connects. Use the following command to do so, replacing `"your-gateway-id"` with your gateway ID in {{% tts %}} and  `"your-lns-api-key"` with the LNS API key you created in the last step:
 
 ```bash
-$ export GTW_ID="your-gateway-id"
-$ export LNS_KEY="your-lns-api-key"
-$ export SECRET=$(echo -n $LNS_KEY | xxd -ps -u -c 8192)
-$ ttn-lw-cli gateways update $GTW_ID --lbs-lns-secret.value $SECRET
+GTW_ID="your-gateway-id"
+LNS_KEY="your-lns-api-key"
+SECRET=$(echo -n $LNS_KEY | xxd -ps -u -c 8192)
+ttn-lw-cli gateways update $GTW_ID --lbs-lns-secret.value $SECRET
 ```
 
 {{< note >}}If you receive an error running `ttn-lw-cli gateways update`, you may need to update the CLI. See instructions in [Installing the CLI]({{< ref "/getting-started/cli/installing-cli" >}}).{{</ note >}}
@@ -120,8 +120,8 @@ This is a file which {{% tts %}} uses to verify the identity of your gateway.
 Use the following commands to create a file called `cups.key`, replacing `"your-cups-api-key"` with the CUPS API key you created above.
 
 ```bash
-$ export CUPS_KEY="your-cups-api-key"
-$ echo "Authorization: Bearer $CUPS_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > cups.key
+CUPS_KEY="your-cups-api-key"
+echo "Authorization: Bearer $CUPS_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > cups.key
 ```
 
 The above command creates a file called `cups.key`, terminated with a Carriage Return Line Feed (`0x0D0A`) character. Upload this file in your gateway as the CUPS key.

--- a/doc/content/gateways/lora-basics-station/lns.md
+++ b/doc/content/gateways/lora-basics-station/lns.md
@@ -54,8 +54,8 @@ This is a file which {{% tts %}} uses to verify the identity of your gateway.
 Use the following command to create a file called `lns.key`, replacing `"your-lns-api-key"` with the LNS API key you created above.
 
 ```bash
-$ export LNS_KEY="your-lns-api-key"
-$ echo "Authorization: Bearer $LNS_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > lns.key
+LNS_KEY="your-lns-api-key"
+echo "Authorization: Bearer $LNS_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > lns.key
 ```
 
 The above command creates a file called `lns.key`, terminated with a Carriage Return Line Feed (`0x0D0A`) character. Upload this file in your gateway as the LNS key.

--- a/doc/content/gateways/mikrotik-knot/_index.md
+++ b/doc/content/gateways/mikrotik-knot/_index.md
@@ -75,7 +75,7 @@ Go to [**Interfaces**](http://192.168.88.1/webfig/#Interfaces), click on **PPP-o
 To test whether a connection with your LTE-M network is established, go to the **Terminal** tab in the RouterOS web interface and run the command:
 
 ```
-$ /interface ppp-client info ppp-out1
+/interface ppp-client info ppp-out1
 ```
 If the gateway is set up correctly, it will respond with a message like:
 

--- a/doc/content/gateways/milesightug6x/_index.md
+++ b/doc/content/gateways/milesightug6x/_index.md
@@ -35,7 +35,7 @@ Connect your machine to the same local network as that of the gateway, and enter
 
 {{< figure src="login.png" alt="Login" >}}
 
-> See [Milesight's official documentation](https://www.milesight-iot.com/documents-download) for more information.
+See [Milesight's official documentation](https://www.milesight-iot.com/documents-download) for more information.
 
 ### Disable Default Server
 

--- a/doc/content/gateways/multitechconduit-mlinux/_index.md
+++ b/doc/content/gateways/multitechconduit-mlinux/_index.md
@@ -47,13 +47,13 @@ After connecting to the gateway, it must be commissioned, or you will not be abl
 To connect the gateway to your network, you must reconfigure it as a DHCP client. After commissioning the device, ssh in using the username and password you set up:
 
 ```bash
-$ ssh username@192.168.2.1
+ssh username@192.168.2.1
 ```
 
 Modify the network configuration file, `/etc/network/interfaces`:
 
 ```bash
-$ sudo nano /etc/network/interfaces
+sudo nano /etc/network/interfaces
 ```
 
 Configure the eth0 peripheral as dhcp, and comment out the static configuration:
@@ -85,10 +85,10 @@ Once the `global_conf.json` file is generated, you will need to add this to your
 Login to your router at its IP address on your local network, and copy the `global_conf.json` contents in to a file at `/var/config/lora/global_conf.json`
 
 ```bash
-$ ssh username@<GATEWAY_IP_ADDRESS>
-$ sudo mkdir /var/config/lora
-$ sudo touch /var/config/lora/global_conf.json
-$ sudo nano /var/config/lora/global_conf.json
+ssh username@<GATEWAY_IP_ADDRESS>
+sudo mkdir /var/config/lora
+sudo touch /var/config/lora/global_conf.json
+sudo nano /var/config/lora/global_conf.json
 ```
 
 Copy in the contents of the `global_conf.json` file you downloaded. While the file is open, change the value of `clksrc` to `0`:
@@ -106,18 +106,18 @@ Multitech devices require a `clksrc` of `0`. Do not skip this step, or your devi
 Finally, edit the configuration settings to start the `lora-packet-forwarder` by default, and disable the `lora-network-server`:
 
 ```bash
-$ /etc/init.d/lora-network-server stop
-$ sudo nano /etc/defaults/lora-network-server
+/etc/init.d/lora-network-server stop
+sudo nano /etc/defaults/lora-network-server
 #ENABLED=”no”
 
-$ sudo nano /etc/defaults/lora-packet-forwarder
+sudo nano /etc/defaults/lora-packet-forwarder
 #ENABLED=”yes”
 ```
 
 Start the packet forwarder, and {{% tts %}} will begin receiving packets from your gateway:
 
 ```bash
-$ sudo /etc/init.d/lora-packet-forwarder start
+sudo /etc/init.d/lora-packet-forwarder start
 ```
 
 ## Troubleshooting

--- a/doc/content/gateways/nasysoutdoorgateway/_index.md
+++ b/doc/content/gateways/nasysoutdoorgateway/_index.md
@@ -23,7 +23,7 @@ Create a gateway by following the instructions for [Adding Gateways]({{< ref "/g
 Find the IP address the gateway. This can be done in various ways. You can connect your machine to the same local network as that of the gateway Ethernet connection and scan for open SSH ports or assign a static IP to the gateway and use that. Once the gateway IP address is found, ssh into it.
 
 ```bash
-$ ssh root@<GatewayIP>
+ssh root@<GatewayIP>
 ```
 
 The default username is **root**, and the default password can be also found in the sticker.
@@ -35,10 +35,10 @@ The Gateway Configuration Server can be used to retrieve a proper `global_conf.j
 Update the configuration files on the gateway with your downloaded `global_conf.json` and restart the packet forwarder:
 
 ```bash
-$ mv /opt/nas-lgw/local_conf.json /opt/nas-lgw/local_conf.json.old
-$ cp global_conf.json /opt/nas-lgw/global_conf.json
+mv /opt/nas-lgw/local_conf.json /opt/nas-lgw/local_conf.json.old
+cp global_conf.json /opt/nas-lgw/global_conf.json
 
-$ systemctl restart nas-lgw
+systemctl restart nas-lgw
 ```
 
 If your configuration was successful, your gateway will connect to {{% tts %}} after a couple of seconds.
@@ -50,7 +50,7 @@ If the gateway does not connect to {{% tts %}} after a few minutes, issue a `reb
 If you still have trouble connecting to {{% tts %}}, then try editing the `gateway_conf` section:
 
 ```bash
-$ vi /opt/nas-lgw/global_conf.json
+vi /opt/nas-lgw/global_conf.json
 ```
 
 Edit the server parameters:
@@ -63,11 +63,11 @@ Edit the server parameters:
 You can access the gateway system logs using journalctl. See `journalctl --help` for details
 
 ```bash
-$ journalctl -f -u nas_lgw -n 1000
+journalctl -f -u nas_lgw -n 1000
 ```
 
 The gateway logs will rotate when they reach about 15M in size, which means that you will generally not be able to access very old logs. At times of dense traffic (e.g. ~1000s of devices) this typically means that you will only have logs for 2-3 hours. If you want to keep historical data (for whatever reason), then you will have to forward the logs to an external server. If you decide to do so, then `netcat` may be useful:
 
 ```bash
-$ journalctl -f | nc server-hostname server-port
+journalctl -f | nc server-hostname server-port
 ```

--- a/doc/content/gateways/tektelickonamicro/_index.md
+++ b/doc/content/gateways/tektelickonamicro/_index.md
@@ -43,7 +43,7 @@ Find the gateway's IP address. This can be done in various ways. You can connect
 Once the gateway IP address is found, SSH into it with the following command:
 
 ```bash
-$ ssh root@<GatewayIP>
+ssh root@<GatewayIP>
 ```
 
 The password for the **root** user can be found on the back panel of the gateway. It is typically a 9 character alphanumeric string starting with **1846XXXXX**.

--- a/doc/content/gateways/tektelickonamicro/lbs.md
+++ b/doc/content/gateways/tektelickonamicro/lbs.md
@@ -18,14 +18,14 @@ Obtain the **ipk/bsp** package by contacting Tektelic's support team. Create an 
 Upload the `Basic-Station-packages-vx.x.x-for-Tektelic-gateways.tar.gz` to the directory `/lib/firmware` on the target gateway and extract it using following command:
 
 ```bash 
-$ tar -C /lib/firmware \
+tar -C /lib/firmware \
 -zxvf /lib/firmware/Basic-Station-packages-vx.x.x-for-Tektelic-gateways.tar.gz
 ```
 
 Add the feed location to the package manager configuration file by using the following command:
 
 ```bash
-$ echo "src/gz bstn file:///lib/firmware/Basic-Station-packages-vx.x.x-for-Tektelic-gateways" \
+echo "src/gz bstn file:///lib/firmware/Basic-Station-packages-vx.x.x-for-Tektelic-gateways" \
 > /etc/opkg/bstn-feed.conf
 ```
 
@@ -48,7 +48,7 @@ Upload the `ipk/bsp` folder to the gateway and extract it in to `/lib/firmware`.
 Add the feed location to the package manager configuration file by using the following command:
 
 ```bash
-$ echo "src/gz bstn file:///lib/firmware/bsp" > /etc/opkg/bstn-feed.conf
+echo "src/gz bstn file:///lib/firmware/bsp" > /etc/opkg/bstn-feed.conf
 ```
 
 Enter the following command:
@@ -68,7 +68,7 @@ opkg install tektelic-bstn curl libcurl4
 Make sure Basic Station is installed by using the following command:
 
 ```bash
-$ opkg list-installed | grep bstn
+opkg list-installed | grep bstn
 ```
 
 The version of the Basic Station package should be displayed.
@@ -76,7 +76,7 @@ The version of the Basic Station package should be displayed.
 Then, make sure Basic Station is running by using the following command:
 
 ```bash
-$ ps aux | grep bstn
+ps aux | grep bstn
 ```
 
 The Basic Station process ID should be displayed.
@@ -100,7 +100,7 @@ By default, CUPS is enabled in Basic Station to connect with {{% tts %}}. If you
 Finally, enter the following command to restart the Basic Station:
 
 ```bash
-$ /etc/init.d/tektelic-bstn restart
+/etc/init.d/tektelic-bstn restart
 ```
 
 Now your Gateway should be able to connect to {{% tts %}}.

--- a/doc/content/gateways/tektelickonamicro/udp.md
+++ b/doc/content/gateways/tektelickonamicro/udp.md
@@ -12,7 +12,7 @@ This section guides you to connect the Tektelic Kona Micro IoT LoRaWAN Gateway t
 Now you can edit the gateway configuration file.
 
 ```bash
-$ vi /etc/default/config.json
+vi /etc/default/config.json
 ```
 
 Press the `i` key on your keyboard to start insert mode. Once finished editing, press `ESC` and enter `:wq` to write the file and quit.
@@ -26,7 +26,7 @@ Edit the server parameters:
 Save the configuration and restart the packet forwarder.
 
 ```bash
-$ /etc/init.d/pkt_fwd restart
+/etc/init.d/pkt_fwd restart
 ```
 
 If your configuration was successful, your gateway will connect to {{% tts %}} after a couple of seconds.
@@ -36,5 +36,5 @@ If your configuration was successful, your gateway will connect to {{% tts %}} a
 If the gateway does not connect to {{% tts %}} after a few minutes, disconnect and reconnect the power supply to power-cycle the gateway. Packet forwarder logs can be observed by SSH-ing into the gateway and running:
 
 ```bash
-$ tail -f /var/log/pkt_fwd.log
+tail -f /var/log/pkt_fwd.log
 ```

--- a/doc/content/gateways/thethingsindoorgateway/_index.md
+++ b/doc/content/gateways/thethingsindoorgateway/_index.md
@@ -116,7 +116,7 @@ For this, you need to authorize your gateways for claiming. This is currently on
 {{< cli-only >}}
 
 ```bash
-$ ttn-lw-cli gateways claim authorize <gateway-id>
+ttn-lw-cli gateways claim authorize <gateway-id>
 ```
 
 Now claim the gateway as described in the [Claiming {{% ttig %}}]({{< ref "#claiming-the-things-indoor-gateway" >}}) section.
@@ -125,7 +125,7 @@ Once complete, make sure to unauthorize the gateway to prevent further claiming.
 
 
 ```bash
-$ ttn-lw-cli gateways claim unauthorize <gateway-id>
+ttn-lw-cli gateways claim unauthorize <gateway-id>
 ```
 
 

--- a/doc/content/gateways/troubleshooting/_index.md
+++ b/doc/content/gateways/troubleshooting/_index.md
@@ -32,8 +32,8 @@ See the [Root Certificates Reference]({{< ref "/reference/root-certificates" >}}
 Use the following commands to generate a `api.key` file which is correctly formatted ({{% lbs %}} requires that `.key` files end with a CRLF character).
 
 ```bash
-$ export API_KEY="your-api-key"
-$ echo "Authorization: Bearer $API_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > api.key
+API_KEY="your-api-key"
+echo "Authorization: Bearer $API_KEY" | perl -p -e 's/\r\n|\n|\r/\r\n/g'  > api.key
 ```
 
 Upload or copy the contents of this file in to your gateway as the **Gateway Key**.

--- a/doc/content/gateways/udp/_index.md
+++ b/doc/content/gateways/udp/_index.md
@@ -42,7 +42,7 @@ Open the command prompt in Windows or any Linux terminal to run a curl command (
 Make sure you replace `thethings.example.com` with your server address, `{GATEWAY_ID}` with your Gateway ID, and `{GATEWAY_API_KEY}` with the API key you generated:
 
 ```bash
-$ curl -XGET \
+curl -XGET \
     "https://thethings.example.com/api/v3/gcs/gateways/{GATEWAY_ID}/semtechudp/global_conf.json" \
     -H "Authorization: Bearer {GATEWAY_API_KEY}" > global_conf.json
 ```

--- a/doc/content/getting-started/api/_index.md
+++ b/doc/content/getting-started/api/_index.md
@@ -36,7 +36,7 @@ Set the `User-Agent` HTTP header containing your integration name and version. T
 Fields may be specified in HTTP requests by appending them as query string parameters. For example, to request the `name`, `description`, and `locations` of devices in an `EndDeviceRegistry.Get` request, add these fields to the `field_mask` field. To get this data for device `dev1` in application `app1`:
 
 ```bash
-$ curl --location \
+curl --location \
   --header "Authorization: Bearer NNSXS.XXXXXXXXX" \
   --header 'Accept: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -46,7 +46,7 @@ $ curl --location \
 The same request in tenant `tenant1` on a multi-tenant deployment:
 
 ```bash
-$ curl --location \
+curl --location \
   --header "Authorization: Bearer NNSXS.XXXXXXXXX" \
   --header 'Accept: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -60,7 +60,7 @@ Fields may also be specified as a JSON object in a POST request.
 To get a stream of events for device `dev1` in application `app1` :
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Accept: text/event-stream' \
   --header 'Content-Type: application/json' \
@@ -84,7 +84,7 @@ See [here](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/U
 To schedule a downlink, you may use the `DownlinkQueuePush` or `DownlinkQueueReplace` endpoints of the [Application Server API]({{< ref "reference/api/application_server#the-appas-service" >}}). For example, to schedule a downlink queue push to device `dev1` in application `app1`:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -101,7 +101,7 @@ $ curl --location \
 To schedule a human readable downlink to the same device using a downlink [Payload Formatter]({{< ref "integrations/payload-formatters" >}}):
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -128,7 +128,7 @@ If you want to do something like registering a device directly via the API, you 
 To register a device `newdev1` in application `app1`, first, register the `DevEUI`, `JoinEUI` and cluster addresses in the Identity Server. This is also where you register a friendly name, description, attributes, location, and more - see all fields in the [API Reference]({{< ref "reference/api" >}}):
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
@@ -161,7 +161,7 @@ $ curl --location \
 Register LoRaWAN settings in the Network Server:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -196,7 +196,7 @@ $ curl --location \
 Register the `DevEUI` and `JoinEUI` in the Application Server:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
   --request PUT \
@@ -222,7 +222,7 @@ $ curl --location \
 Finally, for OTAA devices, register the `DevEUI`, `JoinEUI`, cluster addresses, and keys in the Join Server:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
   --request PUT \

--- a/doc/content/getting-started/aws/ami/post-deployment/_index.md
+++ b/doc/content/getting-started/aws/ami/post-deployment/_index.md
@@ -61,13 +61,13 @@ SSH access is possible only via the IP addresses set using the **Restrict SSH Ac
 For example, you can use the OpenSSH client via the terminal and login using:
 
 ```bash
-$ ssh -i <private-key-file> ec2-user@PublicIP
+ssh -i <private-key-file> ec2-user@PublicIP
 ```
 
 Upon accessing the machine, navigate to the `tti` directory:
 
 ```bash
-$ cd /tti
+cd /tti
 ```
 
 This directory is structured as follows:
@@ -86,7 +86,7 @@ This directory is structured as follows:
 The Things Enterprise Stack binary is run as a `systemd` service. In order to check the logs, run the following:
 
 ```bash
-$ sudo journalctl -f -u lorawan-stack.service
+sudo journalctl -f -u lorawan-stack.service
 ```
 
 ## Routing LoRaWAN Traffic

--- a/doc/content/getting-started/aws/ami/troubleshooting/_index.md
+++ b/doc/content/getting-started/aws/ami/troubleshooting/_index.md
@@ -23,32 +23,37 @@ You can SSH into the EC2 machine using the public IP output value.
 
 Log in AWS Console and open the CloudFormation resource and click on your recently deployed stack. Navigate to the **Outputs** tab and copy the value of the **PublicIP** field. 
 
-Now, using the private key of the **SSH Key** value that you entered during deployment, you can SSH into the machine using
+Now, using the private key of the **SSH Key** value that you entered during deployment, you can SSH into the machine using:
+
 ```bash
-$ ssh -i <path-to-private-key> ec2-user@<PublicIP>
+ssh -i <path-to-private-key> ec2-user@<PublicIP>
 ```
 
 ### How can I see logs of {{% tts %}}?
 
-{{% tts %}} binary runs as a `systemd` service. In order to access the logs, SSH into the machine as described above and use the following command.
+{{% tts %}} binary runs as a `systemd` service. In order to access the logs, SSH into the machine as described above and use the following command:
 ```bash
-  $ sudo journalctl -f -u lorawan-stack.service
+sudo journalctl -f -u lorawan-stack.service
 ```
 
 ### How do I see more detailed debug logs of {{% tts %}}?
 
 By default, {{% tts %}} does not log detailed `DEBUG` messages. In order to enable this, SSH into the EC2 instance as described above and add the following lines to the file `/tti/lorawan-stack/config.yml` using an editor such as `nano`.
+
 ```bash
 log:
   level: debug
 ```
-- Restart the service for this to take effect.
+Restart the service for this to take effect:
+
 ```bash
-$ sudo systemctl restart lorawan-stack.service
+sudo systemctl restart lorawan-stack.service
 ```
-- The debug logs can be read using the `journalctl`, same as above:
+
+The debug logs can be read using the `journalctl`, same as above:
+
 ```bash
-$ sudo journalctl -f -u lorawan-stack.service
+sudo journalctl -f -u lorawan-stack.service
   ```
 
 ### My Gateway doesn't connect. What do I do?

--- a/doc/content/getting-started/aws/ecs/database-operations/_index.md
+++ b/doc/content/getting-started/aws/ecs/database-operations/_index.md
@@ -25,7 +25,7 @@ Under **Advanced Options** > **Container Overrides** > `ttes`, set the **Command
 Alternatively, you can run ops commands using the AWS CLI:
 
 ```bash
-$ aws ecs run-task \
+aws ecs run-task \
   --task-definition TASK_DEFINITION \
   --cluster CLUSTER_NAME \
   --launch-type EC2 \

--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -119,8 +119,8 @@ In addition to the re-used parameters (see [Prerequisites]({{< relref "../prereq
 After deploying the `2-4b-routing-s3` template, you need to upload the interop configuration to the interop bucket. For details on this configuration, see the [Interoperability Repository reference]({{< ref "/reference/interop-repository" >}}). If you do not have such configuration, you can upload an empty configuration file:
 
 ```bash
-$ touch config.yml
-$ aws s3 cp config.yml s3://${InteropConfigBucket}/config.yml
+touch config.yml
+aws s3 cp config.yml s3://${InteropConfigBucket}/config.yml
 ```
 
 {{< note >}} If you did not set a bucket name, see the `InteropConfigBucket` output of the `2-4b-routing-s3` stack for the name of the bucket. {{</ note >}}
@@ -156,7 +156,7 @@ For multi-tenant deployments that use tenant billing through Stripe (see the [St
 For the **Gateway Secrets Encryption Key Value** parameter, provide an AES-128 Key in Base64. The following command can be used to randomly generate one:
 
 ```bash
-$ openssl rand -base64 16
+openssl rand -base64 16
 ```
 
 ## Configuration
@@ -189,10 +189,10 @@ Under **Amazon ECS ARN and resource ID settings** the **new ARN and resource ID 
 Alternatively, you can configure these settings for the entire AWS account using the AWS CLI:
 
 ```bash
-$ aws ecs put-account-setting-default --name serviceLongArnFormat --value enabled --region $AWS_REGION
-$ aws ecs put-account-setting-default --name taskLongArnFormat --value enabled --region $AWS_REGION
-$ aws ecs put-account-setting-default --name containerInstanceLongArnFormat --value enabled --region $AWS_REGION
-$ aws ecs put-account-setting-default --name awsvpcTrunking --value enabled --region $AWS_REGION
+aws ecs put-account-setting-default --name serviceLongArnFormat --value enabled --region $AWS_REGION
+aws ecs put-account-setting-default --name taskLongArnFormat --value enabled --region $AWS_REGION
+aws ecs put-account-setting-default --name containerInstanceLongArnFormat --value enabled --region $AWS_REGION
+aws ecs put-account-setting-default --name awsvpcTrunking --value enabled --region $AWS_REGION
 ```
 
 {{< note >}} These settings need to be applied in **each** AWS region where you want to deploy a cluster. {{</ note >}}

--- a/doc/content/getting-started/aws/ecs/interop/_index.md
+++ b/doc/content/getting-started/aws/ecs/interop/_index.md
@@ -4,9 +4,11 @@ description: "LoRaWAN Backend Interfaces"
 weight: 3
 ---
 
-{{% tts %}} exposes the Join Server API defined by LoRaWAN Backend Interfaces 1.0 and 1.1. This is used for interoperability between LoRaWAN networks. The functionality can be exposed either by the Join Server or by the Identity Server, but not both at once.
+{{% tts %}} exposes the Join Server API defined by LoRaWAN Backend Interfaces 1.0 and 1.1. This is used for interoperability between LoRaWAN networks.
 
-Join Server is capable of handling the join flow, that is `HomeNSReq`, `JoinReq` and `AppSKeyReq` requests. Identity Server can only answer to `HomeNSReq`. Typically, you should enable interoperability if you want to use device activations through Packet Broker. You can use Join Server interoperability if you want to expose the entire join flow to other LoRaWAN network servers.
+<!--more-->
+
+The functionality can be exposed either by the Join Server or by the Identity Server, but not both at once. Join Server is capable of handling the join flow, that is `HomeNSReq`, `JoinReq` and `AppSKeyReq` requests. Identity Server can only answer to `HomeNSReq`. Typically, you should enable interoperability if you want to use device activations through Packet Broker. You can use Join Server interoperability if you want to expose the entire join flow to other LoRaWAN network servers.
 
 # TLS
 

--- a/doc/content/getting-started/cli/configuring-cli/_index.md
+++ b/doc/content/getting-started/cli/configuring-cli/_index.md
@@ -21,25 +21,25 @@ To generate the CLI configuration file, use the following command in your termin
 If using {{% tts %}} Community Edition, use the following command as per your regional `cluster`:
 
 ```bash
-$ ttn-lw-cli use <eu1/au1/nam1>.cloud.thethings.network
+ttn-lw-cli use <eu1/au1/nam1>.cloud.thethings.network
 ```
 
 or on Windows, this would be:
 
 ```bash
-$ ttn-lw-cli.exe use <eu1/au1/nam1>.cloud.thethings.network
+ttn-lw-cli.exe use <eu1/au1/nam1>.cloud.thethings.network
 ```
 
 If you are using {{% tts %}} Cloud use the following command with your `tenant id` and regional `cluster`. 
 
 ```bash
-$ ttn-lw-cli use <tenant_id>.<eu1/au1/nam1/>.cloud.thethings.industries
+ttn-lw-cli use <tenant_id>.<eu1/au1/nam1/>.cloud.thethings.industries
 ```
 
 If you are hosting your own deployment, use the following, replacing `thethings.example.com` with your [server address]({{< ref "getting-started/server-addresses" >}}):
 
 ```bash
-$ ttn-lw-cli use thethings.example.com
+ttn-lw-cli use thethings.example.com
 ```
 
 {{< /tabs/tab >}}
@@ -49,13 +49,13 @@ $ ttn-lw-cli use thethings.example.com
 If you are hosting your own deployment, use the following, replacing `thethings.example.com` with your [server address]({{< ref "getting-started/server-addresses" >}}):
 
 ```bash
-$ tti-lw-cli use thethings.example.com
+tti-lw-cli use thethings.example.com
 ```
 
 or on Windows:
 
 ```bash
-$ tti-lw-cli.exe use thethings.example.com
+tti-lw-cli.exe use thethings.example.com
 ```
 
 {{< /tabs/tab >}}
@@ -81,7 +81,7 @@ Once you have the configuration file, proceed to [Step 2 - Configure CLI](#step-
 If the deployment is using a CA that is not already trusted by your system, use the `--fetch-ca` flag to also connect to the server and retrieve the CA required for establishing secure communication, i.e:
 
 ```bash
-$ tti-lw-cli use thethings.example.com --fetch-ca
+tti-lw-cli use thethings.example.com --fetch-ca
 ```
 
 If you are using a [custom certificate authority]({{< ref "/getting-started/installation/certificates#custom-certificate-authority" >}}), you will have to specify the path to the CA file with `--ca="/path/to/ca.pem"` flag when running the CLI.
@@ -149,19 +149,19 @@ set TTN_LW_CONFIG=/path/to/.ttn-lw-cli.yml
 To check if configuration is being properly loaded, use the following command:
 
 ```bash
-$ ttn-lw-cli config
+ttn-lw-cli config
 ```
 
 or on Windows:
 
 ```bash
-$ ttn-lw-cli.exe config
+ttn-lw-cli.exe config
 ```
 
 or for Enterprise deployments:
 
 ```bash
-$ tti-lw-cli config
+tti-lw-cli config
 ```
 
 ## Step 3 - Login

--- a/doc/content/getting-started/cli/installing-cli/_index.md
+++ b/doc/content/getting-started/cli/installing-cli/_index.md
@@ -29,13 +29,13 @@ On macOS, Homebrew is the recommended package manager. See the [official Homebre
 Once Homebrew is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 
 ```bash
-$ brew install TheThingsNetwork/lorawan-stack/ttn-lw-cli
+brew install TheThingsNetwork/lorawan-stack/ttn-lw-cli
 ```
 
 To upgrade the CLI if it is already installed, use:
 
 ```bash
-$ brew upgrade TheThingsNetwork/lorawan-stack/ttn-lw-cli
+brew upgrade TheThingsNetwork/lorawan-stack/ttn-lw-cli
 ```
 
 Once installation is complete, you can run the CLI using `ttn-lw-cli` in your terminal.
@@ -47,13 +47,13 @@ Once installation is complete, you can run the CLI using `ttn-lw-cli` in your te
 Once Homebrew is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 
 ```bash
-$ brew install TheThingsIndustries/lorawan-stack/tti-lw-cli
+brew install TheThingsIndustries/lorawan-stack/tti-lw-cli
 ```
 
 To upgrade the CLI if it is already installed, use:
 
 ```bash
-$ brew upgrade TheThingsIndustries/lorawan-stack/tti-lw-cli
+brew upgrade TheThingsIndustries/lorawan-stack/tti-lw-cli
 ```
 
 Now you can run the CLI using `tti-lw-cli` in your terminal.
@@ -73,14 +73,14 @@ On Linux, `snap` is the recommended package manager. See the [official `snap` do
 Once `snap` is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 
 ```bash
-$ sudo snap install ttn-lw-stack
-$ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
+sudo snap install ttn-lw-stack
+sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
 ```
 
 To upgrade the CLI if it is already installed, use:
 
 ```bash
-$ sudo snap refresh ttn-lw-stack
+sudo snap refresh ttn-lw-stack
 ```
 
 Once installation is complete, you can run the CLI using `ttn-lw-cli` in your terminal.
@@ -92,14 +92,14 @@ Once installation is complete, you can run the CLI using `ttn-lw-cli` in your te
 Once `snap` is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 
 ```bash
-$ sudo snap install tti-lw-stack
-$ sudo snap alias tti-lw-stack.tti-lw-cli tti-lw-cli
+sudo snap install tti-lw-stack
+sudo snap alias tti-lw-stack.tti-lw-cli tti-lw-cli
 ```
 
 To upgrade the CLI if it is already installed, use:
 
 ```bash
-$ sudo snap refresh tti-lw-stack
+sudo snap refresh tti-lw-stack
 ```
 
 Now you can run the CLI using `tti-lw-cli` in your terminal.
@@ -143,13 +143,13 @@ Supported shells are `bash`, `zsh`, `fish` and `powershell`.
 Use `ttn-lw-cli complete` to generate an auto-completion script for the `ttn-lw-cli` command while specifying the shell you are using:
 
 ```bash
-$ ttn-lw-cli complete --shell bash --executable ttn-lw-cli > ttn-lw-cli-autocomplete
+ttn-lw-cli complete --shell bash --executable ttn-lw-cli > ttn-lw-cli-autocomplete
 ```
 
 Now you need to source the generated file to enable auto-completion:
 
 ```bash
-$ . ./ttn-lw-cli-autocomplete
+. ./ttn-lw-cli-autocomplete
 ```
 
 Alternatively, put in a default directory so that it gets loaded automatically (this directory depends on your operating system and your shell).
@@ -157,7 +157,7 @@ Alternatively, put in a default directory so that it gets loaded automatically (
 For example, for `bash`, this directory is typically `/etc/bash_completion.d/`:
 
 ```bash
-$ sudo cp ./ttn-lw-cli-autocomplete /etc/bash_completion.d/
+sudo cp ./ttn-lw-cli-autocomplete /etc/bash_completion.d/
 ```
 
 ### Windows
@@ -165,9 +165,9 @@ $ sudo cp ./ttn-lw-cli-autocomplete /etc/bash_completion.d/
 Generating and sourcing an auto-completion PowerShell script on Windows is slightly different. In addition to `ttn-lw-cli` being replaced with `ttn-lw-cli.exe`, `ttn-lw-cli-autocomplete` needs to be replaced with `ttn-lw-cli-autocomplete.ps1` as follows:
 
 ```bash
-$ ttn-lw-cli.exe complete --shell powershell --executable ttn-lw-cli.exe > ttn-lw-cli-autocomplete.ps1
+ttn-lw-cli.exe complete --shell powershell --executable ttn-lw-cli.exe > ttn-lw-cli-autocomplete.ps1
 
-$ . ./ttn-lw-cli-autocomplete.ps1
+. ./ttn-lw-cli-autocomplete.ps1
 ```
 
 ## Configuring the CLI

--- a/doc/content/getting-started/cli/login/_index.md
+++ b/doc/content/getting-started/cli/login/_index.md
@@ -15,13 +15,13 @@ The CLI needs to be logged on in order to create gateways, applications, devices
 {{< tabs/tab "Cloud, Community Edition, and Open Source" >}}
 
 ```bash
-$ ttn-lw-cli login
+ttn-lw-cli login
 ```
 
 or on Windows:
 
 ```bash
-$ ttn-lw-cli.exe login
+ttn-lw-cli.exe login
 ```
 
 {{< /tabs/tab >}}
@@ -29,13 +29,13 @@ $ ttn-lw-cli.exe login
 {{< tabs/tab "Enterprise" >}}
 
 ```bash
-$ tti-lw-cli login
+tti-lw-cli login
 ```
 
 or on Windows:
 
 ```bash
-$ tti-lw-cli.exe login
+tti-lw-cli.exe login
 ```
 
 {{< /tabs/tab >}}

--- a/doc/content/getting-started/cli/troubleshooting.md
+++ b/doc/content/getting-started/cli/troubleshooting.md
@@ -40,7 +40,7 @@ You can also run the CLI with the `--fetch-ca` flag which will make sure to conn
 Many CLI commands require that a user or organization is set to grant permissions over an entity. For example, to create an application:
 
 ```bash
-$ ttn-lw-cli applications create app1 --user-id user1
+ttn-lw-cli applications create <application-id> --user-id <user-id>
 ```
 
 ## Permission Denied

--- a/doc/content/getting-started/cloud-hosted/tti-join-server/activate-devices-cloud-hosted.md
+++ b/doc/content/getting-started/cloud-hosted/tti-join-server/activate-devices-cloud-hosted.md
@@ -23,7 +23,7 @@ The Things Join Server is a LoRaWAN Join Server. Learn how to activate devices o
 Use the command-line interface (CLI) configuration file with Cloud cluster. 
 
 ```bash
-$ ttn-lw-cli login
+ttn-lw-cli login
 ```
 
 ## Register
@@ -37,14 +37,14 @@ When registering the devices on a Network Server and Application Server, you nee
    
 List the supported LoRaWAN versions, regional parameters versions, frequency plans and other options with:
 ```bash
-$ ttn-lw-cli end-devices list-frequency-plans
-$ ttn-lw-cli end-devices set --help
+ttn-lw-cli end-devices list-frequency-plans
+ttn-lw-cli end-devices set --help
 ```
 
 To register the device in application `test-app` with device ID `eui-0004a310001ff9e0`:
 
 ```bash
-$ ttn-lw-cli end-devices set test-app eui-0004a310001ff9e0 \
+ttn-lw-cli end-devices set test-app eui-0004a310001ff9e0 \
   --net-id 000013 \
   --lorawan-version 1.0.2 \
   --lorawan-phy-version 1.0.2-b \

--- a/doc/content/getting-started/cloud-hosted/tti-join-server/register-devices.md
+++ b/doc/content/getting-started/cloud-hosted/tti-join-server/register-devices.md
@@ -25,7 +25,7 @@ Learn more about [obtaining a IEEE MAC Address Block](https://standards.ieee.org
 Use the command-line interface (CLI) configuration file with Join Server only. 
 
 ```bash
-$ ttn-lw-cli login
+ttn-lw-cli login
 ```
 
 ## Register
@@ -39,7 +39,7 @@ It is recommended to provision the LoRaWAN 1.1.x NwkKey for future compliance. T
 To register a LoRaWAN 1.0.x device in application `test-app`, device ID `test-device`, AppEUI `70B3D57ED0000000` and DevEUI `0004A310001FF9E0` and an AppKey:
 
 ```bash
-$ ttn-lw-cli end-devices create test-app test-device \
+ttn-lw-cli end-devices create test-app test-device \
   --app-eui 70B3D57ED0000000 \
   --dev-eui 0004A310001FF9E0 \
   --root-keys.app-key.key D3FD8EEED7E8880025CC63D5E8E1D7FB
@@ -79,7 +79,7 @@ $ ttn-lw-cli end-devices create test-app test-device \
 To register a LoRaWAN 1.1.x device in application `test-app`, device ID `test-device`, JoinEUI `70B3D57ED0000000` and DevEUI `0004A310001FF9E0` and an AppKey:
 
 ```bash
-$ ttn-lw-cli end-devices create test-app test-device \
+ttn-lw-cli end-devices create test-app test-device \
   --join-eui 70B3D57ED0000000 \
   --dev-eui 0004A310001FF9E0 \
   --root-keys.app-key.key D3FD8EEED7E8880025CC63D5E8E1D7FB \

--- a/doc/content/getting-started/events/_index.md
+++ b/doc/content/getting-started/events/_index.md
@@ -24,7 +24,9 @@ See the following video from [The Things Network youtube channel](https://youtu.
 To follow your gateway `gtw1` and application `app1` events at the same time:
 
 ```bash
-$ ttn-lw-cli events subscribe --gateway-id gtw1 --application-id app1
+GTW_ID="gtw1"
+APP_ID="app1"
+ttn-lw-cli events subscribe --gateway-id $GTW_ID --application-id $APP_ID
 ```
 
 ## Subscribe with HTTP
@@ -32,7 +34,7 @@ $ ttn-lw-cli events subscribe --gateway-id gtw1 --application-id app1
 You can get streaming events with `curl`. For this, you need an API key for the entities you want to watch, for example:
 
 ```bash
-$ ttn-lw-cli users api-key create \
+ttn-lw-cli users api-key create \
   --user-id admin \
   --right-application-all \
   --right-gateway-all
@@ -41,7 +43,7 @@ $ ttn-lw-cli users api-key create \
 With the created API key:
 
 ```bash
-$ curl https://thethings.example.com/api/v3/events \
+curl https://thethings.example.com/api/v3/events \
   -X POST \
   -H "Authorization: Bearer NNSXS.BR55PTYILPPVXY.." \
   -H "Accept: text/event-stream" \

--- a/doc/content/getting-started/installation/certificates.md
+++ b/doc/content/getting-started/installation/certificates.md
@@ -15,8 +15,8 @@ In this guide, we show you how to request a free, trusted certificate from [Let'
 {{% tts %}} can be configured to automatically retrieve and update Let's Encrypt certificates. Assuming you followed the [configuration]({{< relref "configuration" >}}) steps, create an `acme` directory where {{% tts %}} can store the certificate data:
 
 ```bash
-$ mkdir ./acme
-$ sudo chown 886:886 ./acme
+mkdir ./acme
+sudo chown 886:886 ./acme
 ```
 
 {{< warning >}} `886` is the `UID` and the `GID` of the user that runs {{% tts %}} in the Docker container. If you don't set these permissions, you may encounter an error resembling `open /var/lib/acme/acme_account+key<...>: permission denied`. {{</ warning >}}
@@ -54,7 +54,7 @@ You will also need to comment out the Let's Encrypt section of `ttn-lw-stack-doc
 If you want to use the certificate (`cert.pem`) and key (`key.pem`) that you already have, you also need to set these permissions.
 
 ```bash
-$ sudo chown 886:886 ./cert.pem ./key.pem
+sudo chown 886:886 ./cert.pem ./key.pem
 ```
 
 {{< warning >}} If you don't set these permissions, you may encounter an error resembling `/run/secrets/key.pem: permission denied`. {{</ warning >}}
@@ -89,7 +89,7 @@ Write the configuration for your CA to `ca.json`:
 Then use the following command to generate the CA key and certificate:
 
 ```bash
-$ cfssl genkey -initca ca.json | cfssljson -bare ca
+cfssl genkey -initca ca.json | cfssljson -bare ca
 ```
 
 Now write the configuration for your certificate to `cert.json`:
@@ -108,7 +108,7 @@ Now write the configuration for your certificate to `cert.json`:
 Then, run the following command to generate the server key and certificate:
 
 ```bash
-$ cfssl gencert -ca ca.pem -ca-key ca-key.pem cert.json | cfssljson -bare cert
+cfssl gencert -ca ca.pem -ca-key ca-key.pem cert.json | cfssljson -bare cert
 ```
 
 The next steps assume the certificate key is called `key.pem`, so you'll need to rename `cert-key.pem` to `key.pem`.

--- a/doc/content/getting-started/installation/running-the-stack.md
+++ b/doc/content/getting-started/installation/running-the-stack.md
@@ -13,13 +13,13 @@ Begin by opening a terminal prompt in the same directory as your `docker-compose
 The first time {{% tts %}} is started, it requires some initialization. Start by pulling the Docker images:
 
 ```bash
-$ docker-compose pull
+docker-compose pull
 ```
 
 Next, you need to initialize the database of the Identity Server:
 
 ```bash
-$ docker-compose run --rm stack is-db init
+docker-compose run --rm stack is-db init
 ```
 
 If you receive an error running {{% tts %}}, make sure a {{% tts %}} container isn't already running. Use `docker ps` to see running containers.
@@ -27,13 +27,13 @@ If you receive an error running {{% tts %}}, make sure a {{% tts %}} container i
 For the Storage Integration available in {{% tts %}} Enterprise, the database of the Application Server needs to be initialized as well:
 
 ```bash
-$ docker-compose run --rm stack storage-db init
+docker-compose run --rm stack storage-db init
 ```
 
 {{% tts %}} Enterprise requires a tenant to be present, even if multi-tenancy is not included in the license. You create a tenant with:
 
 ```bash
-$ docker-compose run --rm stack is-db create-tenant
+docker-compose run --rm stack is-db create-tenant
 ```
 
 This will take the `tenancy.default-id` Tenant ID from the [configuration]({{< relref "configuration" >}}) in `ttn-lw-stack-docker.yml`. To specify another Tenant ID, use the `--id` parameter.
@@ -41,7 +41,7 @@ This will take the `tenancy.default-id` Tenant ID from the [configuration]({{< r
 Next, an initial `admin` user has to be created. Make sure to give it a good password.
 
 ```bash
-$ docker-compose run --rm stack is-db create-admin-user \
+docker-compose run --rm stack is-db create-admin-user \
   --id admin \
   --email your@email.com
 ```
@@ -49,7 +49,7 @@ $ docker-compose run --rm stack is-db create-admin-user \
 Then the command-line interface needs to be registered as an OAuth client:
 
 ```bash
-$ docker-compose run --rm stack is-db create-oauth-client \
+docker-compose run --rm stack is-db create-oauth-client \
   --id cli \
   --name "Command Line Interface" \
   --owner admin \
@@ -61,9 +61,9 @@ $ docker-compose run --rm stack is-db create-oauth-client \
 Afterwards, the same needs to be done for the Console. If running a multi-tenant environment, use option `--tenant-id NULL` to register the OAuth client for all tenants. For `--secret`, make sure to enter the same value as you set for `console.oauth.client-secret` in the `ttn-lw-stack-docker.yml` file in the [Configuration]({{< relref "configuration" >}}) step. 
 
 ```bash
-$ CONSOLE_SECRET="your-console-secret"
-$ SERVER_ADDRESS="your-server-address"
-$ docker-compose run --rm stack is-db create-oauth-client \
+CONSOLE_SECRET="your-console-secret"
+SERVER_ADDRESS="your-server-address"
+docker-compose run --rm stack is-db create-oauth-client \
   --id console \
   --name "Console" \
   --owner admin \
@@ -79,7 +79,7 @@ $ docker-compose run --rm stack is-db create-oauth-client \
 Start {{% tts %}} with:
 
 ```bash
-$ docker-compose up
+docker-compose up
 ```
 
 This starts the stack, so you will see the stack logs being printed to your terminal. You can also start the stack in detached mode by adding `-d` to the command above. In that case you can get logs with [`docker-compose logs`](https://docs.docker.com/compose/reference/logs/).

--- a/doc/content/getting-started/migrating/gateway-migration.md
+++ b/doc/content/getting-started/migrating/gateway-migration.md
@@ -12,7 +12,7 @@ Migrating gateways to {{% tts %}} is an easy, two step process.
 
 Add the Gateway in the {{% tts %}}. 
 
-> For detailed instructions on adding gateways to {{% tts %}} using the CLI or Console, see [Adding Gateways]({{< ref "gateways/adding-gateways" >}}).
+For detailed instructions on adding gateways to {{% tts %}} using the CLI or Console, see [Adding Gateways]({{< ref "gateways/adding-gateways" >}}).
 
 ### Step 2
 

--- a/doc/content/getting-started/migrating/import-devices.md
+++ b/doc/content/getting-started/migrating/import-devices.md
@@ -47,7 +47,7 @@ To complete these steps, you need the have the latest version of `ttn-lw-cli` in
 To import `devices.json` file in {{% tts %}}, run the following command with `ttn-lw-cli`:
 
 ```bash
-$ ttn-lw-cli end-devices create --application-id "imported-application" < devices.json
+ttn-lw-cli end-devices create --application-id <application-id> < devices.json
 ```
 
 This will import your devices in {{% tts %}}. In case any device import fails, you will see a relevant error message at the end of the output.

--- a/doc/content/getting-started/migrating/migrate-from-chirpstack.md
+++ b/doc/content/getting-started/migrating/migrate-from-chirpstack.md
@@ -18,17 +18,17 @@ This section contains instructions on how to migrate end devices from ChirpStack
 First, configure the environment with the following variables modified according to your setup. Navigate to the folder where you installed `ttn-lw-migrate` and execute:
 
 ```bash
-$ export CHIRPSTACK_API_URL="localhost:8080"    # ChirpStack Application Server URL
-$ export CHIRPSTACK_API_TOKEN="7F0as987e61..."  # ChirpStack API key
-$ export JOIN_EUI="0101010102020203"            # Set The Things Stack JoinEUI for exported devices
-$ export FREQUENCY_PLAN_ID="EU_863_870"         # Set The Things Stack FrequencyPlanID for exported devices
-$ export CHIRPSTACK_API_INSECURE=0              # Set to 1 if not using TLS on ChirpStack
+export CHIRPSTACK_API_URL="localhost:8080"    # ChirpStack Application Server URL
+export CHIRPSTACK_API_TOKEN="7F0as987e61..."  # ChirpStack API key
+export JOIN_EUI="0101010102020203"            # Set The Things Stack JoinEUI for exported devices
+export FREQUENCY_PLAN_ID="EU_863_870"         # Set The Things Stack FrequencyPlanID for exported devices
+export CHIRPSTACK_API_INSECURE=0              # Set to 1 if not using TLS on ChirpStack
 ```
 
 If using Windows OS, replace `export` with `set` and remove the double-quotes in commands above. For example, you would use:
 
 ```bash
-$ set CHIRPSTACK_API_TOKEN=7F0as987e61...
+set CHIRPSTACK_API_TOKEN=7F0as987e61...
 ```
 
 `JoinEUI` and `FrequencyPlanID` have to be set because ChirpStack does not store these variables. See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) for a full list of frequency plans supported by {{% tts %}} (and their IDs).
@@ -40,7 +40,7 @@ With `ttn-lw-migrate` tool you can easily export a single or multiple end device
 To export a single end device to a `devices.json` file:
 
 ```bash
-$ ttn-lw-migrate --source chirpstack device "0102030405060701" > devices.json
+ttn-lw-migrate --source chirpstack device "0102030405060701" > devices.json
 ```
 
 To export multiple end devices, create a `devices.txt` file containing one `DevEUI` per line:
@@ -57,7 +57,7 @@ To export multiple end devices, create a `devices.txt` file containing one `DevE
 To export multiple end devices to a `devices.json` file:
 
 ```bash
-$ ttn-lw-migrate --source chirpstack device < devices.txt > devices.json
+ttn-lw-migrate --source chirpstack device < devices.txt > devices.json
 ```
 
 ## Export Applications
@@ -67,13 +67,13 @@ You can also export applications with `ttn-lw-migrate` tool using their names fr
 To export end devices from a single application:
 
 ```bash
-$ ttn-lw-migrate --source chirpstack application "app1" > applications.json
+ttn-lw-migrate --source chirpstack application "app1" > applications.json
 ```
 
 To export end devices from multiple applications to an `applications.json` file, you need to create a `.txt` file containing one application name per line and run the following command in your terminal:
 
 ```bash
-$ ttn-lw-migrate --source chirpstack application < applications.txt > applications.json
+ttn-lw-migrate --source chirpstack application < applications.txt > applications.json
 ```
 
 {{< warning >}} 

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/_index.md
@@ -17,9 +17,9 @@ This section refers to migrating end devices to {{% tts %}} using [`ttn-lw-migra
 First, you need to configure a few environmental variables. Navigate to the folder where you installed `ttn-lw-migrate` and execute the following, replacing `ttn-v2-application-ID`, `ttn-v2-application-access-key`, and the `FREQUENCY_PLAN_ID` value:
 
 ```bash
-$ export TTNV2_APP_ID="ttn-v2-application-ID"
-$ export TTNV2_APP_ACCESS_KEY="ttn-v2-application-access-key"
-$ export FREQUENCY_PLAN_ID="EU_863_870_TTN"
+export TTNV2_APP_ID="ttn-v2-application-ID"
+export TTNV2_APP_ACCESS_KEY="ttn-v2-application-access-key"
+export FREQUENCY_PLAN_ID="EU_863_870_TTN"
 ```
 
 See the list of [supported Frequency Plans]({{< ref "/reference/frequency-plans" >}}).
@@ -27,21 +27,21 @@ See the list of [supported Frequency Plans]({{< ref "/reference/frequency-plans"
 If using Windows OS Command Prompt, replace `export` with `set` and remove the double-quotes in commands above:
 
 ```bash
-$ set TTNV2_APP_ID=ttn-v2-application-ID
-$ set TTNV2_APP_ACCESS_KEY=ttn-v2-application-access-key
-$ set FREQUENCY_PLAN_ID=EU_863_870_TTN
+set TTNV2_APP_ID=ttn-v2-application-ID
+set TTNV2_APP_ACCESS_KEY=ttn-v2-application-access-key
+set FREQUENCY_PLAN_ID=EU_863_870_TTN
 ```
 
 Commands are slightly different if using Windows PowerShell, for example you could set the `TTNV2_APP_ID` variable as follows:
 
 ```powershell
-$ $env:TTNV2_APP_ID='ttn-v2-application-ID'
+$env:TTNV2_APP_ID='ttn-v2-application-ID'
 ```
 
 Since migration is still possible only from a private The Things Industries V2 (SaaS) cluster, you need to configure one extra environmental variable:
 
 ```bash
-$ export TTNV2_DISCOVERY_SERVER_ADDRESS="<instance-id>.thethings.industries:1900"
+export TTNV2_DISCOVERY_SERVER_ADDRESS="<instance-id>.thethings.industries:1900"
 ```
 
 If the Discovery Server of your private The Things Industries V2 (SaaS) cluster does not use TLS, you will need to use `ttnv2.discovery-server-insecure` flag when running commands with the `ttn-lw-migrate` tool.

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/establish-new-session.md
@@ -45,7 +45,7 @@ Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset 
 To export a single end device from {{% ttnv2 %}}:
 
 ```bash
-$ ttn-lw-migrate device --source ttnv2 "v2-end-device-ID" --ttnv2.with-session=false > devices.json
+ttn-lw-migrate device --source ttnv2 "v2-end-device-ID" --ttnv2.with-session=false > devices.json
 ```
 
 ### Export a Batch of End Devices
@@ -63,7 +63,7 @@ dev3
 To export a batch of end devices from {{% ttnv2 %}}:
 
 ```bash
-$ ttn-lw-migrate device --source ttnv2 --ttnv2.with-session=false < device_ids.txt > devices.json
+ttn-lw-migrate device --source ttnv2 --ttnv2.with-session=false < device_ids.txt > devices.json
 ```
 
 ### Export All End Devices Associated With {{% ttnv2 %}} Application
@@ -71,7 +71,7 @@ $ ttn-lw-migrate device --source ttnv2 --ttnv2.with-session=false < device_ids.t
 To export all devices contained in {{% ttnv2 %}} application:
 
 ```bash
-$ ttn-lw-migrate application --source ttnv2 "ttn-v2-application-ID" --ttnv2.with-session=false > devices.json
+ttn-lw-migrate application --source ttnv2 "ttn-v2-application-ID" --ttnv2.with-session=false > devices.json
 ```
 
 ## Prevent the End Device from Joining {{% ttnv2 %}} Network

--- a/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
+++ b/doc/content/getting-started/migrating/migrating-from-v2/migrate-using-migration-tool/migrate-active-session.md
@@ -43,7 +43,7 @@ Use the `--ttnv2.resets-to-frequency-plan` flag to configure the factory preset 
 To export a single end device from {{% ttnv2 %}} and clear its security keys:
 
 ```bash
-$ ttn-lw-migrate device --source ttnv2 "v2-end-device-ID" > devices.json
+ttn-lw-migrate device --source ttnv2 "v2-end-device-ID" > devices.json
 ```
 
 ### Export a Batch of End Devices
@@ -61,7 +61,7 @@ dev3
 To export a batch of end devices from {{% ttnv2 %}} and clear their security keys:
 
 ```bash
-$ ttn-lw-migrate device --source ttnv2 < device_ids.txt > devices.json
+ttn-lw-migrate device --source ttnv2 < device_ids.txt > devices.json
 ```
 
 ### Export All End Devices Associated With {{% ttnv2 %}} Application
@@ -69,7 +69,7 @@ $ ttn-lw-migrate device --source ttnv2 < device_ids.txt > devices.json
 To export all devices contained in {{% ttnv2 %}} application and clear their security keys:
 
 ```bash
-$ ttn-lw-migrate application --source ttnv2 "ttn-v2-application-ID" > devices.json
+ttn-lw-migrate application --source ttnv2 "ttn-v2-application-ID" > devices.json
 ```
 
 ## Import End Devices in {{% tts %}} Application

--- a/doc/content/getting-started/migrating/migration-tool.md
+++ b/doc/content/getting-started/migrating/migration-tool.md
@@ -21,13 +21,13 @@ We highly recommend installing or upgrading to `ttn-lw-migrate` version `0.5.0` 
 To install `ttn-lw-migrate` tool with `brew`:
 
 ```bash
-$ brew install TheThingsNetwork/homebrew-lorawan-stack/ttn-lw-migrate
+brew install TheThingsNetwork/homebrew-lorawan-stack/ttn-lw-migrate
 ```
 
 To upgrade `ttn-lw-migrate` tool if updates are available:
 
 ```bash
-$ brew upgrade TheThingsNetwork/homebrew-lorawan-stack/ttn-lw-migrate
+brew upgrade TheThingsNetwork/homebrew-lorawan-stack/ttn-lw-migrate
 ```
 
 ### Linux
@@ -35,13 +35,13 @@ $ brew upgrade TheThingsNetwork/homebrew-lorawan-stack/ttn-lw-migrate
 To install `ttn-lw-migrate` tool with `snap`:
 
 ```bash
-$ sudo snap install ttn-lw-migrate
+sudo snap install ttn-lw-migrate
 ```
 
 To upgrade `ttn-lw-migrate` tool if updates are available:
 
 ```bash
-$ sudo snap refresh ttn-lw-migrate
+sudo snap refresh ttn-lw-migrate
 ```
 
 ### Windows
@@ -59,7 +59,7 @@ To use the `ttn-lw-migrate` tool after successful installation, use your termina
 To list available sources that you can migrate your end devices and applications from:
 
 ```bash
-$ ttn-lw-migrate sources
+ttn-lw-migrate sources
 ```
 
 Currently, supported sources are `ttnv2` and `chirpstack`.

--- a/doc/content/getting-started/packet-broker/configure/_index.md
+++ b/doc/content/getting-started/packet-broker/configure/_index.md
@@ -71,7 +71,7 @@ To publicly list your tenant, enable the **List network publicly** switch. This 
 To view the current registration with Packet Broker:
 
 ```bash
-$ ttn-lw-cli packetbroker info
+ttn-lw-cli packetbroker info
 ```
 
 <details><summary>Example output with registration</summary>
@@ -131,7 +131,7 @@ You can register with Packet Broker if you are a tenant. This is the case for al
 To register or update your existing tenant registration:
 
 ```bash
-$ ttn-lw-cli packetbroker register --listed
+ttn-lw-cli packetbroker register --listed
 ```
 
 This updates the registration with Packet Broker based on your {{% tts %}} environment. When using {{% tts %}} Cloud or Dedicated Cloud, the registration is based on your subscription. When using {{% tts %}} Enterprise or Open Source, the registration is based on [your configuration]({{< relref "configure" >}}).
@@ -147,7 +147,7 @@ This permanently deletes all routing policies that you configured as Forwarder t
 To deregister from Packet Broker:
 
 ```bash
-$ ttn-lw-cli packetbroker deregister
+ttn-lw-cli packetbroker deregister
 ```
 
 {{< /tabs/tab >}}

--- a/doc/content/getting-started/packet-broker/configure/gateway-visibilities.md
+++ b/doc/content/getting-started/packet-broker/configure/gateway-visibilities.md
@@ -26,7 +26,7 @@ The default gateway visibility defines rules for all Home Networks if there is n
 Use the following command in your terminal to get the default routing policy:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks gateway-visibilities get default
+ttn-lw-cli packetbroker home-networks gateway-visibilities get default
 ```
 
 If there is no default gateway visibility defined, the above command fails with `not found`.
@@ -58,7 +58,7 @@ In the following example, all gateway visibility configuration fields are enable
 To set the default gateway visibility and enable all fields:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks gateway-visibilities set default --all
+ttn-lw-cli packetbroker home-networks gateway-visibilities set default --all
 ```
 
 To customize, see [Flags]({{< relref "#flags" >}}) below.
@@ -68,7 +68,7 @@ To customize, see [Flags]({{< relref "#flags" >}}) below.
 To delete the default gateway visibility:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks gateway-visibilities delete default
+ttn-lw-cli packetbroker home-networks gateway-visibilities delete default
 ```
 
 #### Flags {#flags}

--- a/doc/content/getting-started/packet-broker/configure/routing-policies.md
+++ b/doc/content/getting-started/packet-broker/configure/routing-policies.md
@@ -58,7 +58,7 @@ The default routing policy defines rules for all Home Networks if there is no sp
 To get the default routing policy:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies get default
+ttn-lw-cli packetbroker home-networks policies get default
 ```
 
 If there is no default policy defined, the above command fails with `not found`.
@@ -93,7 +93,7 @@ The following example has all message types enabled:
 To set the default routing policy to forward all uplink traffic and allow Home Networks to forward all downlink traffic:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies set default --all
+ttn-lw-cli packetbroker home-networks policies set default --all
 ```
 
 To customize, see [Flags]({{< relref "#flags" >}}) below.
@@ -103,7 +103,7 @@ To customize, see [Flags]({{< relref "#flags" >}}) below.
 To delete the default routing policy:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies delete default
+ttn-lw-cli packetbroker home-networks policies delete default
 ```
 
 ### List Home Networks
@@ -113,7 +113,7 @@ In order to configure routing policies with Home Networks, you need to know whic
 To list Packet Broker Home Networks:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks list
+ttn-lw-cli packetbroker home-networks list
 ```
 
 This shows only the Home Networks that have been set to be visible to other networks. If you are using {{% tts %}} Cloud or Dedicated Cloud, [contact The Things Industries support](mailto:support@thethingsindustries.com) to set your network to be listed or not. If you are using {{% tts %}} Open Source or Enterprise, see [Configuration]({{< relref "/reference/configuration/packet-broker-agent" >}}).
@@ -184,7 +184,7 @@ You can see which routing policies Forwarders set for your network as the Home N
 To list the routing policies set by Forwarders for your network:
 
 ```bash
-$ ttn-lw-cli packetbroker forwarder policies list
+ttn-lw-cli packetbroker forwarder policies list
 ```
 
 <details><summary>Example output</summary>
@@ -233,7 +233,7 @@ Home Network routing policies take precedence over the default routing policy.
 To list the routing policies for Home Networks:
 
 ```bash
-$ ttn-lw-cli packetbroker home-network policies list
+ttn-lw-cli packetbroker home-network policies list
 ```
 
 ##### Get Home Network Routing Policy
@@ -241,7 +241,7 @@ $ ttn-lw-cli packetbroker home-network policies list
 To get the routing policy for a Home Network:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies get <net-id> [<tenant-id>]
+ttn-lw-cli packetbroker home-networks policies get <net-id> [<tenant-id>]
 ```
 
 Replace `<net-id>` with your network's `NetID`. The `tenant-id` is optional and represents the tenant within the `NetID`.
@@ -249,7 +249,7 @@ Replace `<net-id>` with your network's `NetID`. The `tenant-id` is optional and 
 To view the routing policy configured between you (the Forwarder) and The Things Stack Community Edition (the Home Network):
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies get 000013 ttn
+ttn-lw-cli packetbroker home-networks policies get 000013 ttn
 ```
 
 ##### Set Home Network Routing Policy
@@ -257,7 +257,7 @@ $ ttn-lw-cli packetbroker home-networks policies get 000013 ttn
 To set the routing policy for a Home Network:
 
 ```bash
-$ ttn-lw-cli packetbroker home-network policies set <net-id> [<tenant-id>] --all
+ttn-lw-cli packetbroker home-network policies set <net-id> [<tenant-id>] --all
 ```
 
 To customize, see [Flags]({{< relref "#flags" >}}) below.
@@ -265,7 +265,7 @@ To customize, see [Flags]({{< relref "#flags" >}}) below.
 To enable forwarding of all packets between you (the Forwarder) and The Things Stack Community Edition (the Home Network):
 
 ```bash
-$ ttn-lw-cli packetbroker home-network policy set 000013 ttn --all
+ttn-lw-cli packetbroker home-network policy set 000013 ttn --all
 ```
 
 ##### Delete Home Network Routing Policy
@@ -273,7 +273,7 @@ $ ttn-lw-cli packetbroker home-network policy set 000013 ttn --all
 To delete the routing policy for a Home Network:
 
 ```bash
-$ ttn-lw-cli packetbroker home-networks policies delete <net-id> [<tenant-id>]
+ttn-lw-cli packetbroker home-networks policies delete <net-id> [<tenant-id>]
 ```
 
 Replace `<net-id>` with your network's `NetID`. The `tenant-id` is optional and represents the tenant within the `NetID`.

--- a/doc/content/getting-started/upgrading/_index.md
+++ b/doc/content/getting-started/upgrading/_index.md
@@ -43,7 +43,7 @@ services:
 Pull the docker images of the new version.
 
 ```bash
-$ docker-compose pull stack
+docker-compose pull stack
 Pulling stack     ... done
 ```
 
@@ -56,7 +56,7 @@ The new version will be pulled locally but not run yet.
 Stop `{{< tts >}}` container.
 
 ```bash
-$ docker-compose stop stack
+docker-compose stop stack
 Stopping <directory>_stack_1 ... done
 ```
 
@@ -67,7 +67,7 @@ Navigate to the Redis data folder, which can be found in the `docker-compose.yml
 Stop the `redis` container.
 
 ```bash
-$ docker-compose stop redis
+docker-compose stop redis
 Stopping <directory>_redis_1 ... done
 ```
 
@@ -78,7 +78,7 @@ To restore `redis` from this file, simply place the file back in the data folder
 Start the `redis` container.
 
 ```bash
-$ docker-compose up -d redis
+docker-compose up -d redis
 Starting <directory>_redis_1 ... done
 ```
 
@@ -87,7 +87,7 @@ Starting <directory>_redis_1 ... done
 Keep the `cockroach` container running and enter a cockroach CLI shell.
 
 ```bash
-$ docker exec -it <directory>_cockroach_1 ./cockroach sql --insecure
+docker exec -it <directory>_cockroach_1 ./cockroach sql --insecure
 ```
 
 Backup the database.
@@ -105,7 +105,7 @@ In order to restore from a backup, copy the backup folder to `${DEV_DATA_DIR:-.e
 Now, again enter a cockroach CLI shell again with the `cockroach` container running.
 
 ```bash
-$ docker exec -it <directory>_cockroach_1 ./cockroach sql --insecure
+docker exec -it <directory>_cockroach_1 ./cockroach sql --insecure
 ```
 
 Delete (or rename) the existing database to prevent conflicts.
@@ -140,25 +140,25 @@ New minor versions of {{< tts >}} include new features/fixes which may require a
 Migrate the Identity Server Database.
 
 ```bash
-$ docker-compose run --rm stack is-db migrate
+docker-compose run --rm stack is-db migrate
 ```
 
 Migrate the Network Server Database.
 
 ```bash
-$ docker-compose run --rm stack ns-db migrate
+docker-compose run --rm stack ns-db migrate
 ```
 
 Migrate the Device Claiming Server Database.
 
 ```bash
-$ docker-compose run --rm stack dcs-db migrate
+docker-compose run --rm stack dcs-db migrate
 ```
 
 Migrate the Application Server Database.
 
 ```bash
-$ docker-compose run --rm stack as-db migrate
+docker-compose run --rm stack as-db migrate
 ```
 
 {{< /tabs/tab >}}
@@ -167,13 +167,13 @@ $ docker-compose run --rm stack as-db migrate
 Migrate the Identity Server Database.
 
 ```bash
-$ docker-compose run --rm stack is-db migrate
+docker-compose run --rm stack is-db migrate
 ```
 
 Migrate the Network Server Database.
 
 ```bash
-$ docker-compose run --rm stack ns-db migrate
+docker-compose run --rm stack ns-db migrate
 ```
 {{< /tabs/tab >}}
 {{< /tabs/container >}}
@@ -184,5 +184,5 @@ $ docker-compose run --rm stack ns-db migrate
 Once the above steps are successfully completed, start {{< tts >}}.
 
 ```bash
-$ docker-compose up -d stack
+docker-compose up -d stack
 ```

--- a/doc/content/getting-started/user-management/org/_index.md
+++ b/doc/content/getting-started/user-management/org/_index.md
@@ -36,12 +36,21 @@ When a user is a member of an organization which is a collaborator for an entity
 
 ## Managing Organizations using the CLI
 
+We define some user parameters that will be used below:
+
+```bash
+ORGANIZATION_ID="org1"
+USER_ID="user1"
+```
+
+Make sure to modify these according to your setup.
+
 ## Creating Organizations
 
 Administrators can create organizations as follows:
 
 ```bash
-$ ttn-lw-cli organizations create org1 --user-id user1
+ttn-lw-cli organizations create $ORGANIZATION_ID --user-id $USER_ID
 ```
 
 This will create an organization `org1` with all the rights of `user1` and make `user1` a collaborator within the organization.
@@ -63,7 +72,7 @@ Output:
 To list organizations with the CLI, use the `organizations list` command.
 
 ```bash
-$ ttn-lw-cli organizations list
+ttn-lw-cli organizations list
 ```
 
 ```json
@@ -88,7 +97,7 @@ $ ttn-lw-cli organizations list
 To search for organizations with the CLI, use the `organizations search` command. Make sure to specify the fields you're interested in. This example will search for organizations with IDs that contain `org1`:
 
 ```bash
-$ ttn-lw-cli organizations search --id-contains org1
+ttn-lw-cli organizations search --id-contains $ORGANIZATION_ID
 ```
 
 Output:
@@ -108,17 +117,17 @@ Output:
 To add a user to an organization, use the  `organizations collaborators set` command. This will add user `user1` as a collaborator of organization `org1` with all organization rights:
 
 ```bash
-$ ttn-lw-cli organizations collaborators set --organization-id org1 --user-id user1 --right-organization-all
+ttn-lw-cli organizations collaborators set --organization-id $ORGANIZATION_ID --user-id $USER_ID --right-organization-all
 ```
 
-You must specify rights when adding a collaborator. Use the `--help` flag to see the list of possible rights, e.g `$ ttn-lw-cli organizations collaborators set --help`.
+You must specify rights when adding a collaborator. Use the `--help` flag to see the list of possible rights, e.g `ttn-lw-cli organizations collaborators set --help`.
 
 ## Removing Users from Organizations
 
 To remove a user from an organization, use the  `organizations collaborators delete` command:
 
 ```bash
-$ ttn-lw-cli organizations collaborators delete --organization-id org1 --user-id user1
+ttn-lw-cli organizations collaborators delete --organization-id $ORGANIZATION_ID --user-id $USER_ID
 ```
 
 This will remove user `user1` as a collaborator of organization `org1`
@@ -128,7 +137,7 @@ This will remove user `user1` as a collaborator of organization `org1`
 To delete an organization, use the `organizations delete` command.
 
 ```bash
-$ ttn-lw-cli organizations delete --organization-id org1
+ttn-lw-cli organizations delete --organization-id $ORGANIZATION_ID
 ```
 
 {{< warning >}} When deleting organizations, their IDs stay reserved in the system. For security reasons, it is not possible to create a new organization with the same ID. {{</ warning >}}

--- a/doc/content/getting-started/user-management/rights/_index.md
+++ b/doc/content/getting-started/user-management/rights/_index.md
@@ -40,26 +40,37 @@ Rights apply to entities which a user or organization is a member (collaborator)
 
 ## Managing Rights using the CLI
 
+We define some user parameters that will be used below:
+
+```bash
+ORGANIZATION_ID="org1"
+USER_ID="user1"
+APP_ID="app1"
+GTW_ID="gateway1"
+```
+
+Make sure to modify these according to your setup.
+
 ## Adding Collaborators
 
 To add collaborators for Gateways, End Devices, or Applications, use the `collaborators add` command. For example, to add a collaborator `user1` to the application `app1` with rights to read and write device info and delete applications, use the command
 
 ```bash
-$ ttn-lw-cli applications collaborators set --application-id app1 \
-  --user-id user1 \
+ttn-lw-cli applications collaborators set --application-id $APP_ID \
+  --user-id $USER_ID \
   --right-application-delete \
   --right-application-devices-read \
   --right-application-devices-write
 ```
 
-To see the list of possible rights for an entity, use the `--help` flag, e.g `$ ttn-lw-cli applications collaborators set --help`.
+To see the list of possible rights for an entity, use the `--help` flag, e.g `ttn-lw-cli applications collaborators set --help`.
 
 ## Listing Collaborators
 
 To see which rights a user has on an entity, use the `collaborators list` command. For example, to see collaborators for the gateway `gateway1`, use the command:
 
 ```bash
-$ ttn-lw-cli gateways collaborators list --gateway-id gateway1
+ttn-lw-cli gateways collaborators list --gateway-id $GTW_ID
 ```
 
 {{< /tabs/tab >}}

--- a/doc/content/getting-started/user-management/user/_index.md
+++ b/doc/content/getting-started/user-management/user/_index.md
@@ -62,14 +62,23 @@ In the bottom of the edit view, you can click **Delete user** to delete the user
 
 ## Managing Users using the CLI
 
+We define some user parameters that will be used below:
+
+```bash
+NAME="My Colleague"
+EMAIL="colleague@thethings.network"
+```
+
+Make sure to modify these according to your setup.
+
 ## Creating Users
 
 Network Administrators can create user accounts as follows:
 
 ```bash
-$ ttn-lw-cli users create colleague \
-  --name "My Colleague" \
-  --primary-email-address colleague@thethings.network
+ttn-lw-cli users create colleague \
+  --name $NAME \
+  --primary-email-address $EMAIL
 ```
 
 You will be prompted to enter the password:
@@ -107,7 +116,7 @@ Please confirm password:***************
 You can create invitations for users to join the network with the `users invitations create` command:
 
 ```bash
-$ ttn-lw-cli users invitations create colleague@thethings.network
+ttn-lw-cli users invitations create $EMAIL
 ```
 
 After you do this, you will be able to list the invitations you've sent:
@@ -132,7 +141,7 @@ After you do this, you will be able to list the invitations you've sent:
 You will also be able to delete an invitation if you want to revoke it:
 
 ```bash
-$ ttn-lw-cli users invitations delete colleague@thethings.network
+ttn-lw-cli users invitations delete $EMAIL
 ```
 
 ## Listing Users
@@ -140,7 +149,7 @@ $ ttn-lw-cli users invitations delete colleague@thethings.network
 To list users with the CLI, use the `users list` command. Make sure to specify the fields you're interested in.
 
 ```bash
-$ ttn-lw-cli users list --name --state --admin
+ttn-lw-cli users list --name --state --admin
 ```
 
 <details><summary>Output</summary>
@@ -172,7 +181,7 @@ Use the pagination flags `--limit` and `--page` when there are many users.
 To search for users with the CLI, use the `users search` command. Make sure to specify the fields you're interested in. We'll search for users with IDs that contain "new":
 
 ```bash
-$ ttn-lw-cli users search --id-contains new --name
+ttn-lw-cli users search --id-contains new --name
 ```
 
 <details><summary>Output</summary>
@@ -196,7 +205,7 @@ Use the pagination flags `--limit` and `--page` when there are many users.
 To update users with the CLI, use the `users update` command. The following command updates the state of user `new-user` to "approved" and makes them admin of the network:
 
 ```bash
-$ ttn-lw-cli users update new-user --state APPROVED --admin true
+ttn-lw-cli users update new-user --state APPROVED --admin true
 ```
 
 <details><summary>Output</summary>

--- a/doc/content/integrations/adding-applications/_index.md
+++ b/doc/content/integrations/adding-applications/_index.md
@@ -40,10 +40,12 @@ Your application will be created and you will be redirected to the application o
 Create the first application:
 
 ```bash
-$ ttn-lw-cli applications create app1 --user-id admin
+APP_ID="app1"
+USER_ID="admin"
+ttn-lw-cli applications create $APP_ID --user-id $USER_ID
 ```
 
-This creates an application `app1` with the `admin` user as collaborator.
+This creates an application `app1` with the `admin` user as collaborator. Make sure to modify user parameters according to your setup.
 
 {{< /tabs/tab >}}
 

--- a/doc/content/integrations/cloud-integrations/influxdb-cloud/_index.md
+++ b/doc/content/integrations/cloud-integrations/influxdb-cloud/_index.md
@@ -82,13 +82,13 @@ Once you have downloaded the Telegraf configuration file as described in [Influx
 Next, you need to copy the previously generated token from the **Tokens** tab and export it to an environmental variable to be used by the InfluxDB **output plugin**, or you can simply pass it directly as a `token` value in the configuration file. You can set the environmental variable by using the following command in your terminal:
 
 ```bash
-$ export INFLUX_TOKEN="paste your token here"
+INFLUX_TOKEN="paste your token here"
 ```
 
 Run the Telegraf agent in your terminal with the following command:
 
 ```bash
-$ telegraf --config /path/to/custom/telegraf.conf
+telegraf --config /path/to/custom/telegraf.conf
 ```
 
 ## Configure Telegraf and The Things Stack for Webhook Integration
@@ -119,13 +119,13 @@ Update the Telegraf configuration you previously downloaded as described in [Inf
 Copy the generated token from the **Tokens** tab and use it as a `token` value for the **output plugin** in your Telegraf configuration file, or export it to an environmental variable with the following command in your terminal:
 
 ```bash
-$ export INFLUX_TOKEN="paste your token here"
+INFLUX_TOKEN="paste your token here"
 ```
 
 Start the Telegraf agent by running the following command in the terminal:
 
 ```bash
-$ telegraf --config /path/to/custom/telegraf.conf
+telegraf --config /path/to/custom/telegraf.conf
 ```
 In {{% tts %}} Console, [create a new webhook]({{< ref "/integrations/webhooks/creating-webhooks" >}}) with JSON **Webhook format**, set the **Base URL** to `http://localhost:8080/telegraf` and tick the box next to the message types you want to enable this webhook for.
 

--- a/doc/content/integrations/mqtt/_index.md
+++ b/doc/content/integrations/mqtt/_index.md
@@ -69,7 +69,7 @@ Subscribing to all topics with the `mosquitto_sub` client can be done with:
 ```bash
 # Tip: when using `mosquitto_sub`, pass the `-d` flag to see the topics messages get published on.
 # For example:
-$ mosquitto_sub -h thethings.example.com -t "#" -u "app1@tenant1" -P "NNSXS.VEEBURF3KR77ZR.." -d
+mosquitto_sub -h thethings.example.com -t "#" -u "app1@tenant1" -P "NNSXS.VEEBURF3KR77ZR.." -d
 ```
 
 ### Example 
@@ -189,7 +189,7 @@ Use [this handy tool](https://v2.cryptii.com/hexadecimal/base64) to convert hexa
 
 ```bash
 # If you use `mosquitto_pub`, use the following command:
-$ mosquitto_pub -h thethings.example.com \
+mosquitto_pub -h thethings.example.com \
   -t "v3/app1@tenant1/devices/dev1/down/push" \
   -u "app1@tenant1" -P "NNSXS.VEEBURF3KR77ZR.." \
   -m '{"downlinks":[{"f_port": 15,"frm_payload":"vu8=","priority": "NORMAL"}]}' \

--- a/doc/content/integrations/mqtt/mqtt-clients/eclipse-mosquitto/_index.md
+++ b/doc/content/integrations/mqtt/mqtt-clients/eclipse-mosquitto/_index.md
@@ -35,7 +35,7 @@ For example, to subscribe to all topics in the application `app1`:
 ```bash
 # Tip: when using `mosquitto_sub`, pass the `-d` flag to see the topics messages get published on.
 # For example:
-$ mosquitto_sub -h "thethings.example.com" -p "1883" -u "app1" -P "NNSXS.VEEBURF3KR77ZR.." -t "#" -d
+mosquitto_sub -h "thethings.example.com" -p "1883" -u "app1" -P "NNSXS.VEEBURF3KR77ZR.." -t "#" -d
 ```
 
 In you want to use TLS, you need to change the port value to `8883` and add the `--cafile` option to the command. `--cafile` option is used to define a path to the file containing trusted CA certificates that are PEM encoded.

--- a/doc/content/integrations/mqtt/mqtt-clients/eclipse-paho/_index.md
+++ b/doc/content/integrations/mqtt/mqtt-clients/eclipse-paho/_index.md
@@ -46,7 +46,7 @@ for a in m:
 Save the file and run it with:
 
 ```bash
-$ python subscribe.py
+python subscribe.py
 ```
 
 Running this script will show the most recent `msg_count` messages published during the last 60 seconds.
@@ -73,7 +73,7 @@ publish.single("v3/{application-id}/devices/{device-id}/down/push", '{"downlinks
 Save the file and run it the terminal with:
 
 ```bash
-$ python publish.py
+python publish.py
 ```
 
 You will see the scheduled message in the console under the **Live data** tab and your end device will receive the message after a short time.

--- a/doc/content/integrations/mqtt/mqtt-clients/hivemq/_index.md
+++ b/doc/content/integrations/mqtt/mqtt-clients/hivemq/_index.md
@@ -30,13 +30,13 @@ Learn how to connect to {{% tts %}} MQTT Server by reading the [MQTT Server]({{<
 Enter the HiveMQ MQTT CLI shell mode by typing the following command in your terminal:
 
 ```bash
-$ mqtt shell
+mqtt shell
 ```
 
 Once in shell mode, you can connect to {{% tts %}} MQTT Server by using the following command:
 
 ```bash
-$ con -h <hostname> -p <port> -V 3 -u <username> -pw <password>
+con -h <hostname> -p <port> -V 3 -u <username> -pw <password>
 ```
 
 Keep in mind that `password` is the value of the authentication API key. For more info, see [Creating an API Key]({{< ref "/integrations/mqtt#creating-an-api-key" >}}).
@@ -60,7 +60,7 @@ Use the `sub` command to subscribe to topics and listen to messages being sent f
 For example, if you want to listen to the uplink messages being sent from `dev1` device in `app1` application, use the following command:
 
 ```bash
-$ sub -t "v3/app1/devices/dev1/up" -s
+sub -t "v3/app1/devices/dev1/up" -s
 ```
 
 `-s` flag is used to subscribe with a context to the given topic, e.g. to stop the console being blocked by subscribing without a context. For detailed descriptions of all the available `sub` command parameters, see the [Subscribe](https://hivemq.github.io/mqtt-cli/docs/shell/subscribe.html) section of the HiveMQ MQTT CLI documentation.
@@ -74,7 +74,7 @@ Use the `pub` command to publish to topics, e.g. to schedule downlink messages t
 For example, to push an unconfirmed downlink message with the hexadecimal payload `BE EF` on `FPort` 15 with normal priority to the `dev1` device, use the following command:
 
 ```bash
-$ pub -t "v3/app1/devices/dev1/down/push" -m '{"downlinks":[{"f_port": 15,"frm_payload":"vu8=","priority": "NORMAL"}]}'
+pub -t "v3/app1/devices/dev1/down/push" -m '{"downlinks":[{"f_port": 15,"frm_payload":"vu8=","priority": "NORMAL"}]}'
 ```
 
 {{< note >}} For scheduling downlink messages, the `f_port` values from `1` to `233` are allowed. {{</ note >}}

--- a/doc/content/integrations/payload-formatters/create.md
+++ b/doc/content/integrations/payload-formatters/create.md
@@ -48,13 +48,24 @@ See the [Javascript]({{< relref "javascript" >}}), [CayenneLPP]({{< relref "caye
 
 {{< tabs/tab "CLI" >}}
 
+We define some user parameters that will be used below:
+
+```bash
+APP_ID="app1" 
+API_KEY="NNSXS.VEEBURF3KR77ZR.."
+GTW_EUI="00800000A00009EF"
+USER_ID="admin"
+```
+
+Make sure to modify these according to your setup.
+
 ## Create an Application Payload Formatter using the CLI
 
 To create an application specific payload formatter, use the following command when linking an application. If creating a [Javascript payload formatter]({{< relref "javascript" >}}), save your `Encoder` and `Decoder` functions to files and load them using the `formatter-parameter-local-file` parameter:
 
 ```bash
-$ ttn-lw-cli applications link set app1 \
-  --api-key NNSXS.VEEBURF3KR77ZR..
+ttn-lw-cli applications link set $APP_ID \
+  --api-key $API_KEY
   --default-formatters.down-formatter FORMATTER_JAVASCRIPT \
   --default-formatters.down-formatter-parameter-local-file "encoder.js" \
   --default-formatters.up-formatter FORMATTER_JAVASCRIPT \
@@ -65,16 +76,30 @@ To create a [CayenneLPP]({{< relref "cayenne" >}}) or [Device Repository]({{< re
 
 ## Create a Device Specific Payload Formatter
 
+We first define some device-related user parameters:
+
+```bash
+DEVICE_ID="dev1-with-formatter"
+DEV_EUI="0004A30B001C0530"
+APP_EUI="800000000000000C"
+FREQUENCY_PLAN="EU_863_870"
+APP_KEY="752BAEC23EAE7964AF27C325F4C23C9A"
+LORAWAN_VERSION="1.0.3"
+LORAWAN_PHY_VERSION="1.0.3-a"
+```
+
+Make sure you modify these according to your setup.
+
 It is possible to assign a device specific payload formatter when creating a device using the CLI. Use the following parameters during device creation, and if creating a [Javascript payload formatter]({{< relref "javascript" >}}), save your `Encoder` and `Decoder` functions to files and load them using the `formatter-parameter-local-file` parameter:
 
 ```bash
-$ ttn-lw-cli end-devices create app1 dev1-with-formatter \
-  --dev-eui 0004A30B001C0530 \
-  --app-eui 800000000000000C \
-  --frequency-plan-id EU_863_870 \
-  --root-keys.app-key.key 752BAEC23EAE7964AF27C325F4C23C9A \
-  --lorawan-version 1.0.3 \
-  --lorawan-phy-version 1.0.3-a \
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+  --dev-eui $DEV_EUI \
+  --app-eui $APP_EUI \
+  --frequency-plan-id $FREQUENCY_PLAN \
+  --root-keys.app-key.key $APP_KEY \
+  --lorawan-version $LORAWAN_VERSION \
+  --lorawan-phy-version $LORAWAN_PHY_VERSION \
   --formatters.down-formatter FORMATTER_JAVASCRIPT \
   --formatters.down-formatter-parameter-local-file "encoder.js" \
   --formatters.up-formatter FORMATTER_JAVASCRIPT \
@@ -88,7 +113,7 @@ To create a [CayenneLPP]({{< relref "cayenne" >}}) or [Device Repository]({{< re
 To change the payload formatter for an existing device, use the `end-devices update` command:
 
 ```bash
-$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID \
   --formatters.down-formatter FORMATTER_JAVASCRIPT \
   --formatters.down-formatter-parameter-local-file "encoder.js" \
   --formatters.up-formatter FORMATTER_JAVASCRIPT \
@@ -98,14 +123,14 @@ $ ttn-lw-cli end-devices set app1 dev1-with-formatter \
 To unset the payload formatters, use the `--unset` flag. The command below will unset all device specific payload formatters:
 
 ```bash
-$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID \
   --unset "formatters"
 ```
 
 It is also possible to unset the uplink or downlink formatters separately:
 
 ```bash
-$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
+ttn-lw-cli end-devices set $APP_ID $DEVICE_ID \
   --unset "formatters.up-formatter,formatters.up-formatter-parameter"
 ```
 

--- a/doc/content/integrations/pubsub/mqtt-client/_index.md
+++ b/doc/content/integrations/pubsub/mqtt-client/_index.md
@@ -41,7 +41,7 @@ After enabling events, click the **Add Pub/Sub** button to enable the integratio
 The Application Server publishes messages for any enabled events. For example, when a device sends an uplink, an `uplink` message is published. To view these using a `mosquitto_sub` client connected to your MQTT server:
 
 ```bash
-$ mosquitto_sub -h <server_hostname> -p <port> -t '#' -v
+mosquitto_sub -h <server_hostname> -p <port> -t '#' -v
 # base-topic/uplink {"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}},"received_at":"2020-05-12T12:23:07.087614Z","uplink_message":{"session_key_id":"AXIDznz4bnQqtW8T3NsIVg==","f_port":1,"f_cnt":327,"frm_payload":"AQ=="}}
 ```
 
@@ -50,7 +50,7 @@ $ mosquitto_sub -h <server_hostname> -p <port> -t '#' -v
 You can schedule downlink messages by publishing to a topic. For example, using a `mosquitto_pub` client connected to your MQTT server:
 
 ```bash
-$ mosquitto_pub -h <server_hostname> -p <port> -t 'base-topic/push-subtopic' -m '{"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}},"downlinks":[{"f_port":1,"frm_payload":"AA==","priority":"NORMAL"}]}'
+mosquitto_pub -h <server_hostname> -p <port> -t 'base-topic/push-subtopic' -m '{"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}},"downlinks":[{"f_port":1,"frm_payload":"AA==","priority":"NORMAL"}]}'
 ```
 
 will push a downlink to the end device `dev1` of the application `app1` with a base64 encoded payload of `AA==`, if ```push-subtopic```is configured as the Sub topic for Downlink queue push.

--- a/doc/content/integrations/pubsub/nats-client/_index.md
+++ b/doc/content/integrations/pubsub/nats-client/_index.md
@@ -39,7 +39,7 @@ After enabling events, click the **Add Pub/Sub** button to enable the integratio
 The Application Server publishes messages for any enabled events. For example, when a device sends an uplink, an `uplink` message is published. To view these using a `nats-sub` client connected to your NATS server:
 
 ```bash
-$ nats-sub -s nats://<server_hostname>:<port> '>'
+nats-sub -s nats://<server_hostname>:<port> '>'
 # Listening on [>]
 # [#1] Received on [base-topic.uplink-subtopic] : '{"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}, "received_at":"2020-05-12T10:12:42.063941Z","uplink_message":{"session_key_id":"AXIDznz4bnQqtW8T3NsIVg==","f_port":1,"f_cnt":102,"frm_payload":"AQ=="}]}'
 ```
@@ -49,7 +49,7 @@ $ nats-sub -s nats://<server_hostname>:<port> '>'
 You can schedule downlink messages by publishing to a topic. For example, using a `nats-pub` client connected to your NATS server:
 
 ```bash
-$ nats-pub -s nats://<server_hostname>:<port> base-topic.push-subtopic '{"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}},"downlinks":[{"f_port":1,"frm_payload":"AA==","priority":"NORMAL"}]}'
+nats-pub -s nats://<server_hostname>:<port> base-topic.push-subtopic '{"end_device_ids":{"device_id":"dev1","application_ids":{"application_id":"app1"}},"downlinks":[{"f_port":1,"frm_payload":"AA==","priority":"NORMAL"}]}'
 ```
 
 will push a downlink to the end device `dev1` of the application `app1` with a base64 encoded payload of `AA==`, if ```push-subtopic```is configured as the Sub topic for **Downlink queue push**.

--- a/doc/content/integrations/storage/configuration.md
+++ b/doc/content/integrations/storage/configuration.md
@@ -36,7 +36,7 @@ The Storage Integration has special configuration options for TimescaleDB, that 
 Initialize the configured database with:
 
 ```bash
-$ ttn-lw-stack storage-db init
+ttn-lw-stack storage-db init
 ```
 
 If you are using TimescaleDB, as mentioned in the [TimescaleDB Options]({{< ref "/integrations/storage/configuration#timescaledb-options" >}}) section above, the following configuration options are also available:
@@ -50,7 +50,7 @@ If you are using TimescaleDB, as mentioned in the [TimescaleDB Options]({{< ref 
 If you are using Docker Compose to run {{% tts %}} (as shown in [Installing {{% tts %}} guide]({{< ref "/getting-started/installation" >}})), initialize the configured database with:
 
 ```bash
-$ docker-compose run --rm stack storage-db init
+docker-compose run --rm stack storage-db init
 ```
 
 If everything went well, upon restart, you should be able to see the following log message:

--- a/doc/content/integrations/storage/enable.md
+++ b/doc/content/integrations/storage/enable.md
@@ -28,7 +28,7 @@ Click on **Activate Storage Integration** to enable the storage integration for 
 Set up a default association between the desired application and the `storage-integration` package.
 
 ```bash
-$ ttn-lw-cli applications packages default-associations set "app1" 100 --package-name storage-integration
+ttn-lw-cli applications packages default-associations set <application-id> <f_port> --package-name storage-integration
 ```
 
 {{< note >}} The `f_port` for the default association is set to `100`. This value is irrelevant, i.e. the storage integration will receive and store all uplink messages, regardless of `f_port`. The `f_port` value is only needed because of the way application packages work with {{% tts %}}. {{</ note >}}
@@ -46,7 +46,7 @@ $ ttn-lw-cli applications packages default-associations set "app1" 100 --package
 Set up an association between the desired end device and the `storage-integration` package.
 
 ```bash
-$ ttn-lw-cli applications packages associations set "app1" "dev1" 100 --package-name storage-integration
+ttn-lw-cli applications packages associations set <application-id> <device-id> <f_port> --package-name storage-integration
 ```
 
 {{< note >}} The `f_port` value is irrelevant. {{</ note >}}
@@ -67,11 +67,17 @@ To disable the integration, you only need to click the **Deactivate Storage Inte
 
 {{< tabs/tab "CLI" >}}
 
-To disable the integration, delete the package association or the default association. First, list associations:
+To disable the integration, delete the package association or the default association. 
+
+To list associations:
 
 ```bash
-# List default associations
-$ ttn-lw-cli applications packages default-associations list "app1"
+ttn-lw-cli applications packages default-associations list $APP_ID
+```
+
+The output will be something like:
+
+```bash
 {
   "defaults": [
     {
@@ -92,7 +98,7 @@ $ ttn-lw-cli applications packages default-associations list "app1"
 Then delete the association with:
 
 ```bash
-$ ttn-lw-cli applications packages default-associations delete "app1" 100
+ttn-lw-cli applications packages default-associations delete <application-id> <f_port>
 ```
 
 {{< /tabs/tab >}}
@@ -103,11 +109,17 @@ $ ttn-lw-cli applications packages default-associations delete "app1" 100
 
 {{< cli-only >}}
 
-To disable the integration, delete the association. First, list associations:
+To disable the integration, delete the association.
+
+To list associations:
 
 ```bash
-# List associations
-$ ttn-lw-cli applications packages associations list "app1" "dev1"
+ttn-lw-cli applications packages associations list $APP_ID $DEVICE_ID
+```
+
+The output will be something like:
+
+```bash
 {
   "associations": [
     {
@@ -131,6 +143,5 @@ $ ttn-lw-cli applications packages associations list "app1" "dev1"
 Delete the association with:
 
 ```bash
-# Delete association between "app1" and "dev1"
-$ ttn-lw-cli applications packages associations delete "app1" "dev1" 100
+ttn-lw-cli applications packages associations delete <application-id> <device-id> <f_port>
 ```

--- a/doc/content/integrations/storage/retrieve.md
+++ b/doc/content/integrations/storage/retrieve.md
@@ -14,14 +14,14 @@ A valid API key with the `RIGHT_APPLICATION_TRAFFIC_READ` rights is required.
 
 ```bash
 # Retrieve stored uplinks for application "app1"
-$ curl -G "https://thethings.example.com/api/v3/as/applications/app1/packages/storage/uplink_message" \
+curl -G "https://thethings.example.com/api/v3/as/applications/<application-id>/packages/storage/uplink_message" \
     -H "Authorization: Bearer $API_KEY" \
     -H "Accept: text/event-stream" \
     -d "limit=10" \
     -d "after=2020-08-20T00:00:00Z"
 
 # Retrieve stored uplinks for device "dev1" of application "app1"
-$ curl -G "https://thethings.example.com/api/v3/as/applications/app1/devices/dev1/packages/storage/uplink_message" \
+curl -G "https://thethings.example.com/api/v3/as/applications/<application-id>/devices/<device-id>/packages/storage/uplink_message" \
     -H "Authorization: Bearer $API_KEY" \
     -H "Accept: text/event-stream" \
     -d "limit=10" \
@@ -40,7 +40,7 @@ $ curl -G "https://thethings.example.com/api/v3/as/applications/app1/devices/dev
 Use field masks to specify a subset of fields that should be returned by the API. For example, to retrieve the decoded payload field only, set the field mask as shown below. Note that the end device identifiers and the timestamp are always included in the message.
 
 ```bash
-$ curl -G "https://thethings.example.com/api/v3/as/applications/app1/packages/storage/uplink_message" \
+curl -G "https://thethings.example.com/api/v3/as/applications/<application-id>/packages/storage/uplink_message" \
     -H "Authorization: Bearer $API_KEY" \
     -H "Accept: text/event-stream" \
     -d "limit=10" \
@@ -58,14 +58,23 @@ $ curl -G "https://thethings.example.com/api/v3/as/applications/app1/packages/st
 
 ## Retrieve Uplinks using the CLI
 
+We define some user parameters that are used below:
+
+```bash
+APP_ID="app1"
+DEVICE_ID="dev1"
+```
+
+Make sure to modify these according to your setup.
+
 You can retrieve uplinks for an application or an end device with:
 
 ```bash
-# Retrieve stored uplinks for application "app1"
-$ ttn-lw-cli applications storage get "app1" --limit 10 --order "-received_at" --after "2018-08-20 00:00:00"
+# Retrieve 10 stored uplinks for application "app1"
+ttn-lw-cli applications storage get $APP_ID --limit 10 --order "-received_at" --after "2018-08-20 00:00:00"
 
-# Retrieve stored uplinks for end device "dev1" of application "app1"
-$ ttn-lw-cli end-devices storage get "app1" "dev1" --limit 2 --order "-received_at" --after "2020-08-20 00:00:00"
+# Retrieve 2 stored uplinks for end device "dev1" of application "app1"
+ttn-lw-cli end-devices storage get $APP_ID $DEVICE_ID --limit 2 --order "-received_at" --after "2020-08-20 00:00:00"
 ```
 
 <details><summary><b>See example output</b></summary>

--- a/doc/content/integrations/webhooks/scheduling-downlinks.md
+++ b/doc/content/integrations/webhooks/scheduling-downlinks.md
@@ -34,7 +34,7 @@ The downlink queue operation paths are:
 For example, to push a downlink to the end device `dev1` of the application `app1` using the webhook `wh1`:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -51,7 +51,7 @@ $ curl --location \
 To schedule a human readable downlink to the same device using a downlink [Payload Formatter]({{< ref "integrations/payload-formatters" >}}):
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \
@@ -74,7 +74,7 @@ You can also save the API key in the webhook configuration page using the the **
 To clear the queue of downlink messages for an end device `dev1` of the application `app1` using the webhook `wh1`:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --header 'User-Agent: my-integration/my-integration-version' \

--- a/doc/content/reference/api/field-mask.md
+++ b/doc/content/reference/api/field-mask.md
@@ -28,7 +28,7 @@ For more information, see Google's [Protocol Buffers reference](https://develope
 Fields may be specified in HTTP `GET` requests by appending them as query string parameters. For example, to request the `name`, `description`, and `locations` of devices in an [`EndDeviceRegistry.Get`]({{< ref "reference/api/end_device#the-enddeviceregistry-service" >}}) request, add these fields to the `field_mask` field. To get this data for device `dev1` in application `app1`:
 
 ```bash
-$ curl --location --header "Authorization: Bearer NNSXS.XXXXXXXXX" "https://thethings.example.com/api/v3/applications/app1/devices/dev1?field_mask=name,description,locations"
+curl --location --header "Authorization: Bearer NNSXS.XXXXXXXXX" "https://thethings.example.com/api/v3/applications/app1/devices/dev1?field_mask=name,description,locations"
 ```
 
 This will return the following:
@@ -101,7 +101,7 @@ Where `ids.device_id`, `name`, and `description` are fields to be updated.
 For example, to update the `name` field of device `dev1` in application `app1`with an [`EndDeviceRegistry.Update`]({{< ref "reference/api/end_device#the-enddeviceregistry-service" >}}) request:
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --request PUT \
@@ -189,7 +189,7 @@ This would return the following confirmation:
 Some endpoints require a message to be sent as part of the request. For example, to request an [Event Stream]({{< ref "reference/api/events#the-event-service" >}}), you must `POST` a [StreamEventsRequest message]({{< ref "reference/api/events#message:StreamEventsRequest" >}}):
 
 ```bash
-$ curl --location \
+curl --location \
   --header 'Authorization: Bearer NNSXS.XXXXXXXXX' \
   --header 'Content-Type: application/json' \
   --request POST \

--- a/doc/content/reference/api/gateway_server_mqtt.md
+++ b/doc/content/reference/api/gateway_server_mqtt.md
@@ -48,9 +48,9 @@ To forward uplink traffic to the Gateway Server, the MQTT client must publish a 
 Below is an example that connects to the Gateway Server as `$GATEWAY_ID`, publishes an uplink message (Protocol Buffer stored as binary file `test-uplink-message`) and disconnects:
 
 ```bash
-$ export GATEWAY_ID="test-gtw@my-tenant"
-$ export GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
-$ mosquitto_pub \
+GATEWAY_ID="test-gtw@my-tenant"
+GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
+mosquitto_pub \
     -h "thethings.example.com" -p 1882 \
     -u "$GATEWAY_ID" -P "$GATEWAY_API_KEY" \
     -t "v3/$GATEWAY_ID/up" -f test-uplink-message
@@ -67,9 +67,9 @@ The Gateway Server instructs the gateway to send a downlink packet by publishing
 The MQTT client must subscribe to this topic after connecting to the Gateway Server. It must also listen for incoming `ttnpb.GatewayDown` messages (which contain both the packet data payload as well as any desired transmission settings). Upon receiving a scheduling request, it must trasmit that message, and [send back a `TxAck` packet]({{< ref "#txack-messages" >}}) on success.
 
 ```bash
-$ export GATEWAY_ID="test-gtw@my-tenant"
-$ export GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
-$ mosquitto_sub \
+GATEWAY_ID="test-gtw@my-tenant"
+GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
+mosquitto_sub \
     -h "thethings.example.com" -p 1882 \
     -u "$GATEWAY_ID" -P "$GATEWAY_API_KEY" \
     -t "v3/$GATEWAY_ID/down" -v
@@ -86,9 +86,9 @@ To forward a gateway status message to the Gateway Server, the MQTT client must 
 Below is an example that connects to the Gateway Server as `$GATEWAY_ID`, publishes a gateway status message (Protocol Buffer stored as binary file `test-gateway-status`) and disconnects:
 
 ```bash
-$ export GATEWAY_ID="test-gtw@my-tenant"
-$ export GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
-$ mosquitto_pub \
+GATEWAY_ID="test-gtw@my-tenant"
+GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
+mosquitto_pub \
     -h "thethings.example.com" -p 1882 \
     -u "$GATEWAY_ID" -P "$GATEWAY_API_KEY" \
     -t "v3/$GATEWAY_ID/status" -f test-gateway-status
@@ -103,9 +103,9 @@ $ mosquitto_pub \
 To forward a `TxAck` packet to the Gateway Server, the MQTT client must publish a Protocol Buffer of type `ttnpb.TxAcknowledgement` under the topic `v3/<gateway-id>@<tenant-id>/down/ack`.
 
 ```bash
-$ export GATEWAY_ID="test-gtw@my-tenant"
-$ export GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
-$ mosquitto_pub \
+GATEWAY_ID="test-gtw@my-tenant"
+GATEWAY_API_KEY="NNSXS.VEEBURF3KR77ZR..." # API key with RIGHT_GATEWAY_LINK rights
+mosquitto_pub \
     -h "thethings.example.com" -p 1882 \
     -u "$GATEWAY_ID" -P "$GATEWAY_API_KEY" \
     -t "v3/$GATEWAY_ID/down/ack" -f example-tx-ack

--- a/doc/content/reference/application-packages/_index.md
+++ b/doc/content/reference/application-packages/_index.md
@@ -10,12 +10,21 @@ Application packages specify state machines running both on the end device and t
 
 {{< cli-only >}}
 
+We first define some user parameters used below:
+
+```bash
+APP_ID="app1"
+DEVICE_ID="dev1"
+```
+
+Make sure to modify these according to your setup.
+
 ## Listing the Available Packages
 
 The application packages available for a given device `dev1` of application `app1` can be obtained as follows:
 
 ```bash
-$ ttn-lw-cli applications packages list app1 dev1
+ttn-lw-cli applications packages list $APP_ID $DEVICE_ID
 ```
 
 This gives the result in the JSON format:
@@ -44,7 +53,9 @@ All of the commands for managing associations and default associations are symme
 In order to associate a given application package to a FPort of an application, you can use the `default-associations set` command:
 
 ```bash
-$ ttn-lw-cli applications packages default-associations set app1 25 --package-name test-package
+F_PORT=25
+APP_PACKAGE_NAME="test-package"
+ttn-lw-cli applications packages default-associations set $APP_ID $F_PORT --package-name $APP_PACKAGE_NAME
 ```
 
 This will associate FPort `25` of application `app1` with the application package `test-package`, as shown by the command output:
@@ -67,9 +78,9 @@ Some application packages are stateful, and as such their state can be updated u
 
 ```bash
 # Create a JSON formatted file containing package data
-$ echo '{ "api_key": "AQEA8+q0v..." }' > package-data.json
+echo '{ "api_key": "AQEA8+q0v..." }' > package-data.json
 # Update the association with the new package data
-$ ttn-lw-cli applications packages default-associations set app1 25 --data-local-file package-data.json
+ttn-lw-cli applications packages default-associations set $APP_ID $F_PORT --data-local-file package-data.json
 ```
 
 This will update the association to use the given `api_key`:
@@ -96,7 +107,7 @@ This will update the association to use the given `api_key`:
 The package associations of a given device can be listed using the `default-associations list` command:
 
 ```bash
-$ ttn-lw-cli applications packages default-associations list app1
+ttn-lw-cli applications packages default-associations list $APP_ID
 ```
 
 <details><summary>Output</summary>
@@ -125,7 +136,7 @@ $ ttn-lw-cli applications packages default-associations list app1
 The associations can be retrieved using the `default-associations get` command:
 
 ```bash
-$ ttn-lw-cli applications packages default-associations get app1 25 --data
+ttn-lw-cli applications packages default-associations get $APP_ID $F_PORT --data
 ```
 
 <details><summary>Output</summary>
@@ -153,5 +164,5 @@ $ ttn-lw-cli applications packages default-associations get app1 25 --data
 The associations can be deleted using the `default-associations delete` command:
 
 ```bash
-$ ttn-lw-cli applications packages associations delete app1 25
+ttn-lw-cli applications packages associations delete $APP_ID $F_PORT
 ```

--- a/doc/content/reference/application-packages/lora-cloud-device-and-application-services.md
+++ b/doc/content/reference/application-packages/lora-cloud-device-and-application-services.md
@@ -27,10 +27,12 @@ After filling in the token name and clicking the **Add New Token** button, the t
 The package can now be enabled using the `default-associations set` command:
 
 ```bash
+APP_ID="app1"
+F_PORT=199
 # Create a JSON formatted file containing the uplink token
-$ echo '{ "token": "AQEAdqwV67..." }' > package-data.json
+echo '{ "token": "AQEAdqwV67..." }' > package-data.json
 # Create the association
-$ ttn-lw-cli applications packages default-associations set app1 199 --package-name lora-cloud-device-management-v1 --data-local-file package-data.json
+ttn-lw-cli applications packages default-associations set $APP_ID $F_PORT --package-name lora-cloud-device-management-v1 --data-local-file package-data.json
 ```
 
 This will enable the package on FPort `199` of all of the devices of application `app1`. You can now use the LoRa Cloud Device & Application Services in order to manage your device!
@@ -63,9 +65,9 @@ The package may be configured to use a custom server URL using the package data:
 
 ```bash
 # Create a JSON formatted file containing the uplink token and the server URL
-$ echo '{ "token": "AQEAdqwV67...", "server_url": "https://app.example.com/" }' > package-data.json
+echo '{ "token": "AQEAdqwV67...", "server_url": "https://app.example.com/" }' > package-data.json
 # Create or update the default association
-$ ttn-lw-cli applications packages default-associations set app1 199 --package-name lora-cloud-device-management-v1 --data-local-file package-data.json
+ttn-lw-cli applications packages default-associations set $APP_ID $F_PORT --package-name lora-cloud-device-management-v1 --data-local-file package-data.json
 ```
 
 <details><summary>Output</summary>

--- a/doc/content/reference/branding/_index.md
+++ b/doc/content/reference/branding/_index.md
@@ -45,7 +45,7 @@ For the exact configuration options that are required to set a custom "branding 
 If you have your favicon as a PNG, use ImageMagick to convert it to ICO:
  
 ```bash
-$ convert console-favicon.png \
+convert console-favicon.png \
     -define icon:auto-resize=64,48,32,16 \
     console-favicon.ico
 ```

--- a/doc/content/reference/components/cli.md
+++ b/doc/content/reference/components/cli.md
@@ -29,7 +29,7 @@ By default the CLI outputs results as one or more JSON objects. These JSON objec
 The `--output-format` flag allows you to specify a [Go template](https://golang.org/pkg/text/template/) that is executed for the result(s) of a command. The example below executes lists applications and outputs their IDs and names:
 
 ```bash
-$ ttn-lw-cli applications list --name --output-format "{{ .ApplicationID }}: {{ .Name }}"
+ttn-lw-cli applications list --name --output-format "{{ .ApplicationID }}: {{ .Name }}"
 ```
 
 ## Login and Logout

--- a/doc/content/reference/federated-auth/oidc.md
+++ b/doc/content/reference/federated-auth/oidc.md
@@ -14,24 +14,36 @@ weight: 3
 A new OAuth 2.0 client must be created in the provider and the client ID and client secret must be noted down. While creating the OAuth2 client, you will be asked to provide a redirect URL, which should have the following format:
 
 ```
-https://thethings.example.com/oauth/login/my-oidc-provider/callback
+https://thethings.example.com/oauth/login/<oidc-provider-id>/callback
 ```
 
-Where `my-oidc-provider` is the ID that you have chosen for this OpenID Connect provider.
+Replace `<oidc-provider-id>` with the ID that you have chosen for this OpenID Connect provider, for example `my-oidc-provider`.
 
 ## How can I register an OpenID Connect provider ?
+
+We first define some user parameters used below:
+
+```bash
+OIDC_PROVIDER_ID="my-oidc-provider"
+OIDC_PROVIDER_NAME="My OIDC Provider"
+OIDC_CLIENT_ID="client123"
+OIDC_CLIENT_SECRET="secret123"
+OIDC_PROVIDER_URL="https://oidc.example.com"
+```
+
+Make sure you modify these according to your setup.
 
 After you have created the OAuth2 client you may register the provider using the `is-db` stack command:
 
 ```bash
-$ tti-lw-stack is-db create-auth-provider
-    --id my-oidc-provider
-    --name "My OIDC Provider"
+tti-lw-stack is-db create-auth-provider
+    --id $OIDC_PROVIDER_ID
+    --name $OIDC_PROVIDER_NAME
     --allow-registrations true
     --oidc
-    --oidc.client-id client123
-    --oidc.client-secret secret123
-    --oidc.provider-url https://oidc.example.com
+    --oidc.client-id $OIDC_CLIENT_ID
+    --oidc.client-secret $OIDC_CLIENT_SECRET
+    --oidc.provider-url $OIDC_PROVIDER_URL
 ```
 
 ## How are usernames generated for external users ?

--- a/doc/content/reference/gateway-rtt/_index.md
+++ b/doc/content/reference/gateway-rtt/_index.md
@@ -32,7 +32,7 @@ To query the RTT Values for each gateway can be found in the Gateway Connection 
  {{< cli-only >}}
 
 ```bash
-$ ttn-lw-cli gateways get-connection-stats [gateway-id]
+ttn-lw-cli gateways get-connection-stats <gateway-id>
 ```
 
 The following is an example:

--- a/doc/content/reference/purge/_index.md
+++ b/doc/content/reference/purge/_index.md
@@ -49,40 +49,40 @@ If you are an administrator, you will be presented with the option to purge the 
 To view soft-deleted users:
 
 ```bash
-$ ttn-lw-cli user list --deleted --all
+ttn-lw-cli user list --deleted --all
 ```
 
 To purge an application:
 
 ```bash
-$ ttn-lw-cli applications purge --application-id <APPLICATION_ID>
+ttn-lw-cli applications purge --application-id <application-id>
 ```
 
 To purge a client:
 
 ```bash
-$ ttn-lw-cli clients purge --client-id <CLIENT_ID>
+ttn-lw-cli clients purge --client-id <client-id>
 ```
 
 To purge a gateway:
 
 ```bash
 # By EUI
-$ ttn-lw-cli gateways purge --gateway-eui <GATEWAY_EUI>
+ttn-lw-cli gateways purge --gateway-eui <gateway-eui>
 # Or by ID
-$ ttn-lw-cli gateways purge --gateway-id <GATEWAY_ID>
+ttn-lw-cli gateways purge --gateway-id <gateway-id>
 ```
 
 To purge an organization:
 
 ```bash
-$ ttn-lw-cli organizations purge --organization-id <ORGANIZATION_ID>
+ttn-lw-cli organizations purge --organization-id <organization-id>
 ```
 
 To purge a user:
 
 ```bash
-$ ttn-lw-cli users purge --user-id <USER_ID>
+ttn-lw-cli users purge --user-id <user-id>
 ```
 
 {{</ tabs/tab >}}

--- a/doc/content/reference/tenant-management/_index.md
+++ b/doc/content/reference/tenant-management/_index.md
@@ -20,13 +20,21 @@ This means all tenant management CLI commands will need to have the `--tenant-ad
 
 ## Basic Operations
 
+We define some user parameters that will be used below:
+
+```bash
+TENANT_ID="tenant1"
+TENANT_ADMIN_KEY="14596c0bdb9b11f6a97273e7c09167531571efa5898274e48660ee8d08f62b67"
+```
+
+Make sure to modify these according to your setup.
+
 ### Create a Tenant
 
 To create a new tenant with the tenant ID `tenant1`:
 
 ```
-$ TENANT_ADMIN_KEY=14596c0bdb9b11f6a97273e7c09167531571efa5898274e48660ee8d08f62b67
-$ tti-lw-cli tenant create tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant create $TETANT_ID --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Get a Tenant
@@ -34,7 +42,7 @@ $ tti-lw-cli tenant create tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
 To get a tenant `tenant1`, i.e. to see details like when it was created or updated, and which its capabilities are:
 
 ```
-$ tti-lw-cli tenant get tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant get $TENANT_ID --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### List Tenants
@@ -42,7 +50,7 @@ $ tti-lw-cli tenant get tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
 To get descriptions of all tenants:
 
 ```
-$ tti-lw-cli tenant list --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant list --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Delete a Tenant
@@ -50,7 +58,7 @@ $ tti-lw-cli tenant list --tenant-admin-key $TENANT_ADMIN_KEY
 To delete a tenant `tenant1`:
 
 ```
-$ tti-lw-cli tenant delete tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant delete $TENANT_ID --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Get Tenant Identifiers for Device EUIs
@@ -58,7 +66,9 @@ $ tti-lw-cli tenant delete tenant1 --tenant-admin-key $TENANT_ADMIN_KEY
 To get a tenant ID based on your device's DevEUI and JoinEUI:
 
 ```
-$ tti-lw-cli tenant get-identifiers-for-end-device-euis --dev-eui 0004A30B001C0530 --join-eui 800000000000000C --tenant-admin-key $TENANT_ADMIN_KEY
+DEV_EUI="0004A30B001C0530"
+JOIN_EUI="800000000000000C"
+tti-lw-cli tenant get-identifiers-for-end-device-euis --dev-eui $DEV_EUI --join-eui $JOIN_EUI --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Get Tenant Identifiers for a Gateway EUI
@@ -66,7 +76,8 @@ $ tti-lw-cli tenant get-identifiers-for-end-device-euis --dev-eui 0004A30B001C05
 To get a tenant ID based on your gateways's EUI:
 
 ```
-$ tti-lw-cli tenant get-identifiers-for-gateway-eui --gateway-eui 00800000A00009EF --tenant-admin-key $TENANT_ADMIN_KEY
+GTW_EUI="00800000A00009EF"
+tti-lw-cli tenant get-identifiers-for-gateway-eui --gateway-eui $GTW_EUI --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Search for Tenants
@@ -74,13 +85,13 @@ $ tti-lw-cli tenant get-identifiers-for-gateway-eui --gateway-eui 00800000A00009
 You can search tenants based on multiple criteria such as name, maximum number of entities, state, configuration, etc. These criteria are defined using flags. To see all available flags, use the following command:
 
 ```
-$ tti-lw-cli tenant search --help
+tti-lw-cli tenant search --help
 ```
 
 For example, to search for recently deleted tenants:
 
 ```
-$ tti-lw-cli tenant search --deleted --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant search --deleted --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ### Update a Tenant
@@ -88,13 +99,13 @@ $ tti-lw-cli tenant search --deleted --tenant-admin-key $TENANT_ADMIN_KEY
 You can update a tenant in multiple ways, for example change its name, set a maximum number of entities, change configuration and billing settings, etc. Use the following command to list all available flags:
 
 ```
-$ tti-lw-cli tenant update --help
+tti-lw-cli tenant update --help
 ```
 
-For example, to update a maximum number of end devices that can be registered in a tenant:
+For example, to update a maximum number of end devices that can be registered in a tenant to 3:
 
 ```
-$ tti-lw-cli tenant update --tenant-id tenant1 --max-end-devices 3 --tenant-admin-key $TENANT_ADMIN_KEY
+tti-lw-cli tenant update --tenant-id $TENANT_ID --max-end-devices 3 --tenant-admin-key $TENANT_ADMIN_KEY
 ```
 
 ## Setting a DevAddr Prefix for a Tenant
@@ -104,5 +115,6 @@ In a multi-tenant deployment, different tenants share the same NetID, but they u
 Setting a DevAddr prefix for a tenant can be done using the `update` operation mentioned in the section above. To set a DevAddr prefix for a tenant `tenant1`:
 
 ```
-$ tti-lw-cli tenant update --tenant-id tenant1 --configuration.default-cluster.ns.dev-addr-prefixes 27123400/24
+DEV_ADDR_PREFIX="27123400/24"
+tti-lw-cli tenant update --tenant-id $tenant_id --configuration.default-cluster.ns.dev-addr-prefixes $DEV_ADDR_PREFIX
 ```

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_generate-qr.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_generate-qr.md
@@ -23,14 +23,17 @@ ttn-lw-cli end-devices generate-qr [application-id] [device-id] [flags]
 
 ### Examples
 
+To generate a QR code for a single end device:
+
+```
+ttn-lw-cli end-devices generate-qr app1 dev1
 ```
 
-  To generate a QR code for a single end device:
-    $ ttn-lw-cli end-devices generate-qr app1 dev1
+To generate a QR code for multiple end devices:
 
-  To generate a QR code for multiple end devices:
-    $ ttn-lw-cli end-devices list app1 \
-      | ttn-lw-cli end-devices generate-qr
+```
+ttn-lw-cli end-devices list app1 \
+  | ttn-lw-cli end-devices generate-qr
 ```
 
 ### Options

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_get.md
@@ -14,10 +14,10 @@ ttn-lw-cli packetbroker home-networks gateway-visibilities get default [flags]
 
 ### Examples
 
-```
+To get the default gateway visibility:
 
-  To get the default gateway visibility:
-    $ ttn-lw-cli packetbroker home-network gateway-visibilities get default
+```
+ttn-lw-cli packetbroker home-network gateway-visibilities get default
 ```
 
 ### Options

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_set.md
@@ -20,15 +20,17 @@ ttn-lw-cli packetbroker home-networks gateway-visibilities set default [flags]
 
 ### Examples
 
+To set the default gateway visibility to show location and online status:
+
+```
+ttn-lw-cli packetbroker home-network gateway-visibilities set default \
+  --location --status
 ```
 
-  To set the default gateway visibility to show location and online status:
-    $ ttn-lw-cli packetbroker home-network gateway-visibilities set default \
-      --location --status
-
-  To set the default gateway visibility to show all fields:
-    $ ttn-lw-cli packetbroker home-network gateway-visibilities set default \
-      --all
+To set the default gateway visibility to show all fields:
+```
+ttn-lw-cli packetbroker home-network gateway-visibilities set default \
+  --all
 ```
 
 ### Options

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_get.md
@@ -14,16 +14,22 @@ ttn-lw-cli packetbroker home-networks policies get [default|[net-id] [tenant-id]
 
 ### Examples
 
+To get the default routing policy:
+
+```
+ttn-lw-cli packetbroker home-network policies get default
 ```
 
-  To get the default routing policy:
-    $ ttn-lw-cli packetbroker home-network policies get default
+To get the routing policy with NetID 000013:
 
-  To get the routing policy with NetID 000013:
-    $ ttn-lw-cli packetbroker home-network policies get 000013
+```
+ttn-lw-cli packetbroker home-network policies get 000013
+```
 
-  To get the routing policy with NetID 000013 and tenant ttn (The Things Network):
-    $ ttn-lw-cli packetbroker home-network policies get 000013 ttn
+To get the routing policy with NetID 000013 and tenant ttn (The Things Network):
+
+```
+ttn-lw-cli packetbroker home-network policies get 000013 ttn
 ```
 
 ### Options

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_set.md
@@ -22,20 +22,24 @@ ttn-lw-cli packetbroker home-networks policies set [default|[net-id] [tenant-id]
 
 ### Examples
 
+To set the default routing policy to pass join, MAC and application data, signal quality and gateway locations:
+
+```
+ttn-lw-cli packetbroker home-network policy set default \
+  --join --mac-data --application-data --signal-quality --localization
 ```
 
-  To set the default routing policy to pass join, MAC and application data,
-  signal quality and gateway locations:
-    $ ttn-lw-cli packetbroker home-network policy set default \
-      --join --mac-data --application-data --signal-quality --localization
+To set the routing policy with NetID 000013 and tenant ID ttn (The Things Network), allowing all data:
 
-  To set the routing policy with NetID 000013 and tenant ID ttn (The Things
-  Network), allowing all data:
-    $ ttn-lw-cli packetbroker home-network policy set 000013 ttn --all
+```
+ttn-lw-cli packetbroker home-network policy set 000013 ttn --all
+```
 
-  To set the routing policy with NetID C00001 to allow only uplink:
-    $ ttn-lw-cli packetbroker home-network policy set C00001 \
-      --mac-data-up --application-data-up --signal-quality --localization
+To set the routing policy with NetID C00001 to allow only uplink:
+
+```
+ttn-lw-cli packetbroker home-network policy set C00001 \
+  --mac-data-up --application-data-up --signal-quality --localization
 ```
 
 ### Options


### PR DESCRIPTION
#### Summary
Closes #227 and #200

#### Changes
- Removed $ character from command blocks to make it easier for people to copy commands
-
- 

#### Notes for Reviewers
WiP

#### Checklist
- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
