### PR TITLE
doc: Fix publish example

### DIFF
--- a/doc/content/integrations/mqtt/mqtt-clients/eclipse-paho/_index.md
+++ b/doc/content/integrations/mqtt/mqtt-clients/eclipse-paho/_index.md
@@ -65,7 +65,7 @@ Open the file you created and paste the code below:
 import context
 import paho.mqtt.publish as publish
 
-publish.single("v3/{application-id}/devices/{device-id}/down/push", '{"downlinks":[{"f_port": 15,"frm_payload":"vu8=","priority": "NORMAL"}]}', hostname="thethings.example.com", port=1883, {'username':"app1",'password':"NNSXS.VEEBURF3KR77ZR.."})
+publish.single("v3/{application-id}/devices/{device-id}/down/push", '{"downlinks":[{"f_port": 15,"frm_payload":"vu8=","priority": "NORMAL"}]}', hostname="thethings.example.com", port=1883, auth={'username':"app1",'password':"NNSXS.VEEBURF3KR77ZR.."})
 ```
 
 {{< note >}} For scheduling downlink messages, the `f_port` values from `1` to `233` are allowed. {{</ note >}}


### PR DESCRIPTION
#### Summary
Add `auth=...` to fix broken publish example.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
