### PR TITLE
doc: Add JS configuration options

### DIFF
--- a/doc/content/reference/configuration/join-server.md
+++ b/doc/content/reference/configuration/join-server.md
@@ -3,6 +3,13 @@ title: "Join Server Options"
 description: ""
 ---
 
+## Security Options
+
+- `js.device-kek-label`: Label of KEK used to encrypt device keys at rest
+
 ## General Options
 
+- `js.default-join-eui`: Default JoinEUI for the Join Server
+- `js.dev-nonce-limit`: Amount of DevNonces stored per device
 - `js.join-eui-prefix`: JoinEUI prefixes handled by this Join Server
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
References https://github.com/TheThingsNetwork/lorawan-stack/issues/5069
A new option was added and therefore is appropriate to add its description in the configuration section of the documentation.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
![localhost_1313_reference_configuration_join-server](https://user-images.githubusercontent.com/28912302/150330524-da6f7f5a-49c4-42c7-a03a-772998f65628.png)

#### Changes
<!-- What are the changes made in this pull request? -->

- Add description of the Join Server configuration options

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
- The description content is the same as the description in the `go run ./cmd/ttn-lw-stack -h`
- The `Security Options` section is inspired by the GCS's [configuration page](https://www.thethingsindustries.com/docs/reference/configuration/gateway-configuration-server/#security-options)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
