### PR TITLE
doc: Add note about updating IDs via API

### DIFF
--- a/doc/content/reference/api/field-mask.md
+++ b/doc/content/reference/api/field-mask.md
@@ -82,7 +82,13 @@ Without the field masks specified, this request would not return the `name`, `de
 
 ### `PUT` Requests
 
-`PUT` requests can be used to update entities by supplying the object as JSON data. To update fields, the field mask must also be specified in the JSON object (query parameters do not work for `PUT` requests). The field mask has the following format:
+`PUT` requests can be used to update entities by supplying the object as JSON data.
+
+{{< note >}} Keep in mind that application ID (`application_ids.application_id`), end device ID (`device_id`), AppEUI/JoinEUI (`join_eui`), DevEUI (`dev_eui`) and API key IDs cannot be updated after creation. These fields are part of the allowed field mask, but they can only be used at creation, after which they can no longer be changed.
+
+For example, to properly register an end device in {{% tts %}} like described in the [Using the API]({{< ref "/getting-started/api#multi-step-actions" >}}) section, it is necessary to set the `dev_eui` field to device's DevEUI. However, updating the DevEUI after device is created will not be possible, i.e. will fail with the `forbidden path(s) in field mask` error. {{</ note >}}
+
+To update fields, the field mask must also be specified in the JSON object (query parameters do not work for `PUT` requests). The field mask has the following format:
 
 ```
 {


### PR DESCRIPTION
#### Summary
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5553

#### Changes
Add a note to documentation that updating ID fields via API is forbidden

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
