### PR TITLE
doc: Add RP002 info, modify specification names

### DIFF
--- a/doc/content/reference/spec-regional-parameters/index.md
+++ b/doc/content/reference/spec-regional-parameters/index.md
@@ -9,24 +9,28 @@ description: ""
 
 This includes all of the following LoRaWAN specification versions:
 
-- LoRaWAN 1.0
-- LoRaWAN 1.0.1
-- LoRaWAN 1.0.2
-- LoRaWAN 1.0.3
-- LoRaWAN 1.0.4
-- LoRaWAN 1.1
+- LoRaWAN Specification 1.0.0
+- LoRaWAN Specification 1.0.1
+- LoRaWAN Specification 1.0.2
+- LoRaWAN Specification 1.0.3
+- LoRaWAN Specification 1.0.4
+- LoRaWAN Specification 1.1.0
 
 The LoRaWAN specification versions are available from the [LoRa Alliance resource hub](https://lora-alliance.org/resource-hub/).
 
 {{% tts %}} supports the following LoRaWAN Regional Parameter specification versions:
 
-- LoRaWAN Regional Parameters 1.0
-- LoRaWAN Regional Parameters 1.0.1
-- LoRaWAN Regional Parameters 1.0.2 Rev A
-- LoRaWAN Regional Parameters 1.0.2 Rev B
-- LoRaWAN Regional Parameters 1.0.3 Rev A
-- LoRaWAN Regional Parameters 1.1 Rev A
-- LoRaWAN Regional Parameters 1.1 Rev B
+- TS001 Technical Specification 1.0.0
+- TS001 Technical Specification 1.0.1
+- RP001 Regional Parameters 1.0.2
+- RP001 Regional Parameters 1.0.2 Rev B
+- RP001 Regional Parameters 1.0.3 Rev A
+- RP001 Regional Parameters 1.1 Rev A
+- RP001 Regional Parameters 1.1 Rev B
+- RP002 Regional Parameters 1.0.0
+- RP002 Regional Parameters 1.0.1
+- RP002 Regional Parameters 1.0.2
+- RP002 Regional Parameters 1.0.3
 
 The LoRaWAN Regional Parameters specification versions are available from the [LoRa Alliance resource hub](https://lora-alliance.org/resource-hub/). More information is also available in [The Things Network LoRaWAN documentation](https://www.thethingsnetwork.org/docs/lorawan/regional-parameters/).
 


### PR DESCRIPTION
#### Summary
Closes #809 

Add info that TTS supports RP002 spec and modify specification names to reflect names in lists for LoRaWAN version and Regional Parameters version in the Console.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
