### PR TITLE
doc: Point link to purchasing page

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -54,5 +54,5 @@ pygmentsUseClasses = true
 
   [[menu.buttons]]
     name = "Get The Things Stack"
-    url = "https://www.thethingsindustries.com/deployment/"
+    url = "https://accounts.thethingsindustries.com/fee-calculator"
     weight = 1


### PR DESCRIPTION
#### Summary
As suggested in #documentation channel on Slack, I'm changing the "Get The Things Stack" button to lead to purchasing page instead of deployment options page

#### Notes for Reviewers
Needs a review because I wasn't sure if something else needs to be changed besides this link

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
