### PR TITLE
Update links in the Balena page

### DIFF
--- a/doc/content/getting-started/installation/balena/index.md
+++ b/doc/content/getting-started/installation/balena/index.md
@@ -9,13 +9,14 @@ weight: 5
 
 To run {{% tts %}} you need to  deploy it to a [balenaCloud](https://www.balena.io/cloud/) fleet. This can be done by by clicking the button below:
 
-[![](https://www.balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/xoseperez/balena-tts-lns)
+[![](https://www.balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/xoseperez/the-things-stack-docker)
 
 First, follow the instructions in your balenaCloud dashboard and click `Create and deploy`.
 
 Then, click `Add device` and configure the balenaOS file by filling in the presented form. Click `Download balenaOS` to download the resulting OS file and flash it to an SD card. Insert the SD card into your Raspberry Pi, connect it to the Internet and power it up. Enjoy the magic 🌟Over-The-Air🌟!
 
-You can find more detailed instructions on [GitHub](https://github.com/xoseperez/the-things-stack-balena) and [balenaHub](https://hub.balena.io/g_xose_p_rez/tts-network-server).
+You can find more detailed instructions on [GitHub](https://github.com/xoseperez/the-things-stack-docker) and [balenaHub](https://hub.balena.io/organizations/xoseperez/projects/the-things-stack).
 
 {{< note >}}
-If you have a LoRa concentrator for the Raspberry Pi (e.g. RAK2245 or RAK2287 SPI-based) you can also turn your Pi in to a LoRaWAN gateway by running the `basicstation` service alongside {{% tts %}}. Find the project [here](https://hub.balena.io/g_xose_p_rez/tts-network-server-basicstation). {{</ note >}}
+If you have a LoRa concentrator for the Raspberry Pi (e.g. RAK2245 or RAK2287 SPI-based) you can also turn your Pi in to a LoRaWAN gateway by running the `basicstation` service alongside {{% tts %}}. Find the project [here](https://hub.balena.io/organizations/xoseperez/projects/basicstation).  Or having everything together including Node-RED, InfluxDB and Grafana for a truly standalone gateway. Check this out [here](https://hub.balena.io/organizations/xoseperez/projects/standalone-lorawan-gw).
+{{</ note >}}


### PR DESCRIPTION
We have upgraded and cleaned up the different projects in the Balena Hub. Previous links were correctly redirecting to existing projects but with these changes it makes more sense (deploying TTS only, deploying BasicStation or deploying everything together).

#### Summary
Upgrades links to Balena Hub project deploying TTS (and related ones).

#### Screenshots
N/A

#### Changes
Changes to links to the already existing TTS project for Balena, as well as BasicStation project and the Standalone Gateway that includes BasicStation, TTS, NodeRED, InfluxDB and Grafana.

#### Notes for Reviewers
I'm the maintainer of the projects originally linked, this is just an update.

#### Checklist
N/A