### PR TITLE
doc: Small updates

### DIFF
--- a/doc/content/getting-started/aws/ami/application-server-telemetry/_index.md
+++ b/doc/content/getting-started/aws/ami/application-server-telemetry/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Application Server Telemetry"
 description: ""
-weight: 4
+weight: 5
 deprecated_in_version: "3.11.1"
 aliases:
   - /integrations/aws-iot/application-server-telemetry

--- a/doc/content/getting-started/aws/ami/best-practices/_index.md
+++ b/doc/content/getting-started/aws/ami/best-practices/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Best Practices"
 description: ""
-weight: 1
+weight: 4
 ---
 
 This page describes best practices of a {{% tts %}} deployment on AWS AMI.

--- a/doc/content/getting-started/aws/ami/troubleshooting/_index.md
+++ b/doc/content/getting-started/aws/ami/troubleshooting/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting AWS AMI Deployment"
 description: ""
-weight: 3
+weight: 6
 ---
 
 <!--

--- a/doc/content/getting-started/aws/ecs/best-practices/_index.md
+++ b/doc/content/getting-started/aws/ecs/best-practices/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Best Practices"
 description: ""
-weight: 1
+weight: 8
 ---
 
 This page describes best practices of a {{% tts %}} deployment on AWS ECS.

--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -14,7 +14,7 @@ Most steps involve deploying a CloudFormation stack from our templates. Some ste
 
 We start with the `1-1-vpc` template that creates the foundation for your deployment: the Virtual Private Cloud (VPC) and the different subnets in two availability zones (AZs). See the [Architecture]({{< relref "../architecture" >}}) section for more information.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/1-1-vpc.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/1-1-vpc.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for a **CIDR block**. The default value is usually fine, but if you plan to deploy multiple clusters, you may want to use CIDRs that do not overlap.
 
@@ -25,6 +25,8 @@ Go to AWS Certificate Manager and request a certificate for your domain of choic
 If you are deploying a multi-tenant deployment, request a certificate that contains both `domain` and `*.domain`. 
 
 Certificate Manager will give further instructions on creating the DNS records that are required for issuing the certificates.
+
+Alternatively, you can continue with the deployment without TLS, and request Let's Encrypt certificates later using [a dedicated template]({{< relref "#lets-encrypt-certificates-optional" >}}).
 
 ## DNS Records
 
@@ -46,7 +48,7 @@ The `1-2-bastion` template will deploy an EC2 instance in one of the public subn
 
 {{< note >}} You can also skip this template, and deploy it when you actually need external access to your cluster. {{</ note >}}
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/1-2-bastion.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/1-2-bastion.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the **Instance Type** you want to use. A small instance is typically fine, since it will only be used to provide access. 
 
@@ -58,13 +60,15 @@ The `1-3-opsgenie` template will deploy an SNS Topic and a Subscription to recei
 
 Once this is deployed, you can enable alerting that's configured for particular resources.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/1-3-opsgenie.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/1-3-opsgenie.gen.template (replace `3.x.y` with the current minor and patch version).
+
+For more information, please refer to the [Opsgenie documentation](https://support.atlassian.com/opsgenie/docs/integrate-opsgenie-with-amazon-cloudwatch/).
 
 ## Aurora Database
 
 The `2-1-db-aurora-master` and `2-2-db-aurora-replica` templates together create a highly available RDS Aurora PostgreSQL cluster. The template `2-1-db-aurora-master` creates a database cluster with a single master instance. The template `2-2-db-aurora-replica` can be deployed multiple times to deploy additional read-only replicas. See the [Architecture]({{< relref "../architecture" >}}) section for more information.
 
-**Master Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-1-db-aurora-master.gen.template (replace `3.x` with the current minor version).
+**Master Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-1-db-aurora-master.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the **Database Name** and **Username** you want to configure on the database (the password will be generated). 
 
@@ -72,7 +76,7 @@ You can select an appropriate **Instance Class** for your network. It is typical
 
 If you are migrating your database from a previous deployment, or if you are upgrading your database, you can fill the ARN of the database **Snapshot** that should be restored.
 
-**Replica Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-2-db-aurora-replica.gen.template (replace `3.x` with the current minor version).
+**Replica Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-2-db-aurora-replica.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for an **Instance Type**, just as for the master template. It is typically fine for small clusters to start with `db.t3.medium` and scale as you grow.
 
@@ -82,7 +86,7 @@ You can deploy one or multiple Redis clusters with the `2-3-db-redis` template. 
 
 Most deployments start with a single `general` cluster that is used for all purposes. It is also possible to use the `general` cluster for persistence only, and use a separate `cache` cluster for caching temporary data. See the [Architecture]({{< relref "../architecture" >}}) section for more information.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-3-db-redis.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-3-db-redis.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the previously described purpose, this template asks for the **Instance Type**. It is typically fine for small clusters to start with `cache.t3.medium` and scale as you grow. 
 
@@ -90,29 +94,17 @@ It is recommended to have a **Multi-AZ** cluster with automatic failover, in whi
 
 If you are migrating your database from a previous deployment, or if you are upgrading your database, you can fill the name of the database **Snapshot** that should be restored.
 
-## TimescaleDB (optional) {#timescaledb-optional}
-
-The template `2-5-db-timescale` is an optional template that creates an EC2 instance that runs [TimescaleDB](https://www.timescale.com/), which is used by the Storage Integration of the Application Server. 
-
-{{< note >}} If you do not want to install the storage integration, you do not need to deploy this. {{</ note >}}
-
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-5-db-timescale.gen.template (replace `3.x` with the current minor version).
-
-In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template requires you to choose an **Instance type** and **SSH Key Name** to be used to login to the instance. You either need to specify the **EBS Volume Snapshot ID** to restore, or the **EBS Volume Size** for the storage volume to create. 
-
-Finally, you need to specify the database name, username and password. If you restore from a snapshot, these must match the existing database in the snapshot.
-
 ## S3 Buckets
 
 The template `2-4a-is-s3` creates S3 buckets for the Identity Server. This template only needs to be deployed for your "main" cluster that contains your Identity Server. Secondary clusters do not have an Identity Server and don't need this template.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-4a-is-s3.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-4a-is-s3.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the names of the buckets you want to create. It is typically fine to leave these parameters empty, and have automatically generated bucket names.
 
 The template `2-4b-routing-s3` creates an S3 bucket that stores configuration for interoperability with other LoRaWAN Backend Interfaces-compliant servers. Even if you don't plan to immediately activate interoperability, this template is still required by another template that you will deploy later in this guide.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/2-4b-routing-s3.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-4b-routing-s3.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the name of the bucket you want to create. It is typically fine to leave this parameter empty, and have a automatically generated bucket name.
 
@@ -125,11 +117,23 @@ aws s3 cp config.yml s3://${InteropConfigBucket}/config.yml
 
 {{< note >}} If you did not set a bucket name, see the `InteropConfigBucket` output of the `2-4b-routing-s3` stack for the name of the bucket. {{</ note >}}
 
+## TimescaleDB (optional) {#timescaledb-optional}
+
+The template `2-5-db-timescale` is an optional template that creates an EC2 instance that runs [TimescaleDB](https://www.timescale.com/), which is used by the Storage Integration of the Application Server. 
+
+{{< note >}} If you do not want to install the storage integration, you do not need to deploy this. {{</ note >}}
+
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-5-db-timescale.gen.template (replace `3.x.y` with the current minor and patch version).
+
+In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template requires you to choose an **Instance type** and **SSH Key Name** to be used to login to the instance. You either need to specify the **EBS Volume Snapshot ID** to restore, or the **EBS Volume Size** for the storage volume to create. 
+
+Finally, you need to specify the database name, username and password. If you restore from a snapshot, these must match the existing database in the snapshot.
+
 ## Security Group Rules
 
 The template `3-1-security-group-rules` creates the security group rules for both external and internal network traffic.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/3-1-security-group-rules.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/3-1-security-group-rules.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the IP address ranges that are allowed to connect to the different ports exposed by {{% tts %}}. The [Architecture]({{< relref "../architecture" >}}) section gives more information about these ports. For (public) deployments that should be accessible from anywhere on the internet, the defaults do not need to be changed.
 
@@ -137,7 +141,7 @@ In addition to the re-used parameters (see [Prerequisites]({{< relref "../prereq
 
 Template `3-2-load-balancer-rules` creates listeners and target groups for the Network Load Balancer. Before deploying this template, go to AWS Certificate Manager, and copy the ARN of the TLS certificate you created earlier.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/3-2-load-balancer-rules.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/3-2-load-balancer-rules.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the previously mentioned TLS certificate ARN, this template asks if you want to serve HTTP/2, which is recommended for all deployments.
 
@@ -145,7 +149,7 @@ In addition to the re-used parameters (see [Prerequisites]({{< relref "../prereq
 
 The `4-1-secrets` template creates several secrets in AWS Secrets Manager
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/4-1-secrets.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/4-1-secrets.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters, the **License Key**, **Cluster Secrets** and **OAuth Client Secrets** (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for login information for your email provider. Currently, only Sendgrid and SMTP are supported. 
 
@@ -163,7 +167,7 @@ openssl rand -base64 16
 
 The `4-2a-configuration` template creates several configuration parameters in AWS Systems Manager Parameter Store.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/4-2a-configuration.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/4-2a-configuration.gen.template (replace `3.x.y` with the current minor and patch version).
 
 As with the other templates, this one also asks for the re-used parameters from the [Prerequisites]({{< relref "../prerequisites" >}}). Next to these parameters, this template has some notable parameters:
 
@@ -172,11 +176,19 @@ As with the other templates, this one also asks for the re-used parameters from 
 
 For the other parameters, see the descriptions and the [Configuration reference]({{< ref "/reference/configuration" >}}).
 
+## Rate limiting
+
+The `4-2b-configuration-rate-limiting` template creates configuration options for rate limiting. Even if you don't want to use rate limiting, deploying this template is obligatory.
+
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/4-2b-configuration-rate-limiting.gen.template (replace `3.x.y` with the current minor and patch version).
+
+More information can be found in the [Rate-limiting]({{< relref "/reference/rate-limiting" >}}) section.
+
 ## Resource Limiting (optional)
 
 The `4-2c-configuration-resource-limiting` template allows setting resource limiting in the Application Server.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/4-2c-configuration-resource-limiting.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/4-2c-configuration-resource-limiting.gen.template (replace `3.x.y` with the current minor and patch version).
 
 More information can be found in the [Resource-limiting]({{< relref "/reference/resource-limiting" >}}) section.
 
@@ -201,7 +213,7 @@ As discussed in the [Architecture]({{< relref "../architecture" >}}) section, we
 
 {{< note >}} All container instances will be deployed with a `schedule_gs=true` attribute which we can use as a constraint for scheduling the UDP Gateway Server in the future. {{</ note >}}
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-1-ecs-cluster.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-1-ecs-cluster.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters and the name of your SSH keypair (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for an **Instance Type** and number of container instances. It is typically fine for small clusters to start with 2x `m5.large`. If you plan to use Fargate for all containers other than the UDP Gateway Server, 2x `t3.micro` may already be sufficient. Again, you can scale to more or larger instances as your network grows.
 
@@ -211,7 +223,7 @@ In addition to the re-used parameters and the name of your SSH keypair (see [Pre
 
 The `5-2-ecs-ops` template creates an ECS Task Definition that will be used for performing database operations such as initializing, migrating and cleaning.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-2-ecs-ops.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-2-ecs-ops.gen.template (replace `3.x.y` with the current minor and patch version).
 
 In addition to the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})), this template asks for the Redis clusters to use. If you only deployed one Redis cluster, this is the `general` cluster. If you deployed a separate cluster for caching, select `cache` as the **Cache Cluster**.
 
@@ -225,13 +237,13 @@ You can now run instances of this task definition to perform operations on the d
 
 Depending on the type of cluster you are deploying, you need to deploy either `5-3a-ecs-is-service` (the Identity Server) or `5-3b-ecs-external-is-proxy` (proxy to Identity Server in another cluster).
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-3a-ecs-is-service.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-3a-ecs-is-service.gen.template (replace `3.x.y` with the current minor and patch version).
 
 Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the Redis clusters to use. The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws` (replace `3.x.y` with the current version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. 
 
 >We recommend to start with 2 instances.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-3b-ecs-external-is-proxy.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-3b-ecs-external-is-proxy.gen.template (replace `3.x.y` with the current minor and patch version).
 
 Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the domain of the cluster that contains the Identity Server. The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws-proxy` (replace `3.x.y` with the current version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. 
 
@@ -241,7 +253,7 @@ Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >
 
 In a multi-tenant deployment where tenants are billed through Stripe, you'll need to deploy the Tenant Billing Server.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-3c-ecs-tbs-service.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-3c-ecs-tbs-service.gen.template (replace `3.x.y` with the current minor and patch version).
 
 Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the Redis clusters to use. The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws` (replace `3.x.y` with the current version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack.
 
@@ -249,7 +261,7 @@ Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >
 
 The `5-4-ecs-services` template creates all other routing services.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-4-ecs-services.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-4-ecs-services.gen.template (replace `3.x.y` with the current minor and patch version).
 
 Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the Redis clusters to use. Indicate whether the services should use the Identity Server in the current cluster, or an external one through the proxy.
 
@@ -257,27 +269,15 @@ For all services: the official image is `docker.io/thethingsindustries/lorawan-s
 
 >We recommend to start with 2 instances of each service. For some services it is not possible (yet) to deploy more than one instance.
 
-## Gateway Configuration Service (optional) 
-
-The `5-3d-ecs-gcs-service` template creates a stand-alone Gateway Configuration Server (GCS) service with a separate console.
-
-> The Gateway Server instances that are deployed by `5-4-ecs-services` already contain GCS services within them. This template is for a stand-alone GCS that may be deployed as a separate cluster with dedicated DNS.
-
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-3d-ecs-gcs.gen.template (replace `3.x` with the current minor version).
-
-Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and the Redis clusters to use.
-
-For all services: the official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws` (replace `3.x.y` with the current version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack.
-
 ## Monitoring (optional, but recommended)
 
 We strongly recommend to monitor your deployment with [Prometheus](https://prometheus.io) and send alerts to [Alertmanager](https://prometheus.io/docs/alerting/latest/overview/), from where you can forward alerts to external on-call notification systems. With the `5-5-ecs-monitoring` you can deploy Prometheus to your ECS cluster.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-5-ecs-monitoring.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-5-ecs-monitoring.gen.template (replace `3.x.y` with the current minor and patch version).
 
 Fill the re-used parameters (see [Prerequisites]({{< relref "../prerequisites" >}})) and information about the cluster. 
 
-The official image is `docker.io/thethingsindustries/lorawan-stack:3.x-aws-prometheus` (replace `3.x` with the current minor version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. Prometheus typically needs CPU=1024 and Memory=2048.
+The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws-prometheus` (replace `3.x.y` with the current minor and patch version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. Prometheus typically needs CPU=1024 and Memory=2048.
 
 {{< note >}} By default, Prometheus stores metrics only for a limited time. You can optionally enable long-term storage of metrics in an S3 bucket. This is done using a [Thanos](https://thanos.io/) sidecar. We do not support querying from long-term storage yet. {{</ note >}}
 
@@ -287,17 +287,17 @@ We recommend to point Prometheus to an external **Alertmanager URL**, so that yo
 
 The template `5-6-ecs-proxy` deploys the proxy that routes incoming gRPC and HTTP requests from the outside world to the right service.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-6-ecs-proxy.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-6-ecs-proxy.gen.template (replace `3.x.y` with the current minor and patch version).
 
-The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws-proxy` (replace `3.x` with the current minor version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. 
+The official image is `docker.io/thethingsindustries/lorawan-stack:3.x.y-aws-proxy` (replace `3.x.y` with the current minor and patch version). When deploying to `FARGATE`, make sure to select [a valid combination of CPU and Memory](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html), or you will get an error about `Invalid CPU or memory value specified` when you deploy the stack. 
 
 >We recommend to start with 2 instances.
 
-## Let's Encrypt Certificates (optional)
+## Let's Encrypt Certificates (optional) {#lets-encrypt-certificates-optional}
 
 Unfortunately not all gateways are able to connect when using AWS-issued certificates. If this is the case in your deployment, you can use the `5-7a-certs-le` and `5-7b-ecs-certbot-scheduled-task` templates to request certificates from [Let's Encrypt](https://letsencrypt.org/).
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-7a-certs-le.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-7a-certs-le.gen.template (replace `3.x.y` with the current minor and patch version).
 
 The Docker image we'll use is `docker.io/thethingsindustries/aws-certbot-dns-route53:latest`. On the initial deployment, leave the **Existing Certificate ARN** blank.
 
@@ -309,6 +309,6 @@ After the task succeeds, go to **Certificate Manager**, find the new certificate
 
 To automatically renew the certificate from Let's Encrypt, we will now deploy template `5-7b-ecs-certbot-scheduled-task`.
 
-**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x/5-7b-ecs-certbot-scheduled-task.gen.template (replace `3.x` with the current minor version).
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-7b-ecs-certbot-scheduled-task.gen.template (replace `3.x.y` with the current minor and patch version).
 
 >We recommend to schedule this task to run every 14 days.

--- a/doc/content/getting-started/aws/ecs/interop/_index.md
+++ b/doc/content/getting-started/aws/ecs/interop/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Interoperability"
 description: "LoRaWAN Backend Interfaces"
-weight: 3
+weight: 8
 ---
 
 {{% tts %}} exposes the Join Server API defined by LoRaWAN Backend Interfaces 1.0 and 1.1. This is used for interoperability between LoRaWAN networks.

--- a/doc/content/getting-started/aws/ecs/troubleshooting/_index.md
+++ b/doc/content/getting-started/aws/ecs/troubleshooting/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting AWS ECS Deployment"
 description: ""
-weight: 3
+weight: 9
 ---
 
 This section contains information to troubleshoot {{% tts %}} deployment.

--- a/doc/content/getting-started/aws/ecs/updating/_index.md
+++ b/doc/content/getting-started/aws/ecs/updating/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Updating"
 description: ""
-weight: 3
+weight: 6
 ---
 
 This page describes the steps for updating {{% tts %}} on AWS ECS.


### PR DESCRIPTION
#### Summary
https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/815

#### Changes
1. Reorder sections in AMI and ECS deployments
2. Remove `application-server-telemetry` section (deprecated in 3.11.1)
3. In ECS deployment:
  - replace "3.x" with "3.x.y"
  - move TimescaleDB template information so that templates are ordered correctly
  - add information about rate limiting template
  - add information in `1-1` about requesting Let's Encrypt certificates in `5-7`
  - remove `5-3d-ecs-gcs-service` template information

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
