### PR TITLE
doc: Add payload formatter maximum size info

### DIFF
--- a/doc/content/integrations/payload-formatters/javascript/_index.md
+++ b/doc/content/integrations/payload-formatters/javascript/_index.md
@@ -15,9 +15,9 @@ Tips:
 
 {{< note >}} Payload formatters use ECMAScript 5 (2009), which has some distinct differences compared to newer, commonly used ECMAScript revisions. See [here](https://www.javatpoint.com/es5-vs-es6) for a quick comparison. Notably, `let`, `const`, and arrow functions are not supported by ES5. {{</ note >}}
 
-{{< note >}} Javascript payload formatters from {{% ttnv2 %}} will work in {{% tts %}}. {{% tts %}} has a new payload formatter signature, but it is also backwards compatible. {{</ note >}}
-
 {{< note >}} For security, the runtime does not support modules, `require` syntax, or any input/output other than defined below. {{</ note >}}
+
+{{< warning >}} The maximum size of a user-defined Javascript payload formatter is 40KB (40960 characters), unless the source of the payload formatter is [Device Repository]({{< ref "/integrations/payload-formatters/device-repo" >}}). {{</ warning>}}
 
 There are three different types of {{% tts %}} JavaScript payload formatters:
 


### PR DESCRIPTION
#### Summary
Closes #875 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
