### PR TITLE
Remove references to customizable email templates

### DIFF
--- a/doc/content/getting-started/installation/configuration/index.md
+++ b/doc/content/getting-started/installation/configuration/index.md
@@ -203,8 +203,6 @@ as passwords for endpoints that you may want to keep for the internal use.
 You can use Sendgrid or an SMTP server. If you skip setting up an email provider,
 {{% tts %}} will print emails to the stack logs.
 
-See [Email Templates]({{< ref "/reference/email-templates" >}}) section for additional info.
-
 ### Component URLs
 
 Finally, the `console` section configures the URLs for the Web UI and the secret used

--- a/doc/content/getting-started/installation/configuration/index.md
+++ b/doc/content/getting-started/installation/configuration/index.md
@@ -200,8 +200,8 @@ as passwords for endpoints that you may want to keep for the internal use.
 ### Email
 
 {{% tts %}} sends emails to users, so the `email` section of the configuration defines how these are sent.
-You can use Sendgrid or an SMTP server. If you skip setting up an email provider,
-{{% tts %}} will print emails to the stack logs.
+You can use Sendgrid or an SMTP server. For development purposes, you can use the `dir` provider that writes emails to a directory.
+If you skip setting up an email provider, {{% tts %}} will print emails to the stack logs.
 
 ### Component URLs
 

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -45,17 +45,17 @@ Most emails contain the name of the network and links to the Identity Server or 
 - `is.email.network.identity-server-url`: The URL of the Identity Server
 - `is.email.network.console-url`: The URL of the Console
 
-Although {{% tts %}} comes with a number of builtin email templates, it is possible to override those with custom templates. You can specify the source where to load templates from, and options for that source. For more information on email templates, see the [email templates reference]({{< ref "/reference/email-templates" >}}).
+Although {{% tts %}} comes with a number of builtin email templates, it is possible to override those with custom templates. You can specify the source where to load templates from, and options for that source. For more information on email templates, see the [email templates reference]({{< ref "/reference/email-templates" >}}). {{< removed-in-version "3.19" >}}
 
-- `is.email.templates.source`: Source of the email template files (directory, url, blob)
-- `is.email.templates.directory`: Directory on the filesystem where email templates are located
-- `is.email.templates.url`: URL where email templates are located
-- `is.email.templates.blob.bucket`: Bucket where email templates are located
-- `is.email.templates.blob.path`: Path within the bucket.
+- `is.email.templates.source`: Source of the email template files (directory, url, blob) {{< deprecated-in-version "3.19" >}}
+- `is.email.templates.directory`: Directory on the filesystem where email templates are located {{< deprecated-in-version "3.19" >}}
+- `is.email.templates.url`: URL where email templates are located {{< deprecated-in-version "3.19" >}}
+- `is.email.templates.blob.bucket`: Bucket where email templates are located {{< deprecated-in-version "3.19" >}}
+- `is.email.templates.blob.path`: Path within the bucket {{< deprecated-in-version "3.19" >}}
 
 If your custom templates rely on other files, such as headers or footers, those files need to be included.
 
-- `is.email.templates.includes`: The email templates that will be preloaded on startup
+- `is.email.templates.includes`: The email templates that will be preloaded on startup {{< deprecated-in-version "3.19" >}}
 
 ## OAuth UI Options
 

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -18,7 +18,7 @@ The Identity Server needs to be connected to a PostgreSQL-compatible database. D
 
 ## Email Options
 
-The Identity Server can be configured with different providers for sending emails. Currently the `sendgrid` and `smtp` providers are implemented.
+The Identity Server can be configured with different providers for sending emails. Currently the `sendgrid`, `smtp` and `dir` providers are implemented.
 
 - `is.email.provider`: Email provider to use
 
@@ -33,6 +33,10 @@ When `smtp` is used as provider, provide the address of the SMTP server (`host:p
 - `is.email.smtp.username`: Username to authenticate with
 - `is.email.smtp.password`: Password to authenticate with
 - `is.email.smtp.connections`: Maximum number of connections to the SMTP server
+
+When `dir` is used as provider, provide the path to the local directory where email messages should be written to.
+
+- `is.email.dir`: Path to the local directory where email messages should be written to {{< new-in-version "3.19" >}}
 
 The email address and name of the sender should be configured regardless of the provider that is used.
 

--- a/doc/content/reference/email-templates/_index.md
+++ b/doc/content/reference/email-templates/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Email Templates"
+removed_in_version: "3.19"
 description: ""
 ---
 

--- a/doc/content/reference/email-templates/available.md
+++ b/doc/content/reference/email-templates/available.md
@@ -1,5 +1,6 @@
 ---
 title: "Available Templates"
+removed_in_version: "3.19"
 description: ""
 weight: 3
 ---

--- a/doc/content/reference/email-templates/overriding.md
+++ b/doc/content/reference/email-templates/overriding.md
@@ -1,5 +1,6 @@
 ---
 title: "Overriding Templates"
+removed_in_version: "3.19"
 description: ""
 weight: 6
 ---

--- a/doc/themes/the-things-stack/layouts/_default/list.html
+++ b/doc/themes/the-things-stack/layouts/_default/list.html
@@ -14,7 +14,7 @@
         <h1 class="title is-size-2">{{ .Title }}
           {{ $context := . }}
         </h1>
-        {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version) }}
+        {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version .Params.removed_in_version) }}
         <h2 class="subtitle">
           {{ with .Params.distributions }}
             {{ $distributions := .}}
@@ -25,6 +25,9 @@
           {{ end }}
           {{ with .Params.deprecated_in_version }}
             {{ partial "deprecated-in-version" .}}
+          {{ end }}
+          {{ with .Params.removed_in_version }}
+            {{ partial "removed-in-version" .}}
           {{ end }}
         </h2>
         {{ end }}

--- a/doc/themes/the-things-stack/layouts/_default/single.html
+++ b/doc/themes/the-things-stack/layouts/_default/single.html
@@ -14,7 +14,7 @@
         <h1 class="title is-size-2">{{ .Title }}
           {{ $context := . }}
         </h1>
-        {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version) }}
+        {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version .Params.removed_in_version) }}
         <h2 class="subtitle">
           {{ with .Params.distributions }}
             {{ $distributions := .}}
@@ -25,6 +25,9 @@
           {{ end }}
           {{ with .Params.deprecated_in_version }}
             {{ partial "deprecated-in-version" .}}
+          {{ end }}
+          {{ with .Params.removed_in_version }}
+            {{ partial "removed-in-version" .}}
           {{ end }}
         </h2>
         {{end }}

--- a/doc/themes/the-things-stack/layouts/partials/pages-cards.html
+++ b/doc/themes/the-things-stack/layouts/partials/pages-cards.html
@@ -6,7 +6,7 @@
         <div class="title-content">
           <h1 class="title is-size-5 is-uppercase"><a href="{{ .Permalink }}">{{ .Title }}</a>
           </h1>
-          {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version) }}
+          {{ if or .Params.distributions (or .Params.new_in_version .Params.deprecated_in_version .Params.removed_in_version) }}
           <h2 class="subtitle">
             {{ with .Params.distributions }}
               {{ partial "distributions" (dict "distributions" .) }}
@@ -16,6 +16,9 @@
             {{ end }}
             {{ with .Params.deprecated_in_version }}
               {{ partial "deprecated-in-version" .}}
+            {{ end }}
+            {{ with .Params.removed_in_version }}
+              {{ partial "removed-in-version" .}}
             {{ end }}
           </h2>
           {{ end }}

--- a/doc/themes/the-things-stack/layouts/partials/removed-in-version.html
+++ b/doc/themes/the-things-stack/layouts/partials/removed-in-version.html
@@ -1,1 +1,1 @@
-<span class="tag is-danger is-light">Removed in {{ (.Get 0) }}</span>
+<span class="tag is-danger is-light">Removed in {{ . }}</span>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This marks email template customization as "removed" and adds the `dir` email provider.

Refs https://github.com/TheThingsNetwork/lorawan-stack/pull/5406

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

n/a

#### Changes
<!-- What are the changes made in this pull request? -->

- Fixed `removed-in-version` shortcode
- Removed email template stuff
- Added `dir` email provider

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~Not sure what our current practice is for deleting pages. If instead of deleting pages, we want to update them with a message, then I can do that too.~

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
