### PR TITLE
Document purging entities via API

### DIFF
--- a/doc/content/getting-started/api/_index.md
+++ b/doc/content/getting-started/api/_index.md
@@ -254,3 +254,16 @@ curl --location \
   }' \
   'https://thethings.example.com/api/v3/js/applications/app1/devices/newdev1'
 ```
+
+## Purge Entities
+
+An admin user can [purge entities]({{< ref "/reference/purge" >}}) such as [applications]({{< ref "/reference/api/application" >}}), [clients]({{< ref "/reference/api/client" >}}), [gateways]({{< ref "/reference/api/gateway" >}}), [organizations]({{< ref "/reference/api/organization" >}}) or [users]({{< ref "/reference/api/user" >}}).
+
+For example, to purge the application `app1`:
+
+```bash
+curl --location \
+  --header "Authorization: Bearer NNSXS.XXXXXXXXX" \
+  --request DELETE \
+  'https://thethings.example.com/api/v3/applications/app1/purge'
+```

--- a/doc/content/reference/api/application.md
+++ b/doc/content/reference/api/application.md
@@ -15,6 +15,12 @@ description: ""
 
 {{< proto/method service="ApplicationRegistry" method="Delete" >}}
 
+{{< proto/method service="ApplicationRegistry" method="Restore" >}}
+
+{{< proto/method service="ApplicationRegistry" method="Purge" >}}
+
+{{< proto/method service="ApplicationRegistry" method="IssueDevEUI" >}}
+
 ## The `EntityRegistrySearch` service
 
 {{< proto/method service="EntityRegistrySearch" method="SearchApplications" >}}

--- a/doc/content/reference/api/client.md
+++ b/doc/content/reference/api/client.md
@@ -1,0 +1,74 @@
+---
+title: "Client APIs"
+description: ""
+---
+
+## The `ClientRegistry` service
+
+{{< proto/method service="ClientRegistry" method="Create" >}}
+
+{{< proto/method service="ClientRegistry" method="Get" >}}
+
+{{< proto/method service="ClientRegistry" method="List" >}}
+
+{{< proto/method service="ClientRegistry" method="Update" >}}
+
+{{< proto/method service="ClientRegistry" method="Delete" >}}
+
+{{< proto/method service="ClientRegistry" method="Restore" >}}
+
+{{< proto/method service="ClientRegistry" method="Purge" >}}
+
+## The `ClientAccess` service
+
+{{< proto/method service="ClientAccess" method="ListRights" >}}
+
+{{< proto/method service="ClientAccess" method="GetCollaborator" >}}
+
+{{< proto/method service="ClientAccess" method="SetCollaborator" >}}
+
+{{< proto/method service="ClientAccess" method="ListCollaborators" >}}
+
+## Messages
+
+{{< proto/message message="Client" >}}
+
+{{< proto/message message="ClientIdentifiers" >}}
+
+{{< proto/message message="CreateClientRequest" >}}
+
+{{< proto/message message="Collaborator" >}}
+
+{{< proto/message message="ContactInfo" >}}
+
+{{< proto/message message="GetClientCollaboratorRequest" >}}
+
+{{< proto/message message="GetClientRequest" >}}
+
+{{< proto/message message="ListClientsRequest" >}}
+
+{{< proto/message message="ListClientCollaboratorsRequest" >}}
+
+{{< proto/message message="OrganizationIdentifiers" >}}
+
+{{< proto/message message="OrganizationOrUserIdentifiers" >}}
+
+{{< proto/message message="SetClientCollaboratorRequest" >}}
+
+{{< proto/message message="UpdateClientRequest" >}}
+
+{{< proto/message message="UserIdentifiers" >}}
+
+## Enums
+
+{{< proto/enum enum="ContactMethod" >}}
+
+{{< proto/enum enum="ContactType" >}}
+
+{{< proto/enum enum="GrantType" >}}
+
+{{< proto/enum enum="State" >}}
+
+{{< proto/enum enum="Right" >}}
+
+{{< api-refs >}}

--- a/doc/content/reference/api/gateway.md
+++ b/doc/content/reference/api/gateway.md
@@ -15,6 +15,12 @@ description: ""
 
 {{< proto/method service="GatewayRegistry" method="Delete" >}}
 
+{{< proto/method service="GatewayRegistry" method="Restore" >}}
+
+{{< proto/method service="GatewayRegistry" method="Purge" >}}
+
+{{< proto/method service="GatewayRegistry" method="GetIdentifiersForEUI" >}}
+
 ## The `EntityRegistrySearch` service
 
 {{< proto/method service="EntityRegistrySearch" method="SearchGateways" >}}
@@ -100,6 +106,8 @@ The Gateway Server exposes the list of available frequency plans with the `Confi
 {{< proto/message message="GetGatewayCollaboratorRequest" >}}
 
 {{< proto/message message="GetGatewayRequest" >}}
+
+{{< proto/message message="GetGatewayIdentifiersForEUIRequest" >}}
 
 {{< proto/message message="ListFrequencyPlansRequest" >}}
 

--- a/doc/content/reference/api/organization.md
+++ b/doc/content/reference/api/organization.md
@@ -15,6 +15,10 @@ description: ""
 
 {{< proto/method service="OrganizationRegistry" method="Delete" >}}
 
+{{< proto/method service="OrganizationRegistry" method="Restore" >}}
+
+{{< proto/method service="OrganizationRegistry" method="Purge" >}}
+
 ## The `EntityRegistrySearch` service
 
 {{< proto/method service="EntityRegistrySearch" method="SearchOrganizations" >}}

--- a/doc/content/reference/api/user.md
+++ b/doc/content/reference/api/user.md
@@ -15,6 +15,14 @@ description: ""
 
 {{< proto/method service="UserRegistry" method="Delete" >}}
 
+{{< proto/method service="UserRegistry" method="Restore" >}}
+
+{{< proto/method service="UserRegistry" method="Purge" >}}
+
+{{< proto/method service="UserRegistry" method="UpdatePassword" >}}
+
+{{< proto/method service="UserRegistry" method="CreateTemporaryPassword" >}}
+
 ## The `EntityRegistrySearch` service
 
 {{< proto/method service="EntityRegistrySearch" method="SearchUsers" >}}
@@ -49,6 +57,8 @@ description: ""
 
 {{< proto/message message="ContactInfo" >}}
 
+{{< proto/message message="CreateTemporaryPasswordRequest" >}}
+
 {{< proto/message message="CreateUserRequest" >}}
 
 {{< proto/message message="DeleteInvitationRequest" >}}
@@ -78,6 +88,8 @@ description: ""
 {{< proto/message message="SendInvitationRequest" >}}
 
 {{< proto/message message="UpdateUserAPIKeyRequest" >}}
+
+{{< proto/message message="UpdateUserPasswordRequest" >}}
 
 {{< proto/message message="UpdateUserRequest" >}}
 

--- a/doc/content/reference/purge/_index.md
+++ b/doc/content/reference/purge/_index.md
@@ -30,6 +30,8 @@ Purging entites deletes them **permanently** and is irreversible!
 
 ## How to Purge Entities
 
+Purging entities using the Console or the CLI is usually most convenient, so those methods are explained in this section. However, it is also possible to purge entities [using the API]({{< ref "/getting-started/api#purge-entities" >}}).
+
 {{< tabs/container "Console" "CLI" >}}
 
 {{< tabs/tab "Console" >}}


### PR DESCRIPTION
#### Summary
- Added some missing API entries (ones I spotted while adding entries for purge)
- Cross-linked sections "Purge Entities" and "Using the API -> Purge Entities"

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
