### PR TITLE
Update register-devices.md

### DIFF
--- a/doc/content/getting-started/cloud-hosted/tti-join-server/register-devices.md
+++ b/doc/content/getting-started/cloud-hosted/tti-join-server/register-devices.md
@@ -40,7 +40,7 @@ To register a LoRaWAN 1.0.x device in application `test-app`, device ID `test-de
 
 ```bash
 ttn-lw-cli end-devices create test-app test-device \
-  --app-eui 70B3D57ED0000000 \
+  --join-eui 70B3D57ED0000000 \
   --dev-eui 0004A310001FF9E0 \
   --root-keys.app-key.key D3FD8EEED7E8880025CC63D5E8E1D7FB
 ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

ttn-lw-cli complains with a warning message when the example device create command from this document is used:
`Flag --app-eui has been deprecated, use the join-eui flag`

This PR changes `--app-eui` to `--join-eui`.

(after writing the comments below) The documentation under https://www.thethingsindustries.com/docs/getting-started/cloud-hosted/tti-join-server/register-devices/ seems outdated and should rather looks like the commands under https://www.thethingsindustries.com/docs/devices/adding-devices/

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

...

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

...

#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
