### PR TITLE
Remove excessive `new-in-version` tags

### DIFF
--- a/doc/content/gateways/thethingsindoorgateway/_index.md
+++ b/doc/content/gateways/thethingsindoorgateway/_index.md
@@ -28,11 +28,11 @@ The gateway EUI can later be found at the bottom in the WiFi setup screen.
 
 {{% ttig %}} is added to The Things Stack via a process called **Gateway Claiming**.
 
+{{< warning >}} Do not register your TTIGs via the regular option of **Adding Gateways**. {{</ warning >}}
+
 {{< tabs/container "Console" "CLI" >}}
 
 {{< tabs/tab "Console" >}}
-
-{{< warning >}} Do not register your TTIGs via the regular option of **Adding Gateways**. {{</ warning >}}
 
 Go to **Gateways** in the top menu, and click the **Claim Gateway** button on the upper right to reach the gateway claiming page.
 
@@ -109,7 +109,7 @@ If this is the first time your gateway is being powered on/connected to WiFi, it
 
 ## Existing Gateways
 
-{{< new-in-version "3.14.1" >}} You can also claim gateways that have been previously claimed or registered to {{% tts %}}.
+You can also claim gateways that have been previously claimed or registered to {{% tts %}}.
 
 For this, you need to authorize your gateways for claiming. This is currently only supported via the CLI.
 

--- a/doc/content/integrations/cloud-integrations/aws-iot/default/_index.md
+++ b/doc/content/integrations/cloud-integrations/aws-iot/default/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 The key features of the Default Integration are:
 
-- **Handling uplink and downlink messages**: {{% tts %}} publishes uplink messages to IoT Core and subscribes to downlink messages that you sent from IoT Core. Also, you receive all downlink queued, sent, failed, acknowledged and not acknowledged events in IoT Core {{< new-in-version "1.1.8" >}} 
+- **Handling uplink and downlink messages**: {{% tts %}} publishes uplink messages to IoT Core and subscribes to downlink messages that you sent from IoT Core. Also, you receive all downlink queued, sent, failed, acknowledged and not acknowledged events in IoT Core
 - **Creating and claiming devices**: manage things in IoT Core, or claim things securely on The Things Join Server by proving ownership
 - **Encrypting and decrypting message payloads**: leverage true LoRaWAN end-to-end encryption by unwrapping the AppSKey from the Join Server
 - **Updating device state in shadow**: monitor devices using useful metrics reported in the shadow state, like signal quality and number of covering gateways

--- a/doc/content/integrations/cloud-integrations/aws-iot/default/messages.md
+++ b/doc/content/integrations/cloud-integrations/aws-iot/default/messages.md
@@ -42,7 +42,7 @@ Click **Subscribe to topic**.
 
 The AWS IoT Integration for {{% tts %}} uses the `lorawan/downlink` topic for downstream traffic.
 
-{{< new-in-version "1.1.8" >}} Feedback events are published on the following topics:
+Feedback events are published on the following topics:
 
 - `lorawan/<thing>/downlink/queued` (when any downlink has been queued)
 - `lorawan/<thing>/downlink/sent` (when the downlink has been sent by the Network Server)

--- a/doc/content/reference/configuration/network-server.md
+++ b/doc/content/reference/configuration/network-server.md
@@ -7,7 +7,7 @@ description: ""
 
 - `ns.dev-addr-prefixes`: Device address prefixes of this Network Server
 - `ns.net-id`: NetID of this Network Server
-- `ns.cluster-id`: {{< new-in-version "3.14.0" >}} ClusterID of this Network Server. This is purely informative and is added as metadata to messages forwarded to the Application Server
+- `ns.cluster-id`: ClusterID of this Network Server. This is purely informative and is added as metadata to messages forwarded to the Application Server
 
 ## Uplink Options
 


### PR DESCRIPTION
#### Summary
Remove old `new-in-version` tags

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
