### PR TITLE
doc: Add Rx1 delay setting example

### DIFF
--- a/doc/content/devices/mac-settings/_index.md
+++ b/doc/content/devices/mac-settings/_index.md
@@ -10,11 +10,11 @@ This section provides guidelines for configuring MAC settings for end devices fr
 
 {{< cli-only >}}
 
-### MAC Settings and MAC State
+## MAC Settings and MAC State
 
 MAC settings on {{% tts %}} are configurable per end device. To configure persistent MAC settings, make changes to `mac-settings.desired_<parameter>`. Updates to `mac-settings.desired_<parameter>` take effect on device creation, after OTAA join or ABP FCnt reset, ResetInd, or after MAC state reset.
 
-`mac-settings.<parameter>` represents what the Network Server believes is configured on the end device, and should not be changed, unless the device does not conform to spec. It may however be necessary to set `mac-settings.RX1_delay` for ABP devices where this is not configured as part of activation.
+`mac-settings.<parameter>` represents what the Network Server believes is configured on the end device, and should not be changed, unless the device does not conform to the LoRaWAN specification. It may however be necessary to set `mac-settings.RX1_delay` for ABP devices where this is not configured as part of activation.
 
 `mac-state` can be used to test MAC settings in the current session. To update settings for testing in the current session, make changes to the `mac-state.desired_parameters.<parameter>`. Updates to the `mac-state.desired_parameters.<parameter>` are applied on the next uplink, and lost on reset.
 
@@ -24,9 +24,37 @@ The expected procedure for testing and updating settings is:
 2. Test that everything works as expected
 3. Modify `mac-settings.desired_<parameter>` to make the change permanent
 
-If no settings are provided on device creation or unset, defaults are first taken from the device Frequency Plan if available, and finally from [Network Server Configuration]({{< ref "/reference/configuration/network-server" >}}).
+See how this applies to the Rx1 delay parameter in the example below. If no settings are provided on device creation or unset, defaults are first taken from the device Frequency Plan if available, and finally from [Network Server Configuration]({{< ref "/reference/configuration/network-server" >}}).
 
-### Available MAC settings
+### Example: Configure Rx1 Delay
+
+{{< note >}} {{% tts %}} configures the `Rx1Delay` to 5 seconds by default to accomodate for high latency backhauls and/or peering with Packet Broker, so this is the recommended configuration. For demonstration purposes, in this example we use 6 seconds. {{</ note >}}
+
+To see Rx1 delay change in the current session, modify the `mac-state.desired-parameters.rx1-delay` parameter:
+
+```
+ttn-lw-cli end-devices update --application-id <application-id> --device-id <device-id> --mac-state.desired-parameters.rx1-delay RX_DELAY_6
+```
+
+The Network Server will schedule an `RxTimingSetupReq` MAC command to communicate a new `Rx1Delay` of 6 seconds to the device. The end device will answer with an `RxTimingSetupAns` MAC command in the next uplink. The Network Server will then start using the `Rx1Delay` of 6 seconds for scheduling downlinks. For this change to take effect, the end device does not need to perform a re-join.
+
+To make the Rx1 delay change persistent upon end device re-join, modify the `mac-settings.desired-rx1-delay` parameter:
+
+```
+ttn-lw-cli end-devices update --application-id <application-id> --device-id <device-id> --mac-settings.desired-rx1-delay RX_DELAY_6
+```
+
+The Rx1 delay change will take effect only after the end device performs a re-join, i.e. in the new session. The `Rx1Delay` of 6 seconds will be communicated to the device during join procedure via Join-accept downlink message.
+
+If the end device does not conform to the LoRaWAN Specification and has a custom Rx1 delay configured in it (6 seconds in this example), modify the `mac-settings.rx1-delay` parameter:
+
+```
+ttn-lw-cli end-devices update --application-id <application-id> --device-id <device-id> --mac-settings.rx1-delay RX_DELAY_6
+```
+
+The Network Server will start using the `Rx1Delay` of 6 seconds for downlink communication with the end device.
+
+## Available MAC settings
 
 Run the following command to get a list of all available MAC settings and available parameter values:
 
@@ -36,7 +64,7 @@ ttn-lw-cli end-devices set --help
 
 You can also refer to the [End Device API Reference page]({{< ref "reference/api/end_device#message:MACSettings" >}}) for documentation on the available MAC settings and MAC state parameters.
 
-### Class Specific Settings
+## Class Specific Settings
 
 Settings that are useful based on device class are:
 
@@ -70,7 +98,7 @@ Class C:
 
 Some additional examples are included below. All settings are available at the [End Device API Reference page]({{< ref "reference/api/end_device#message:MACSettings" >}}) and can be viewed using the `ttn-lw-cli end-devices set --help` command.
 
-### Configure Factory Preset Frequencies for ABP Devices
+## Configure Factory Preset Frequencies for ABP Devices
 
 To tell {{% tts %}} which frequencies are configured in an ABP device, set the `mac-settings.factory-preset-frequencies` parameter. For example, to configure a device using the default EU868 frequencies, use the following command:
 
@@ -80,7 +108,7 @@ ttn-lw-cli devices update <app-id> <device-id> --mac-settings.factory-preset-fre
 
 {{< note >}} For ABP devices, `mac-settings.factory-preset-frequencies` should be specified on `device create` or the settings will only take effect after MAC reset. {{</ note >}}
 
-### Set Duty Cycle
+## Set Duty Cycle
 
 To change the duty cycle, set the `desired-max-duty-cycle` parameter. For example, to set the duty cycle to 0.098%, use the following command:
 
@@ -90,7 +118,7 @@ ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-max-duty-
 
 See the [End Device API Reference]({{< ref "reference/api/end_device#message:MACSettings" >}}) for available fields and definitions of constants. `DUTY_CYCLE_1024` represents 1/1024 ≈ 0.098%.
 
-### Enable ADR
+## Enable ADR
 
 To enable ADR, set the `mac-settings.use-adr` parameter
 
@@ -98,7 +126,7 @@ To enable ADR, set the `mac-settings.use-adr` parameter
 ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.use-adr=true 
 ```
 
-### Set RX1 Delay
+## Set RX1 Delay
 
 The RX1 delay of end devices is set to 5 second by default. To change it, set the `desired-rx1-delay` parameter:
 
@@ -106,7 +134,7 @@ The RX1 delay of end devices is set to 5 second by default. To change it, set th
 ttn-lw-cli end-devices set <app-id> <device-id> --mac-settings.desired-rx1-delay RX_DELAY_5
 ```
 
-### Unset MAC settings
+## Unset MAC settings
 
 The CLI can also be used to unset MAC settings (so that the default ones are used):
 


### PR DESCRIPTION
#### Summary
Closes #709 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
