### PR TITLE
doc: Add info about creating empty headers and fields

### DIFF
--- a/doc/content/integrations/webhooks/webhook-templates/instantiation.md
+++ b/doc/content/integrations/webhooks/webhook-templates/instantiation.md
@@ -8,9 +8,9 @@ The process through which a webhook template becomes a webhook integration is ca
 
 <!--more-->
 
-## Instantiation of Header Values
+## Instantiation of Fields
 
-The fields are directly replaced in the values of the headers using the syntax `{field-id}`. Consider the following fragment of a webhook template, describing the available template fields and the headers to be sent to the endpoint:
+Here is an example of instantiating webhook template fields:
 
 ```yaml
 fields:
@@ -19,6 +19,37 @@ fields:
   description: The token used for authentication
   secret: true
   default-value:
+- id: username
+  name: Username
+  description: The username used on the service
+  secret: false
+  default-value:
+- id: create
+  name: Create device
+  description: If set to true, the device will automatically be created on the first uplink
+  secret: false
+  default-value: "true"
+```
+
+Instantiation of header values, URLs and paths will be explained below using this example.
+
+If the webhook template is to be defined without fields, define the `fields` as follows:
+
+```yaml
+fields: []
+```
+
+or
+
+```yaml
+fields:
+```
+
+## Instantiation of Header Values
+
+The fields are directly replaced in the values of the headers using the syntax `{field-id}`. Consider the fragment of a webhook template presented above - the headers to be sent to the endpoint can be defined, using the available template fields, for example as:
+
+```yaml
 headers:
 - Authorization: Bearer {token}
 ```
@@ -38,22 +69,17 @@ If the webhook template is to be defined without header entries, define the `hea
 headers: {}
 ```
 
-## Instantiation of URLs and Paths
-
-The fields are replaced inside the URLs and the paths according to the [RFC6570](https://tools.ietf.org/html/rfc6570) format. Consider the following fragment of a webhook template, describing the available template fields and the paths of the endpoint.
+or
 
 ```yaml
-fields:
-- id: username
-  name: Username
-  description: The username used on the service
-  secret: false
-  default-value:
-- id: create
-  name: Create device
-  description: If set to true, the device will automatically be created on the first uplink
-  secret: false
-  default-value: "true"
+headers:
+```
+
+## Instantiation of URLs and Paths
+
+The fields are replaced inside the URLs and the paths according to the [RFC6570](https://tools.ietf.org/html/rfc6570) format. Consider the fragment of a webhook template shown above - the base URL and paths of the endpoint can be defined, using the available template fields, for example as:
+
+```yaml
 baseurl: https://www.example.com/lora{/username}
 paths:
 - uplink-message: /uplink{?create}


### PR DESCRIPTION
#### Summary
When [this](https://github.com/TheThingsNetwork/lorawan-stack/issues/5036) is fixed, one will be able to define the `fields` list of objects as empty using `fields:` or `fields: []`.

#### Changes
I reorganized the section a bit in order to separate the instructions on instantiating fields, headers and paths. I also added info that headers can be defines as empty using `headers:` 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
