### PR TITLE
doc: Add note about auth check for local TTS server

### DIFF
--- a/doc/content/gateways/thethingsindoorgateway/_index.md
+++ b/doc/content/gateways/thethingsindoorgateway/_index.md
@@ -136,6 +136,8 @@ Once {{% ttig %}} is claimed on a {{% tts %}} cluster, the following steps will 
 
 If you want to connect your gateway to an LNS on a local network (for example if you have {{% tts %}} installed for debugging on your laptop), use the steps below.
 
+{{< note >}} In order to connect your {{% ttig %}} to a local {{% tts %}} network, the [`gs.basic-station.allow-unauthenticated` option]({{< ref "/reference/configuration/gateway-server#security-options" >}}) must be set to `true` in [{{% tts %}} configuration]({{< ref "/getting-started/installation/configuration#understanding-the-things-stack-configuration" >}}). {{</ note >}}
+
 First, register the {{% ttig %}} on your target LNS by following [the instructions]({{< ref "/gateways/adding-gateways" >}}).
 
 In order for this to work, both the {{% ttig %}} and the local machine where the LNS is running must be connected to the same WiFi access point.


### PR DESCRIPTION
#### Summary
Closes #804 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
