### PR TITLE
doc: Add retry options to cli configuration

### DIFF
--- a/doc/content/reference/configuration/cli.md
+++ b/doc/content/reference/configuration/cli.md
@@ -24,6 +24,12 @@ By default the CLI uses JSON as the input and output format. It is also possible
 - `input-format`: Input format
 - `output-format`: Output format
 
+The CLI is capable of retrying requests that were rejected by the rate limiter: errors of type `ResourceExausthed` and `Unavailable`. By default, this behavior is disabled but can be set through the following configurations:
+- `retry-config.max`: Maximum amount of times that a request can be reattempted.
+- `retry-config.default-timeout`: Default timeout between retry attempts.
+- `retry-config.enable-metadata`: Enables use of the request response metadata to dynamically calculate a timeout for the retry attempts.
+- `retry-config.jitter`: Fraction that creates a deviation of the timeout used between retry attempts.
+
 ## API Options
 
 The CLI needs to be configured with the addresses of the OAuth server. The [Getting Started guide]({{< ref "/getting-started/cli/installing-cli" >}}) gives a good example configuration for a typical deployment.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4902
References https://github.com/TheThingsNetwork/lorawan-stack/pull/5121

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
![localhost_1313_reference_configuration_cli](https://user-images.githubusercontent.com/28912302/152013269-b5924651-e3d9-4137-986f-7a854641faef.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Add retry options to the CLI configuration reference

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `CONTRIBUTING.md` specifies:
>Use the {{< new-in-version "3.8.5" >}} shortcode to tag documentation for features added in a particular version. For documentation that targets `master`, that's the next patch bump, e.g 3.8.x. For documentation targeting `develop` that's the next minor bump, e.g 3.x.0.

But the branch `develop` doesn't seem to exist anymore. On another note, the `{{< new-in-version "3.8.5" >}}` doesn't really match other examples in the configuration reference, so for now I'm leaving it out of the cli-retry section.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
