### PR TITLE
Doc/3.18.1 release

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -24,7 +24,7 @@ pygmentsUseClasses = true
   github_repository = "https://github.com/TheThingsIndustries/lorawan-stack-docs"
   github_repository_edit = "https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/content"
   tts_github_repository = "https://github.com/TheThingsNetwork/lorawan-stack"
-  version = "3.18.0"
+  version = "3.18.1"
 
 [markup]
   [markup.goldmark]

--- a/doc/content/reference/api/end_device.md
+++ b/doc/content/reference/api/end_device.md
@@ -123,11 +123,17 @@ See the [EndDevice message](#message:EndDevice) and its sub-messages for additio
 
 ## The `EndDeviceClaimingServer` service
 
-{{< proto/method service="EndDeviceClaimingServer" method="Claim" >}}
-
 {{< proto/method service="EndDeviceClaimingServer" method="AuthorizeApplication" >}}
 
+{{< proto/method service="EndDeviceClaimingServer" method="Claim" >}}
+
+{{< proto/method service="EndDeviceClaimingServer" method="GetClaimStatus" >}}
+
+{{< proto/method service="EndDeviceClaimingServer" method="GetInfoByJoinEUI" >}}
+
 {{< proto/method service="EndDeviceClaimingServer" method="UnauthorizeApplication" >}}
+
+{{< proto/method service="EndDeviceClaimingServer" method="Unclaim" >}}
 
 ## Messages
 
@@ -192,6 +198,14 @@ See the [EndDevice message](#message:EndDevice) and its sub-messages for additio
 {{< proto/message message="GatewayIdentifiers" >}}
 
 {{< proto/message message="GatewayAntennaIdentifiers" >}}
+
+{{< proto/message message="GetClaimStatusResponse" >}}
+
+{{< proto/message message="GetClaimStatusResponse.VendorSpecific" >}}
+
+{{< proto/message message="GetInfoByJoinEUIRequest" >}}
+
+{{< proto/message message="GetInfoByJoinEUIResponse" >}}
 
 {{< proto/message message="GetEndDeviceRequest" >}}
 

--- a/doc/content/reference/api/gateway_server.md
+++ b/doc/content/reference/api/gateway_server.md
@@ -3,13 +3,25 @@ title: "Gateway Server APIs"
 description: ""
 ---
 
-## <a name="Gs">The `Gs` service</a>
+## The `Gs` service
 
 {{< proto/method service="Gs" method="GetGatewayConnectionStats" >}}
+
+## The `GatewayConfigurator` service
+
+{{< proto/method service="GatewayConfigurator" method="PullConfiguration" >}}
+
+## The `GatewayConfigurationService` service
+
+{{< proto/method service="GatewayConfigurationService" method="GetGatewayConfiguration" >}}
 
 ## Messages
 
 {{< proto/message message="GatewayIdentifiers" >}}
+
+{{< proto/message message="GetGatewayConfigurationRequest" >}}
+
+{{< proto/message message="GetGatewayConfigurationResponse" >}}
 
 {{< proto/message message="GatewayConnectionStats" >}}
 
@@ -20,6 +32,8 @@ description: ""
 {{< proto/message message="GatewayStatus" >}}
 
 {{< proto/message message="Location" >}}
+
+{{< proto/message message="PullGatewayConfigurationRequest" >}}
 
 ## Enums
 

--- a/doc/content/ttn-lw-cli/ttn-lw-cli.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli"
 slug: ttn-lw-cli
-
 ---
 
 ## ttn-lw-cli

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications"
 slug: ttn-lw-cli_applications
-
 ---
 
 ## ttn-lw-cli applications

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications activation-settings"
 slug: ttn-lw-cli_applications_activation-settings
-
 ---
 
 ## ttn-lw-cli applications activation-settings

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications activation-settings delete"
 slug: ttn-lw-cli_applications_activation-settings_delete
-
 ---
 
 ## ttn-lw-cli applications activation-settings delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications activation-settings get"
 slug: ttn-lw-cli_applications_activation-settings_get
-
 ---
 
 ## ttn-lw-cli applications activation-settings get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_activation-settings_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications activation-settings set"
 slug: ttn-lw-cli_applications_activation-settings_set
-
 ---
 
 ## ttn-lw-cli applications activation-settings set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys"
 slug: ttn-lw-cli_applications_api-keys
-
 ---
 
 ## ttn-lw-cli applications api-keys

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys create"
 slug: ttn-lw-cli_applications_api-keys_create
-
 ---
 
 ## ttn-lw-cli applications api-keys create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys delete"
 slug: ttn-lw-cli_applications_api-keys_delete
-
 ---
 
 ## ttn-lw-cli applications api-keys delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys get"
 slug: ttn-lw-cli_applications_api-keys_get
-
 ---
 
 ## ttn-lw-cli applications api-keys get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys list"
 slug: ttn-lw-cli_applications_api-keys_list
-
 ---
 
 ## ttn-lw-cli applications api-keys list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_api-keys_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications api-keys set"
 slug: ttn-lw-cli_applications_api-keys_set
-
 ---
 
 ## ttn-lw-cli applications api-keys set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications claim"
 slug: ttn-lw-cli_applications_claim
-
 ---
 
 ## ttn-lw-cli applications claim

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim_authorize.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim_authorize.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications claim authorize"
 slug: ttn-lw-cli_applications_claim_authorize
-
 ---
 
 ## ttn-lw-cli applications claim authorize

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim_unauthorize.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_claim_unauthorize.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications claim unauthorize"
 slug: ttn-lw-cli_applications_claim_unauthorize
-
 ---
 
 ## ttn-lw-cli applications claim unauthorize

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications collaborators"
 slug: ttn-lw-cli_applications_collaborators
-
 ---
 
 ## ttn-lw-cli applications collaborators

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications collaborators delete"
 slug: ttn-lw-cli_applications_collaborators_delete
-
 ---
 
 ## ttn-lw-cli applications collaborators delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications collaborators get"
 slug: ttn-lw-cli_applications_collaborators_get
-
 ---
 
 ## ttn-lw-cli applications collaborators get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications collaborators list"
 slug: ttn-lw-cli_applications_collaborators_list
-
 ---
 
 ## ttn-lw-cli applications collaborators list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_collaborators_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications collaborators set"
 slug: ttn-lw-cli_applications_collaborators_set
-
 ---
 
 ## ttn-lw-cli applications collaborators set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info"
 slug: ttn-lw-cli_applications_contact-info
-
 ---
 
 ## ttn-lw-cli applications contact-info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info create"
 slug: ttn-lw-cli_applications_contact-info_create
-
 ---
 
 ## ttn-lw-cli applications contact-info create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info delete"
 slug: ttn-lw-cli_applications_contact-info_delete
-
 ---
 
 ## ttn-lw-cli applications contact-info delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info list"
 slug: ttn-lw-cli_applications_contact-info_list
-
 ---
 
 ## ttn-lw-cli applications contact-info list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_request-validation.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_request-validation.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info request-validation"
 slug: ttn-lw-cli_applications_contact-info_request-validation
-
 ---
 
 ## ttn-lw-cli applications contact-info request-validation

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_validate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_contact-info_validate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications contact-info validate"
 slug: ttn-lw-cli_applications_contact-info_validate
-
 ---
 
 ## ttn-lw-cli applications contact-info validate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications create"
 slug: ttn-lw-cli_applications_create
-
 ---
 
 ## ttn-lw-cli applications create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications delete"
 slug: ttn-lw-cli_applications_delete
-
 ---
 
 ## ttn-lw-cli applications delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications get"
 slug: ttn-lw-cli_applications_get
-
 ---
 
 ## ttn-lw-cli applications get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_issue-dev-eui.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_issue-dev-eui.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications issue-dev-eui"
 slug: ttn-lw-cli_applications_issue-dev-eui
-
 ---
 
 ## ttn-lw-cli applications issue-dev-eui

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications link"
 slug: ttn-lw-cli_applications_link
-
 ---
 
 ## ttn-lw-cli applications link

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications link delete"
 slug: ttn-lw-cli_applications_link_delete
-
 ---
 
 ## ttn-lw-cli applications link delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications link get"
 slug: ttn-lw-cli_applications_link_get
-
 ---
 
 ## ttn-lw-cli applications link get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_link_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications link set"
 slug: ttn-lw-cli_applications_link_set
-
 ---
 
 ## ttn-lw-cli applications link set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications list"
 slug: ttn-lw-cli_applications_list
-
 ---
 
 ## ttn-lw-cli applications list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages"
 slug: ttn-lw-cli_applications_packages
-
 ---
 
 ## ttn-lw-cli applications packages

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages associations"
 slug: ttn-lw-cli_applications_packages_associations
-
 ---
 
 ## ttn-lw-cli applications packages associations

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages associations delete"
 slug: ttn-lw-cli_applications_packages_associations_delete
-
 ---
 
 ## ttn-lw-cli applications packages associations delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages associations get"
 slug: ttn-lw-cli_applications_packages_associations_get
-
 ---
 
 ## ttn-lw-cli applications packages associations get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages associations list"
 slug: ttn-lw-cli_applications_packages_associations_list
-
 ---
 
 ## ttn-lw-cli applications packages associations list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_associations_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages associations set"
 slug: ttn-lw-cli_applications_packages_associations_set
-
 ---
 
 ## ttn-lw-cli applications packages associations set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages default-associations"
 slug: ttn-lw-cli_applications_packages_default-associations
-
 ---
 
 ## ttn-lw-cli applications packages default-associations

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages default-associations delete"
 slug: ttn-lw-cli_applications_packages_default-associations_delete
-
 ---
 
 ## ttn-lw-cli applications packages default-associations delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages default-associations get"
 slug: ttn-lw-cli_applications_packages_default-associations_get
-
 ---
 
 ## ttn-lw-cli applications packages default-associations get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages default-associations list"
 slug: ttn-lw-cli_applications_packages_default-associations_list
-
 ---
 
 ## ttn-lw-cli applications packages default-associations list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_default-associations_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages default-associations set"
 slug: ttn-lw-cli_applications_packages_default-associations_set
-
 ---
 
 ## ttn-lw-cli applications packages default-associations set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_packages_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications packages list"
 slug: ttn-lw-cli_applications_packages_list
-
 ---
 
 ## ttn-lw-cli applications packages list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs"
 slug: ttn-lw-cli_applications_pubsubs
-
 ---
 
 ## ttn-lw-cli applications pubsubs

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs delete"
 slug: ttn-lw-cli_applications_pubsubs_delete
-
 ---
 
 ## ttn-lw-cli applications pubsubs delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_get-formats.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_get-formats.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs get-formats"
 slug: ttn-lw-cli_applications_pubsubs_get-formats
-
 ---
 
 ## ttn-lw-cli applications pubsubs get-formats

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs get"
 slug: ttn-lw-cli_applications_pubsubs_get
-
 ---
 
 ## ttn-lw-cli applications pubsubs get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs list"
 slug: ttn-lw-cli_applications_pubsubs_list
-
 ---
 
 ## ttn-lw-cli applications pubsubs list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_pubsubs_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications pubsubs set"
 slug: ttn-lw-cli_applications_pubsubs_set
-
 ---
 
 ## ttn-lw-cli applications pubsubs set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_purge.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_purge.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications purge"
 slug: ttn-lw-cli_applications_purge
-
 ---
 
 ## ttn-lw-cli applications purge

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_restore.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_restore.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications restore"
 slug: ttn-lw-cli_applications_restore
-
 ---
 
 ## ttn-lw-cli applications restore

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_rights.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_rights.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications rights"
 slug: ttn-lw-cli_applications_rights
-
 ---
 
 ## ttn-lw-cli applications rights

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications search"
 slug: ttn-lw-cli_applications_search
-
 ---
 
 ## ttn-lw-cli applications search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications set"
 slug: ttn-lw-cli_applications_set
-
 ---
 
 ## ttn-lw-cli applications set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications storage"
 slug: ttn-lw-cli_applications_storage
-
 ---
 
 ## ttn-lw-cli applications storage

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage_count.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage_count.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications storage count"
 slug: ttn-lw-cli_applications_storage_count
-
 ---
 
 ## ttn-lw-cli applications storage count

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_storage_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications storage get"
 slug: ttn-lw-cli_applications_storage_get
-
 ---
 
 ## ttn-lw-cli applications storage get
@@ -152,6 +151,7 @@ ttn-lw-cli applications storage get [application-id] [flags]
       --up.uplink-message.session-key-id                                                 select the up.uplink_message.session_key_id field
       --up.uplink-message.settings                                                       select the up.uplink_message.settings field and all allowed sub-fields
       --up.uplink-message.settings.coding-rate                                           select the up.uplink_message.settings.coding_rate field
+      --up.uplink-message.settings.concentrator-timestamp                                select the up.uplink_message.settings.concentrator_timestamp field
       --up.uplink-message.settings.data-rate                                             select the up.uplink_message.settings.data_rate field and all allowed sub-fields
       --up.uplink-message.settings.data-rate.modulation.fsk                              select the up.uplink_message.settings.data_rate.modulation.fsk field and all allowed sub-fields
       --up.uplink-message.settings.data-rate.modulation.fsk.bit-rate                     select the up.uplink_message.settings.data_rate.modulation.fsk.bit_rate field

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_subscribe.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_subscribe.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications subscribe"
 slug: ttn-lw-cli_applications_subscribe
-
 ---
 
 ## ttn-lw-cli applications subscribe

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks"
 slug: ttn-lw-cli_applications_webhooks
-
 ---
 
 ## ttn-lw-cli applications webhooks

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks delete"
 slug: ttn-lw-cli_applications_webhooks_delete
-
 ---
 
 ## ttn-lw-cli applications webhooks delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_get-formats.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_get-formats.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks get-formats"
 slug: ttn-lw-cli_applications_webhooks_get-formats
-
 ---
 
 ## ttn-lw-cli applications webhooks get-formats

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks get"
 slug: ttn-lw-cli_applications_webhooks_get
-
 ---
 
 ## ttn-lw-cli applications webhooks get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks list"
 slug: ttn-lw-cli_applications_webhooks_list
-
 ---
 
 ## ttn-lw-cli applications webhooks list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_applications_webhooks_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli applications webhooks set"
 slug: ttn-lw-cli_applications_webhooks_set
-
 ---
 
 ## ttn-lw-cli applications webhooks set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers"
 slug: ttn-lw-cli_authentication-providers
-
 ---
 
 ## ttn-lw-cli authentication-providers

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers create"
 slug: ttn-lw-cli_authentication-providers_create
-
 ---
 
 ## ttn-lw-cli authentication-providers create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers delete"
 slug: ttn-lw-cli_authentication-providers_delete
-
 ---
 
 ## ttn-lw-cli authentication-providers delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers get"
 slug: ttn-lw-cli_authentication-providers_get
-
 ---
 
 ## ttn-lw-cli authentication-providers get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers list"
 slug: ttn-lw-cli_authentication-providers_list
-
 ---
 
 ## ttn-lw-cli authentication-providers list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_update.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_authentication-providers_update.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli authentication-providers update"
 slug: ttn-lw-cli_authentication-providers_update
-
 ---
 
 ## ttn-lw-cli authentication-providers update

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients"
 slug: ttn-lw-cli_clients
-
 ---
 
 ## ttn-lw-cli clients

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients collaborators"
 slug: ttn-lw-cli_clients_collaborators
-
 ---
 
 ## ttn-lw-cli clients collaborators

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients collaborators delete"
 slug: ttn-lw-cli_clients_collaborators_delete
-
 ---
 
 ## ttn-lw-cli clients collaborators delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients collaborators get"
 slug: ttn-lw-cli_clients_collaborators_get
-
 ---
 
 ## ttn-lw-cli clients collaborators get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients collaborators list"
 slug: ttn-lw-cli_clients_collaborators_list
-
 ---
 
 ## ttn-lw-cli clients collaborators list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_collaborators_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients collaborators set"
 slug: ttn-lw-cli_clients_collaborators_set
-
 ---
 
 ## ttn-lw-cli clients collaborators set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info"
 slug: ttn-lw-cli_clients_contact-info
-
 ---
 
 ## ttn-lw-cli clients contact-info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info create"
 slug: ttn-lw-cli_clients_contact-info_create
-
 ---
 
 ## ttn-lw-cli clients contact-info create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info delete"
 slug: ttn-lw-cli_clients_contact-info_delete
-
 ---
 
 ## ttn-lw-cli clients contact-info delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info list"
 slug: ttn-lw-cli_clients_contact-info_list
-
 ---
 
 ## ttn-lw-cli clients contact-info list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_request-validation.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_request-validation.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info request-validation"
 slug: ttn-lw-cli_clients_contact-info_request-validation
-
 ---
 
 ## ttn-lw-cli clients contact-info request-validation

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_validate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_contact-info_validate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients contact-info validate"
 slug: ttn-lw-cli_clients_contact-info_validate
-
 ---
 
 ## ttn-lw-cli clients contact-info validate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients create"
 slug: ttn-lw-cli_clients_create
-
 ---
 
 ## ttn-lw-cli clients create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients delete"
 slug: ttn-lw-cli_clients_delete
-
 ---
 
 ## ttn-lw-cli clients delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients get"
 slug: ttn-lw-cli_clients_get
-
 ---
 
 ## ttn-lw-cli clients get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients list"
 slug: ttn-lw-cli_clients_list
-
 ---
 
 ## ttn-lw-cli clients list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_purge.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_purge.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients purge"
 slug: ttn-lw-cli_clients_purge
-
 ---
 
 ## ttn-lw-cli clients purge

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_restore.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_restore.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients restore"
 slug: ttn-lw-cli_clients_restore
-
 ---
 
 ## ttn-lw-cli clients restore

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_rights.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_rights.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients rights"
 slug: ttn-lw-cli_clients_rights
-
 ---
 
 ## ttn-lw-cli clients rights

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients search"
 slug: ttn-lw-cli_clients_search
-
 ---
 
 ## ttn-lw-cli clients search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_clients_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_clients_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli clients set"
 slug: ttn-lw-cli_clients_set
-
 ---
 
 ## ttn-lw-cli clients set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_config.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_config.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli config"
 slug: ttn-lw-cli_config
-
 ---
 
 ## ttn-lw-cli config

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices"
 slug: ttn-lw-cli_end-devices
-
 ---
 
 ## ttn-lw-cli end-devices

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_claim.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_claim.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices claim"
 slug: ttn-lw-cli_end-devices_claim
-
 ---
 
 ## ttn-lw-cli end-devices claim

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices create"
 slug: ttn-lw-cli_end-devices_create
-
 ---
 
 ## ttn-lw-cli end-devices create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices delete"
 slug: ttn-lw-cli_end-devices_delete
-
 ---
 
 ## ttn-lw-cli end-devices delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices downlink"
 slug: ttn-lw-cli_end-devices_downlink
-
 ---
 
 ## ttn-lw-cli end-devices downlink

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_clear.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_clear.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices downlink clear"
 slug: ttn-lw-cli_end-devices_downlink_clear
-
 ---
 
 ## ttn-lw-cli end-devices downlink clear

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices downlink list"
 slug: ttn-lw-cli_end-devices_downlink_list
-
 ---
 
 ## ttn-lw-cli end-devices downlink list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_push.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_push.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices downlink push"
 slug: ttn-lw-cli_end-devices_downlink_push
-
 ---
 
 ## ttn-lw-cli end-devices downlink push

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_replace.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_downlink_replace.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices downlink replace"
 slug: ttn-lw-cli_end-devices_downlink_replace
-
 ---
 
 ## ttn-lw-cli end-devices downlink replace

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_generate-qr.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_generate-qr.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices generate-qr"
 slug: ttn-lw-cli_end-devices_generate-qr
-
 ---
 
 ## ttn-lw-cli end-devices generate-qr

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_get-default-mac-settings.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_get-default-mac-settings.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices get-default-mac-settings"
 slug: ttn-lw-cli_end-devices_get-default-mac-settings
-
 ---
 
 ## ttn-lw-cli end-devices get-default-mac-settings

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices get"
 slug: ttn-lw-cli_end-devices_get
-
 ---
 
 ## ttn-lw-cli end-devices get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list-frequency-plans.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list-frequency-plans.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices list-frequency-plans"
 slug: ttn-lw-cli_end-devices_list-frequency-plans
-
 ---
 
 ## ttn-lw-cli end-devices list-frequency-plans

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list-qr-formats.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list-qr-formats.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices list-qr-formats"
 slug: ttn-lw-cli_end-devices_list-qr-formats
-
 ---
 
 ## ttn-lw-cli end-devices list-qr-formats

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices list"
 slug: ttn-lw-cli_end-devices_list
-
 ---
 
 ## ttn-lw-cli end-devices list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_provision.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_provision.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices provision"
 slug: ttn-lw-cli_end-devices_provision
-
 ---
 
 ## ttn-lw-cli end-devices provision

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_reset.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_reset.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices reset"
 slug: ttn-lw-cli_end-devices_reset
-
 ---
 
 ## ttn-lw-cli end-devices reset

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices search"
 slug: ttn-lw-cli_end-devices_search
-
 ---
 
 ## ttn-lw-cli end-devices search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices set"
 slug: ttn-lw-cli_end-devices_set
-
 ---
 
 ## ttn-lw-cli end-devices set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices storage"
 slug: ttn-lw-cli_end-devices_storage
-
 ---
 
 ## ttn-lw-cli end-devices storage

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage_count.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage_count.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices storage count"
 slug: ttn-lw-cli_end-devices_storage_count
-
 ---
 
 ## ttn-lw-cli end-devices storage count

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_storage_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices storage get"
 slug: ttn-lw-cli_end-devices_storage_get
-
 ---
 
 ## ttn-lw-cli end-devices storage get
@@ -155,6 +154,7 @@ ttn-lw-cli end-devices storage get [application-id] [device-id] [flags]
       --up.uplink-message.session-key-id                                                 select the up.uplink_message.session_key_id field
       --up.uplink-message.settings                                                       select the up.uplink_message.settings field and all allowed sub-fields
       --up.uplink-message.settings.coding-rate                                           select the up.uplink_message.settings.coding_rate field
+      --up.uplink-message.settings.concentrator-timestamp                                select the up.uplink_message.settings.concentrator_timestamp field
       --up.uplink-message.settings.data-rate                                             select the up.uplink_message.settings.data_rate field and all allowed sub-fields
       --up.uplink-message.settings.data-rate.modulation.fsk                              select the up.uplink_message.settings.data_rate.modulation.fsk field and all allowed sub-fields
       --up.uplink-message.settings.data-rate.modulation.fsk.bit-rate                     select the up.uplink_message.settings.data_rate.modulation.fsk.bit_rate field

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_use-external-join-server.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_end-devices_use-external-join-server.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli end-devices use-external-join-server"
 slug: ttn-lw-cli_end-devices_use-external-join-server
-
 ---
 
 ## ttn-lw-cli end-devices use-external-join-server

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_events.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_events.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli events"
 slug: ttn-lw-cli_events
-
 ---
 
 ## ttn-lw-cli events

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_events_find-related.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_events_find-related.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli events find-related"
 slug: ttn-lw-cli_events_find-related
-
 ---
 
 ## ttn-lw-cli events find-related

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_external-users.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_external-users.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli external-users"
 slug: ttn-lw-cli_external-users
-
 ---
 
 ## ttn-lw-cli external-users

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli external-users create"
 slug: ttn-lw-cli_external-users_create
-
 ---
 
 ## ttn-lw-cli external-users create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli external-users delete"
 slug: ttn-lw-cli_external-users_delete
-
 ---
 
 ## ttn-lw-cli external-users delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_get-by-external-id.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_get-by-external-id.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli external-users get-by-external-id"
 slug: ttn-lw-cli_external-users_get-by-external-id
-
 ---
 
 ## ttn-lw-cli external-users get-by-external-id

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_get-by-user-id.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_external-users_get-by-user-id.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli external-users get-by-user-id"
 slug: ttn-lw-cli_external-users_get-by-user-id
-
 ---
 
 ## ttn-lw-cli external-users get-by-user-id

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways"
 slug: ttn-lw-cli_gateways
-
 ---
 
 ## ttn-lw-cli gateways

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys"
 slug: ttn-lw-cli_gateways_api-keys
-
 ---
 
 ## ttn-lw-cli gateways api-keys

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys create"
 slug: ttn-lw-cli_gateways_api-keys_create
-
 ---
 
 ## ttn-lw-cli gateways api-keys create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys delete"
 slug: ttn-lw-cli_gateways_api-keys_delete
-
 ---
 
 ## ttn-lw-cli gateways api-keys delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys get"
 slug: ttn-lw-cli_gateways_api-keys_get
-
 ---
 
 ## ttn-lw-cli gateways api-keys get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys list"
 slug: ttn-lw-cli_gateways_api-keys_list
-
 ---
 
 ## ttn-lw-cli gateways api-keys list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_api-keys_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways api-keys set"
 slug: ttn-lw-cli_gateways_api-keys_set
-
 ---
 
 ## ttn-lw-cli gateways api-keys set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways claim"
 slug: ttn-lw-cli_gateways_claim
-
 ---
 
 ## ttn-lw-cli gateways claim

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim_authorize.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim_authorize.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways claim authorize"
 slug: ttn-lw-cli_gateways_claim_authorize
-
 ---
 
 ## ttn-lw-cli gateways claim authorize

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim_unauthorize.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_claim_unauthorize.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways claim unauthorize"
 slug: ttn-lw-cli_gateways_claim_unauthorize
-
 ---
 
 ## ttn-lw-cli gateways claim unauthorize

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways collaborators"
 slug: ttn-lw-cli_gateways_collaborators
-
 ---
 
 ## ttn-lw-cli gateways collaborators

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways collaborators delete"
 slug: ttn-lw-cli_gateways_collaborators_delete
-
 ---
 
 ## ttn-lw-cli gateways collaborators delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways collaborators get"
 slug: ttn-lw-cli_gateways_collaborators_get
-
 ---
 
 ## ttn-lw-cli gateways collaborators get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways collaborators list"
 slug: ttn-lw-cli_gateways_collaborators_list
-
 ---
 
 ## ttn-lw-cli gateways collaborators list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_collaborators_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways collaborators set"
 slug: ttn-lw-cli_gateways_collaborators_set
-
 ---
 
 ## ttn-lw-cli gateways collaborators set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info"
 slug: ttn-lw-cli_gateways_contact-info
-
 ---
 
 ## ttn-lw-cli gateways contact-info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info create"
 slug: ttn-lw-cli_gateways_contact-info_create
-
 ---
 
 ## ttn-lw-cli gateways contact-info create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info delete"
 slug: ttn-lw-cli_gateways_contact-info_delete
-
 ---
 
 ## ttn-lw-cli gateways contact-info delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info list"
 slug: ttn-lw-cli_gateways_contact-info_list
-
 ---
 
 ## ttn-lw-cli gateways contact-info list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_request-validation.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_request-validation.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info request-validation"
 slug: ttn-lw-cli_gateways_contact-info_request-validation
-
 ---
 
 ## ttn-lw-cli gateways contact-info request-validation

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_validate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_contact-info_validate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways contact-info validate"
 slug: ttn-lw-cli_gateways_contact-info_validate
-
 ---
 
 ## ttn-lw-cli gateways contact-info validate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways create"
 slug: ttn-lw-cli_gateways_create
-
 ---
 
 ## ttn-lw-cli gateways create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways delete"
 slug: ttn-lw-cli_gateways_delete
-
 ---
 
 ## ttn-lw-cli gateways delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_get-connection-stats.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_get-connection-stats.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways get-connection-stats"
 slug: ttn-lw-cli_gateways_get-connection-stats
-
 ---
 
 ## ttn-lw-cli gateways get-connection-stats

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways get"
 slug: ttn-lw-cli_gateways_get
-
 ---
 
 ## ttn-lw-cli gateways get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_list-frequency-plans.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_list-frequency-plans.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways list-frequency-plans"
 slug: ttn-lw-cli_gateways_list-frequency-plans
-
 ---
 
 ## ttn-lw-cli gateways list-frequency-plans

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways list"
 slug: ttn-lw-cli_gateways_list
-
 ---
 
 ## ttn-lw-cli gateways list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_purge.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_purge.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways purge"
 slug: ttn-lw-cli_gateways_purge
-
 ---
 
 ## ttn-lw-cli gateways purge

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_restore.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_restore.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways restore"
 slug: ttn-lw-cli_gateways_restore
-
 ---
 
 ## ttn-lw-cli gateways restore

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_rights.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_rights.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways rights"
 slug: ttn-lw-cli_gateways_rights
-
 ---
 
 ## ttn-lw-cli gateways rights

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways search"
 slug: ttn-lw-cli_gateways_search
-
 ---
 
 ## ttn-lw-cli gateways search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_gateways_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli gateways set"
 slug: ttn-lw-cli_gateways_set
-
 ---
 
 ## ttn-lw-cli gateways set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_login.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_login.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli login"
 slug: ttn-lw-cli_login
-
 ---
 
 ## ttn-lw-cli login

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_logout.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_logout.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli logout"
 slug: ttn-lw-cli_logout
-
 ---
 
 ## ttn-lw-cli logout

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_lorawan.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_lorawan.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli lorawan"
 slug: ttn-lw-cli_lorawan
-
 ---
 
 ## ttn-lw-cli lorawan

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_lorawan_decode.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_lorawan_decode.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli lorawan decode"
 slug: ttn-lw-cli_lorawan_decode
-
 ---
 
 ## ttn-lw-cli lorawan decode

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations"
 slug: ttn-lw-cli_organizations
-
 ---
 
 ## ttn-lw-cli organizations

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys"
 slug: ttn-lw-cli_organizations_api-keys
-
 ---
 
 ## ttn-lw-cli organizations api-keys

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys create"
 slug: ttn-lw-cli_organizations_api-keys_create
-
 ---
 
 ## ttn-lw-cli organizations api-keys create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys delete"
 slug: ttn-lw-cli_organizations_api-keys_delete
-
 ---
 
 ## ttn-lw-cli organizations api-keys delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys get"
 slug: ttn-lw-cli_organizations_api-keys_get
-
 ---
 
 ## ttn-lw-cli organizations api-keys get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys list"
 slug: ttn-lw-cli_organizations_api-keys_list
-
 ---
 
 ## ttn-lw-cli organizations api-keys list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_api-keys_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations api-keys set"
 slug: ttn-lw-cli_organizations_api-keys_set
-
 ---
 
 ## ttn-lw-cli organizations api-keys set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations collaborators"
 slug: ttn-lw-cli_organizations_collaborators
-
 ---
 
 ## ttn-lw-cli organizations collaborators

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations collaborators delete"
 slug: ttn-lw-cli_organizations_collaborators_delete
-
 ---
 
 ## ttn-lw-cli organizations collaborators delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations collaborators get"
 slug: ttn-lw-cli_organizations_collaborators_get
-
 ---
 
 ## ttn-lw-cli organizations collaborators get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations collaborators list"
 slug: ttn-lw-cli_organizations_collaborators_list
-
 ---
 
 ## ttn-lw-cli organizations collaborators list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_collaborators_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations collaborators set"
 slug: ttn-lw-cli_organizations_collaborators_set
-
 ---
 
 ## ttn-lw-cli organizations collaborators set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info"
 slug: ttn-lw-cli_organizations_contact-info
-
 ---
 
 ## ttn-lw-cli organizations contact-info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info create"
 slug: ttn-lw-cli_organizations_contact-info_create
-
 ---
 
 ## ttn-lw-cli organizations contact-info create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info delete"
 slug: ttn-lw-cli_organizations_contact-info_delete
-
 ---
 
 ## ttn-lw-cli organizations contact-info delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info list"
 slug: ttn-lw-cli_organizations_contact-info_list
-
 ---
 
 ## ttn-lw-cli organizations contact-info list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_request-validation.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_request-validation.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info request-validation"
 slug: ttn-lw-cli_organizations_contact-info_request-validation
-
 ---
 
 ## ttn-lw-cli organizations contact-info request-validation

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_validate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_contact-info_validate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations contact-info validate"
 slug: ttn-lw-cli_organizations_contact-info_validate
-
 ---
 
 ## ttn-lw-cli organizations contact-info validate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations create"
 slug: ttn-lw-cli_organizations_create
-
 ---
 
 ## ttn-lw-cli organizations create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations delete"
 slug: ttn-lw-cli_organizations_delete
-
 ---
 
 ## ttn-lw-cli organizations delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations get"
 slug: ttn-lw-cli_organizations_get
-
 ---
 
 ## ttn-lw-cli organizations get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations list"
 slug: ttn-lw-cli_organizations_list
-
 ---
 
 ## ttn-lw-cli organizations list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_purge.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_purge.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations purge"
 slug: ttn-lw-cli_organizations_purge
-
 ---
 
 ## ttn-lw-cli organizations purge

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_restore.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_restore.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations restore"
 slug: ttn-lw-cli_organizations_restore
-
 ---
 
 ## ttn-lw-cli organizations restore

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_rights.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_rights.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations rights"
 slug: ttn-lw-cli_organizations_rights
-
 ---
 
 ## ttn-lw-cli organizations rights

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations search"
 slug: ttn-lw-cli_organizations_search
-
 ---
 
 ## ttn-lw-cli organizations search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_organizations_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli organizations set"
 slug: ttn-lw-cli_organizations_set
-
 ---
 
 ## ttn-lw-cli organizations set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker"
 slug: ttn-lw-cli_packetbroker
-
 ---
 
 ## ttn-lw-cli packetbroker

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_deregister.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_deregister.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker deregister"
 slug: ttn-lw-cli_packetbroker_deregister
-
 ---
 
 ## ttn-lw-cli packetbroker deregister

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker forwarders"
 slug: ttn-lw-cli_packetbroker_forwarders
-
 ---
 
 ## ttn-lw-cli packetbroker forwarders

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders_policies.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders_policies.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker forwarders policies"
 slug: ttn-lw-cli_packetbroker_forwarders_policies
-
 ---
 
 ## ttn-lw-cli packetbroker forwarders policies

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders_policies_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_forwarders_policies_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker forwarders policies list"
 slug: ttn-lw-cli_packetbroker_forwarders_policies_list
-
 ---
 
 ## ttn-lw-cli packetbroker forwarders policies list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks"
 slug: ttn-lw-cli_packetbroker_home-networks
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks gateway-visibilities"
 slug: ttn-lw-cli_packetbroker_home-networks_gateway-visibilities
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks gateway-visibilities

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks gateway-visibilities delete"
 slug: ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_delete
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks gateway-visibilities delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks gateway-visibilities get"
 slug: ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_get
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks gateway-visibilities get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks gateway-visibilities set"
 slug: ttn-lw-cli_packetbroker_home-networks_gateway-visibilities_set
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks gateway-visibilities set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks list"
 slug: ttn-lw-cli_packetbroker_home-networks_list
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks policies"
 slug: ttn-lw-cli_packetbroker_home-networks_policies
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks policies

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks policies delete"
 slug: ttn-lw-cli_packetbroker_home-networks_policies_delete
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks policies delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks policies get"
 slug: ttn-lw-cli_packetbroker_home-networks_policies_get
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks policies get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks policies list"
 slug: ttn-lw-cli_packetbroker_home-networks_policies_list
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks policies list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_home-networks_policies_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker home-networks policies set"
 slug: ttn-lw-cli_packetbroker_home-networks_policies_set
-
 ---
 
 ## ttn-lw-cli packetbroker home-networks policies set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker info"
 slug: ttn-lw-cli_packetbroker_info
-
 ---
 
 ## ttn-lw-cli packetbroker info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_networks.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_networks.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker networks"
 slug: ttn-lw-cli_packetbroker_networks
-
 ---
 
 ## ttn-lw-cli packetbroker networks

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_networks_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_networks_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker networks list"
 slug: ttn-lw-cli_packetbroker_networks_list
-
 ---
 
 ## ttn-lw-cli packetbroker networks list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_register.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_packetbroker_register.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli packetbroker register"
 slug: ttn-lw-cli_packetbroker_register
-
 ---
 
 ## ttn-lw-cli packetbroker register

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_simulate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_simulate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli simulate"
 slug: ttn-lw-cli_simulate
-
 ---
 
 ## ttn-lw-cli simulate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_simulate_application-uplink.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_simulate_application-uplink.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli simulate application-uplink"
 slug: ttn-lw-cli_simulate_application-uplink
-
 ---
 
 ## ttn-lw-cli simulate application-uplink
@@ -36,6 +35,7 @@ ttn-lw-cli simulate application-uplink [application-id] [device-id] [flags]
       --received-at string                                                    (YYYY-MM-DDTHH:MM:SSZ)
       --session-key-id string                                                 (hex)
       --settings.coding-rate string                                           
+      --settings.concentrator-timestamp int                                   
       --settings.data-rate.modulation.fsk.bit-rate uint32                     
       --settings.data-rate.modulation.lora.bandwidth uint32                   
       --settings.data-rate.modulation.lora.spreading-factor uint32            

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates"
 slug: ttn-lw-cli_templates
-
 ---
 
 ## ttn-lw-cli templates

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_assign-euis.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_assign-euis.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates assign-euis"
 slug: ttn-lw-cli_templates_assign-euis
-
 ---
 
 ## ttn-lw-cli templates assign-euis

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates create"
 slug: ttn-lw-cli_templates_create
-
 ---
 
 ## ttn-lw-cli templates create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_execute.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_execute.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates execute"
 slug: ttn-lw-cli_templates_execute
-
 ---
 
 ## ttn-lw-cli templates execute

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_extend.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_extend.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates extend"
 slug: ttn-lw-cli_templates_extend
-
 ---
 
 ## ttn-lw-cli templates extend

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_from-data.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_from-data.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates from-data"
 slug: ttn-lw-cli_templates_from-data
-
 ---
 
 ## ttn-lw-cli templates from-data

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_list-formats.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_list-formats.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates list-formats"
 slug: ttn-lw-cli_templates_list-formats
-
 ---
 
 ## ttn-lw-cli templates list-formats

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_templates_map.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_templates_map.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli templates map"
 slug: ttn-lw-cli_templates_map
-
 ---
 
 ## ttn-lw-cli templates map

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants"
 slug: ttn-lw-cli_tenants
-
 ---
 
 ## ttn-lw-cli tenants

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants create"
 slug: ttn-lw-cli_tenants_create
-
 ---
 
 ## ttn-lw-cli tenants create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants delete"
 slug: ttn-lw-cli_tenants_delete
-
 ---
 
 ## ttn-lw-cli tenants delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-identifiers-for-end-device-euis.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-identifiers-for-end-device-euis.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants get-identifiers-for-end-device-euis"
 slug: ttn-lw-cli_tenants_get-identifiers-for-end-device-euis
-
 ---
 
 ## ttn-lw-cli tenants get-identifiers-for-end-device-euis

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-identifiers-for-gateway-eui.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-identifiers-for-gateway-eui.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants get-identifiers-for-gateway-eui"
 slug: ttn-lw-cli_tenants_get-identifiers-for-gateway-eui
-
 ---
 
 ## ttn-lw-cli tenants get-identifiers-for-gateway-eui

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-registry-totals.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get-registry-totals.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants get-registry-totals"
 slug: ttn-lw-cli_tenants_get-registry-totals
-
 ---
 
 ## ttn-lw-cli tenants get-registry-totals

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants get"
 slug: ttn-lw-cli_tenants_get
-
 ---
 
 ## ttn-lw-cli tenants get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants list"
 slug: ttn-lw-cli_tenants_list
-
 ---
 
 ## ttn-lw-cli tenants list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants search"
 slug: ttn-lw-cli_tenants_search
-
 ---
 
 ## ttn-lw-cli tenants search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_update.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_tenants_update.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli tenants update"
 slug: ttn-lw-cli_tenants_update
-
 ---
 
 ## ttn-lw-cli tenants update

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_use.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_use.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli use"
 slug: ttn-lw-cli_use
-
 ---
 
 ## ttn-lw-cli use

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users"
 slug: ttn-lw-cli_users
-
 ---
 
 ## ttn-lw-cli users

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys"
 slug: ttn-lw-cli_users_api-keys
-
 ---
 
 ## ttn-lw-cli users api-keys

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys create"
 slug: ttn-lw-cli_users_api-keys_create
-
 ---
 
 ## ttn-lw-cli users api-keys create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys delete"
 slug: ttn-lw-cli_users_api-keys_delete
-
 ---
 
 ## ttn-lw-cli users api-keys delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys get"
 slug: ttn-lw-cli_users_api-keys_get
-
 ---
 
 ## ttn-lw-cli users api-keys get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys list"
 slug: ttn-lw-cli_users_api-keys_list
-
 ---
 
 ## ttn-lw-cli users api-keys list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_api-keys_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users api-keys set"
 slug: ttn-lw-cli_users_api-keys_set
-
 ---
 
 ## ttn-lw-cli users api-keys set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info"
 slug: ttn-lw-cli_users_contact-info
-
 ---
 
 ## ttn-lw-cli users contact-info

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info create"
 slug: ttn-lw-cli_users_contact-info_create
-
 ---
 
 ## ttn-lw-cli users contact-info create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info delete"
 slug: ttn-lw-cli_users_contact-info_delete
-
 ---
 
 ## ttn-lw-cli users contact-info delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info list"
 slug: ttn-lw-cli_users_contact-info_list
-
 ---
 
 ## ttn-lw-cli users contact-info list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_request-validation.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_request-validation.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info request-validation"
 slug: ttn-lw-cli_users_contact-info_request-validation
-
 ---
 
 ## ttn-lw-cli users contact-info request-validation

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_validate.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_contact-info_validate.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users contact-info validate"
 slug: ttn-lw-cli_users_contact-info_validate
-
 ---
 
 ## ttn-lw-cli users contact-info validate

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_create-login-token.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_create-login-token.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users create-login-token"
 slug: ttn-lw-cli_users_create-login-token
-
 ---
 
 ## ttn-lw-cli users create-login-token

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users create"
 slug: ttn-lw-cli_users_create
-
 ---
 
 ## ttn-lw-cli users create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users delete"
 slug: ttn-lw-cli_users_delete
-
 ---
 
 ## ttn-lw-cli users delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_forgot-password.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_forgot-password.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users forgot-password"
 slug: ttn-lw-cli_users_forgot-password
-
 ---
 
 ## ttn-lw-cli users forgot-password

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_get.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_get.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users get"
 slug: ttn-lw-cli_users_get
-
 ---
 
 ## ttn-lw-cli users get

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users invitations"
 slug: ttn-lw-cli_users_invitations
-
 ---
 
 ## ttn-lw-cli users invitations

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_create.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_create.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users invitations create"
 slug: ttn-lw-cli_users_invitations_create
-
 ---
 
 ## ttn-lw-cli users invitations create

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users invitations delete"
 slug: ttn-lw-cli_users_invitations_delete
-
 ---
 
 ## ttn-lw-cli users invitations delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_invitations_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users invitations list"
 slug: ttn-lw-cli_users_invitations_list
-
 ---
 
 ## ttn-lw-cli users invitations list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users list"
 slug: ttn-lw-cli_users_list
-
 ---
 
 ## ttn-lw-cli users list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth"
 slug: ttn-lw-cli_users_oauth
-
 ---
 
 ## ttn-lw-cli users oauth

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth access-tokens"
 slug: ttn-lw-cli_users_oauth_access-tokens
-
 ---
 
 ## ttn-lw-cli users oauth access-tokens

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth access-tokens delete"
 slug: ttn-lw-cli_users_oauth_access-tokens_delete
-
 ---
 
 ## ttn-lw-cli users oauth access-tokens delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_access-tokens_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth access-tokens list"
 slug: ttn-lw-cli_users_oauth_access-tokens_list
-
 ---
 
 ## ttn-lw-cli users oauth access-tokens list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth authorizations"
 slug: ttn-lw-cli_users_oauth_authorizations
-
 ---
 
 ## ttn-lw-cli users oauth authorizations

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth authorizations delete"
 slug: ttn-lw-cli_users_oauth_authorizations_delete
-
 ---
 
 ## ttn-lw-cli users oauth authorizations delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_oauth_authorizations_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users oauth authorizations list"
 slug: ttn-lw-cli_users_oauth_authorizations_list
-
 ---
 
 ## ttn-lw-cli users oauth authorizations list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_purge.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_purge.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users purge"
 slug: ttn-lw-cli_users_purge
-
 ---
 
 ## ttn-lw-cli users purge

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_restore.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_restore.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users restore"
 slug: ttn-lw-cli_users_restore
-
 ---
 
 ## ttn-lw-cli users restore

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_rights.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_rights.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users rights"
 slug: ttn-lw-cli_users_rights
-
 ---
 
 ## ttn-lw-cli users rights

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_search.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_search.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users search"
 slug: ttn-lw-cli_users_search
-
 ---
 
 ## ttn-lw-cli users search

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users sessions"
 slug: ttn-lw-cli_users_sessions
-
 ---
 
 ## ttn-lw-cli users sessions

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions_delete.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions_delete.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users sessions delete"
 slug: ttn-lw-cli_users_sessions_delete
-
 ---
 
 ## ttn-lw-cli users sessions delete

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions_list.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_sessions_list.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users sessions list"
 slug: ttn-lw-cli_users_sessions_list
-
 ---
 
 ## ttn-lw-cli users sessions list

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_set.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_set.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users set"
 slug: ttn-lw-cli_users_set
-
 ---
 
 ## ttn-lw-cli users set

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_users_update-password.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_users_update-password.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli users update-password"
 slug: ttn-lw-cli_users_update-password
-
 ---
 
 ## ttn-lw-cli users update-password

--- a/doc/content/ttn-lw-cli/ttn-lw-cli_version.md
+++ b/doc/content/ttn-lw-cli/ttn-lw-cli_version.md
@@ -1,7 +1,6 @@
 ---
 title: "ttn-lw-cli version"
 slug: ttn-lw-cli_version
-
 ---
 
 ## ttn-lw-cli version

--- a/doc/content/whats-new/3.18.1.md
+++ b/doc/content/whats-new/3.18.1.md
@@ -1,0 +1,42 @@
+---
+date: 2022-03-09
+title: "3.18.1"
+---
+
+### Added
+
+- Add HTTP basic authentication configuration to the webhooks form in the Console.
+- Show repository formatter code in the payload formatter form in the Console and allow pasting the application and payload formatter code when using the JavaScript option.
+- Add `query` field to search requests, allowing to search for a string in any of ID, Name, Description and EUI (for entities that have EUIs).
+- gRPC service to Gateway Configuration Server so that gateway configurations can be obtained via gRPC requests.
+- The option to configure the Redis idle connection pool timeout, using the `redis.idle-timeout` setting.
+- New RP002 regional parameters as options during device registration in the Console.
+- Fallback for frequency plan, MAC and PHY version values for end device import in the Console.
+- Default gateway visibility configuration in Packet Broker agent in the Console.
+
+### Changed
+
+- The custom webhook option is now shown at the top of the list in the Console when adding new webhooks.
+- Wording around webhook statuses to `Healthy`, `Requests failing` and `Pending`.
+- The uplink event preview in the Console now shows the highest SNR.
+- When scheduling downlink messages with decoded payload, the downlink queued event now contains the encoded, plain binary payload.
+- When Application Server forwards downlink messages to Network Server, the event payload now contains the encrypted LoRaWAN `FRMPayload`.
+- Integration settings are now retrieved from the read-only Redis replica.
+- The Network Server will now match downlink acknowledgements on the `cache` redis cluster (previously the `general` cluster was used).
+- Gateway Connection statistics updates are now debounced. The debounce period occurs before the statistics are stored, and can be configured using the `gs.update-connection-stats-debounce-time` setting (default 5 seconds).
+- Event publication when the Redis backend is used may no longer block the hot path. Instead, the events are now asynchronously published, which may render their ordering to change.
+  - The events are queued and published using the worker pool mechanism, under the `redis_events_transactions` pool.
+  - The length of the queue used by the pool may be configured using the `events.redis.publish.queue-size` setting.
+  - The maximum worker count used by the pool may be configured using the `events.redis.publish.max-workers` setting.
+- Payload formatter form layout in the Console.
+
+### Removed
+
+- Ability to select the `Repository` payload formatter type for end devices that have no Device Repository association or have no associated repository payload formatter.
+
+### Fixed
+
+- Webhook statuses being shown as pending regardless of their actual condition.
+- Consistent ordering of entities with equal values for the sort field.
+- Fix `xtime` sent to LBS gateways for Class C downlinks.
+- Tenant settings being available in non-multi-tenancy environments in the Console.

--- a/doc/data/api/ttn.lorawan.v3/messages/GetClaimStatusResponse.VendorSpecific.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetClaimStatusResponse.VendorSpecific.yml
@@ -1,0 +1,11 @@
+name: GetClaimStatusResponse.VendorSpecific
+fields:
+- name: organization_unique_identifier
+  type: uint32
+  default: 0
+- name: data
+  comment: Vendor Specific data in JSON format.
+  message:
+    package: google.protobuf
+    name: Struct
+  default: {}

--- a/doc/data/api/ttn.lorawan.v3/messages/GetClaimStatusResponse.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetClaimStatusResponse.yml
@@ -1,0 +1,18 @@
+name: GetClaimStatusResponse
+fields:
+- name: end_device_ids
+  message:
+    name: EndDeviceIdentifiers
+  rules:
+    required: true
+  default: {}
+- name: home_net_id
+  type: bytes
+  default: ""
+- name: home_ns_id
+  type: bytes
+  default: ""
+- name: vendor_specific
+  message:
+    name: GetClaimStatusResponse.VendorSpecific
+  default: {}

--- a/doc/data/api/ttn.lorawan.v3/messages/GetGatewayConfigurationRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetGatewayConfigurationRequest.yml
@@ -1,0 +1,26 @@
+name: GetGatewayConfigurationRequest
+fields:
+- name: gateway_ids
+  message:
+    name: GatewayIdentifiers
+  rules:
+    required: true
+  default: {}
+- name: format
+  type: string
+  rules:
+    max_len: 36
+    pattern: ^[a-z0-9](?:[-]?[a-z0-9]){2,}$|^$
+  default: ""
+- name: type
+  type: string
+  rules:
+    max_len: 36
+    pattern: ^[a-z0-9](?:[-]?[a-z0-9]){2,}$|^$
+  default: ""
+- name: filename
+  type: string
+  rules:
+    max_len: 36
+    pattern: ^[a-z0-9](?:[-._]?[a-z0-9]){2,}$|^$
+  default: ""

--- a/doc/data/api/ttn.lorawan.v3/messages/GetGatewayConfigurationResponse.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetGatewayConfigurationResponse.yml
@@ -1,0 +1,5 @@
+name: GetGatewayConfigurationResponse
+fields:
+- name: contents
+  type: bytes
+  default: ""

--- a/doc/data/api/ttn.lorawan.v3/messages/GetInfoByJoinEUIRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetInfoByJoinEUIRequest.yml
@@ -1,0 +1,5 @@
+name: GetInfoByJoinEUIRequest
+fields:
+- name: join_eui
+  type: bytes
+  default: ""

--- a/doc/data/api/ttn.lorawan.v3/messages/GetInfoByJoinEUIResponse.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/GetInfoByJoinEUIResponse.yml
@@ -1,0 +1,10 @@
+name: GetInfoByJoinEUIResponse
+fields:
+- name: join_eui
+  type: bytes
+  default: ""
+- name: supports_claiming
+  comment: If set, this Join EUI is available for claiming on one of the configured
+    Join Servers.
+  type: bool
+  default: false

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchApplicationsRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchApplicationsRequest.yml
@@ -2,6 +2,12 @@ name: SearchApplicationsRequest
 comment: This message is used for finding applications in the EntityRegistrySearch
   service.
 fields:
+- name: query
+  comment: Find applications where the ID, name or description contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find applications where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchClientsRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchClientsRequest.yml
@@ -2,6 +2,12 @@ name: SearchClientsRequest
 comment: This message is used for finding OAuth clients in the EntityRegistrySearch
   service.
 fields:
+- name: query
+  comment: Find OAuth clients where the ID, name or description contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find OAuth clients where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchEndDevicesRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchEndDevicesRequest.yml
@@ -6,6 +6,12 @@ fields:
   rules:
     required: true
   default: {}
+- name: query
+  comment: Find end devices where the ID, name, description or EUI contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find end devices where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchGatewaysRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchGatewaysRequest.yml
@@ -1,6 +1,12 @@
 name: SearchGatewaysRequest
 comment: This message is used for finding gateways in the EntityRegistrySearch service.
 fields:
+- name: query
+  comment: Find gateways where the ID, name, description or EUI contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find gateways where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchOrganizationsRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchOrganizationsRequest.yml
@@ -2,6 +2,12 @@ name: SearchOrganizationsRequest
 comment: This message is used for finding organizations in the EntityRegistrySearch
   service.
 fields:
+- name: query
+  comment: Find organizations where the ID, name or description contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find organizations where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/SearchUsersRequest.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/SearchUsersRequest.yml
@@ -1,6 +1,12 @@
 name: SearchUsersRequest
 comment: This message is used for finding users in the EntityRegistrySearch service.
 fields:
+- name: query
+  comment: Find users where the ID, name or description contains this substring.
+  type: string
+  rules:
+    max_len: 50
+  default: ""
 - name: id_contains
   comment: Find users where the ID contains this substring.
   type: string

--- a/doc/data/api/ttn.lorawan.v3/messages/TxSettings.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages/TxSettings.yml
@@ -43,3 +43,10 @@ fields:
   message:
     name: TxSettings.Downlink
   default: {}
+- name: concentrator_timestamp
+  comment: |-
+    Concentrator timestamp for the downlink as calculated by the Gateway Server scheduler.
+    This value takes into account necessary offsets such as the RTT (Round Trip Time) and TOA (Time Of Arrival).
+    This field is set and used only by the Gateway Server.
+  type: int64
+  default: 0

--- a/doc/data/api/ttn.lorawan.v3/services/EndDeviceClaimingServer.yml
+++ b/doc/data/api/ttn.lorawan.v3/services/EndDeviceClaimingServer.yml
@@ -5,8 +5,8 @@ comment: |-
 methods:
   Claim:
     name: Claim
-    comment: Claims the end device by claim authentication code or QR code and transfers
-      the device to the target application.
+    comment: Claims the end device on a Join Server by claim authentication code or
+      QR code.
     input:
       name: ClaimEndDeviceRequest
     output:
@@ -14,6 +14,37 @@ methods:
     http:
     - method: POST
       path: /edcs/claim
+  Unclaim:
+    name: Unclaim
+    comment: Unclaims the end device on a Join Server.
+    input:
+      name: EndDeviceIdentifiers
+    output:
+      package: google.protobuf
+      name: Empty
+    http:
+    - method: DELETE
+      path: /edcs/claim/{application_ids.application_id}/devices/{device_id}
+  GetInfoByJoinEUI:
+    name: GetInfoByJoinEUI
+    comment: Return whether claiming is available for a given JoinEUI.
+    input:
+      name: GetInfoByJoinEUIRequest
+    output:
+      name: GetInfoByJoinEUIResponse
+    http:
+    - method: POST
+      path: /edcs/claim/info
+  GetClaimStatus:
+    name: GetClaimStatus
+    comment: Gets the claim status of an end device.
+    input:
+      name: EndDeviceIdentifiers
+    output:
+      name: GetClaimStatusResponse
+    http:
+    - method: GET
+      path: /edcs/claim/{application_ids.application_id}/devices/{device_id}
   AuthorizeApplication:
     name: AuthorizeApplication
     comment: |-

--- a/doc/data/api/ttn.lorawan.v3/services/GatewayConfigurationService.yml
+++ b/doc/data/api/ttn.lorawan.v3/services/GatewayConfigurationService.yml
@@ -1,0 +1,15 @@
+name: GatewayConfigurationService
+methods:
+  GetGatewayConfiguration:
+    name: GetGatewayConfiguration
+    input:
+      name: GetGatewayConfigurationRequest
+    output:
+      name: GetGatewayConfigurationResponse
+    http:
+    - method: ""
+      path: ""
+    - method: GET
+      path: /gcs/gateways/configuration/{gateway_ids.gateway_id}/{format}/{filename}
+    - method: GET
+      path: /gcs/gateways/configuration/{gateway_ids.gateway_id}/{format}/{type}/{filename}


### PR DESCRIPTION
#### Summary
Replaces #803 

#### Notes for Reviewers
When CLI docs are automatically generated, blank lines in headers of CLI docs (introduced in #794) aren't there, hence the big diff. 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
