### PR TITLE
doc: Add information about non-TLS interop port

### DIFF
--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -124,7 +124,9 @@ You can suppress log messages for successful HTTP requests (e.g. to reduce the n
 
 {{% tts %}} supports interoperability according to LoRaWAN Backend Interfaces specification. The following options are used to configure the server for this.
 
-- `interop.listen-tls`: Address for the interop server to listen on
+- `interop.listen`: Address for the interop server to listen on for non-TLS connections
+
+- `interop.listen-tls`: Address for the interop server to listen on for TLS connections
 
 - `interop.sender-client-ca.source`: Source of the interop server sender client CAs configuration (static, directory, url, blob)
 

--- a/doc/content/reference/networking/_index.md
+++ b/doc/content/reference/networking/_index.md
@@ -19,7 +19,7 @@ The following table lists the default ports used.
 | Application data, events | MQTT | API key, token | 1883 | 8883 |
 | Management, data, events | gRPC | API key, token | 1884 | 8884 |
 | Management | HTTP | API key, token | 1885 | 8885 |
-| Backend Interfaces | HTTP | Custom | N/A | 8886 |
+| Backend Interfaces | HTTP | Custom | 1886 | 8886 |
 | {{% lbs %}} LNS | Web Sockets | Auth Token, Custom | 1887 | 8887 |
 | Tabs Hubs LNS {{< distributions "Cloud" "Enterprise" >}} | Web Sockets | Auth Token, Custom | 1888 | 8888 |
 


### PR DESCRIPTION
#### Summary
https://github.com/TheThingsNetwork/lorawan-stack/pull/4979

#### Changes
Added information about 1886 non-TLS interop port

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
