### PR TITLE
doc: Add algorithm reference to rate limiting

### DIFF
--- a/doc/content/reference/rate-limiting/_index.md
+++ b/doc/content/reference/rate-limiting/_index.md
@@ -7,6 +7,8 @@ description: ""
 
 <!--more-->
 
+For more details about the algorithm used, read [here](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm).
+
 ## Example configuration
 
 The rate limiting configuration is split into multiple profiles. For each profile, we provide a name, the maximum allowed rate per minute, and optionally a maximum burst rate. Finally, we associate the profile with a number of rate limiting classes. Refer to the [Rate Limited Entities]({{< ref "#rate-limited-entities" >}}) section below for a list of all available rate limiting classes and what they mean.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5080

From the discussion in the issue, it seems adequate to have a reference that would introduce the behaviour of the algorithm used to whoever is trying to use rate limiting, it might facilitate the understanding of what's happening behind the curtains.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
![localhost_1313_reference_rate-limiting_](https://user-images.githubusercontent.com/28912302/149586123-ee77b60a-1103-4021-a803-b5db16ae9ac2.png)

#### Changes
<!-- What are the changes made in this pull request? -->
- Add sentence that points to a wikipedia explanation of the generic cell rate algorithm

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
I opted to leave the reference as its own sentence, since it starts with `For more details...` i imagine that only people interested in how it was implemented will click it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
