### PR TITLE
doc: Fix CSV reference link

### DIFF
--- a/doc/content/getting-started/migrating/import-devices.md
+++ b/doc/content/getting-started/migrating/import-devices.md
@@ -10,8 +10,8 @@ There are two ways to import devices in {{% tts %}} - using [Console]({{< ref "/
 
 {{% tts %}} supports importing end devices in JSON and CSV format:
 
-- To import devices you created by following [Migrating End Devices from {{% ttnv2 %}}]({{< ref "/getting-started/migrating/migrating-from-v2" >}}) or [Migrating End Devices from ChirpStack]({{< ref "/getting-started/migrating/migrate-from-chirpstack" >}}), use **{{% tts %}} JSON** format (identified by `the-things-stack`).
-- To import devices that are in a CSV file, use the **{{% tts %}} CSV** (identified by `the-things-stack-csv`). The CSV data format is documented in [Data Formats]({{< ref "/reference/data-formats#csv" >}}), including a handy Excel template.
+- To import devices that are in a JSON file (for example, the one you created by following [Migrating End Devices from {{% ttnv2 %}}]({{< ref "/getting-started/migrating/migrating-from-v2" >}}) or [Migrating End Devices from ChirpStack]({{< ref "/getting-started/migrating/migrate-from-chirpstack" >}})), use **{{% tts %}} JSON** format (identified by `the-things-stack`). The JSON format data format is documented in the [JSON File Reference]({{< ref "/getting-started/migrating/device-json" >}}).
+- To import devices that are in a CSV file, use the **{{% tts %}} CSV** (identified by `the-things-stack-csv`). The CSV data format is documented in the [CSV File Reference]({{< ref "/getting-started/migrating/device-csv" >}}), including a handy Excel template.
 
 {{< tabs/container "Console" "CLI" >}}
 


### PR DESCRIPTION
#### Summary
Fix a bad link for CSV file reference

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
