### PR TITLE
doc: Update join flow

### DIFF
--- a/doc/content/getting-started/events/_index.md
+++ b/doc/content/getting-started/events/_index.md
@@ -59,170 +59,592 @@ See the events of a typical join flow in the example below:
 
 <details><summary>Join flow example</summary>
 
-```js
-{
-  "name": "gs.up.receive", // Gateway Server received an uplink message from a device.
-  "time": "2019-04-04T09:54:34.786220Z",
-  "identifiers": [
-    {
-      "gateway_ids": {
-        "gateway_id": "multitech",
-        "eui": "00800000A0000DB4"
+```json
+[
+  {
+    "name": "gs.up.receive", //The Gateway Server receives an uplink message (Join Request) from the end device
+    "time": "2022-07-05T09:01:06.987556027Z",
+    "identifiers": [
+      {
+        "gateway_ids": {
+          "gateway_id": "gw2",
+          "eui": "B827EBFFFE8DB887"
+        }
       }
-    }
-  ],
-  "correlation_ids": [
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA"
-  ]
-}
-{
-  "name": "js.join.accept", // Join Server accepted the join-accept.
-  "time": "2019-04-04T09:54:34.806812Z",
-  "identifiers": [
-    {
-      "device_ids": {
-        "device_id": "dev1",
-        "application_ids": {
-          "application_id": "app1"
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.GatewayUplinkMessage",
+      "message": {
+        "payload": {
+          "join_request_payload": {
+            "join_eui": "0000000000000000",
+            "dev_eui": "70B3D57ED0050EAD",
+            "dev_nonce": "AF7C"
+          }
         },
-        "dev_eui": "4200000000000000",
-        "join_eui": "4200000000000000"
+        "rx_metadata": [
+          {
+            "gateway_ids": {
+              "gateway_id": "gw2",
+              "eui": "B827EBFFFE8DB887"
+            }
+          }
+        ],
+        "correlation_ids": [
+          "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+          "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB"
+        ]
       }
-    }
-  ],
-  "correlation_ids": [
-    "rpc:/ttn.lorawan.v3.NsJs/HandleJoin:01D7KWB0NCTDY835V5N3CYWBZK"
-  ]
-}
-{
-  "name": "ns.up.join.forward", // Network Server forwarded the join-accept and it got accepted.
-  "time": "2019-04-04T09:54:34.808132Z",
-  "identifiers": [
-    {
-      "device_ids": {
-        "device_id": "dev1",
-        "application_ids": {
-          "application_id": "app1"
-        },
-        "dev_eui": "4200000000000000",
-        "join_eui": "4200000000000000"
-      }
-    }
-  ],
-  "correlation_ids": [
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA",
-    "ns:uplink:01D7KWB0N5C1T8TE2HAVBJN5Y4",
-    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01D7KWB0N5G2N5C0AFXT4YMF8R"
-  ]
-}
-{
-  "name": "ns.up.merge_metadata", // Network Server merged metadata of incoming uplink messages.
-  "time": "2019-04-04T09:54:34.991332Z",
-  "identifiers": [
-    {
-      "device_ids": {
-        "device_id": "dev1",
-        "application_ids": {
-          "application_id": "app1"
-        },
-        "dev_eui": "4200000000000000",
-        "join_eui": "4200000000000000"
-      }
-    }
-  ],
-  "data": {
-    "@type": "type.googleapis.com/google.protobuf.Value",
-    "value": 1 // There was 1 gateway that received the join-request.
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB"
+    ]
   },
-  "correlation_ids": [
-    // Here you find the correlation IDs of all gs.up.receive events that were merged.
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA",
-    "ns:uplink:01D7KWB0N5C1T8TE2HAVBJN5Y4",
-    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01D7KWB0N5G2N5C0AFXT4YMF8R"
-  ]
-}
-{
-  "name": "as.up.join.receive", // Application Server receives the join-accept.
-  "time": "2019-04-04T09:54:35.005090Z",
-  "identifiers": [
-    {
-      "device_ids": {
-        "device_id": "dev1",
+  {
+    "name": "ns.up.join.receive", //The Network Server receives the Join Request
+    "time": "2022-07-05T09:01:06.995021407Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.UplinkMessage",
+      "payload": {
+        "join_request_payload": {
+          "join_eui": "0000000000000000",
+          "dev_eui": "70B3D57ED0050EAD",
+          "dev_nonce": "AF7C"
+        }
+      },
+      "rx_metadata": [
+        {
+          "gateway_ids": {
+            "gateway_id": "gw2",
+            "eui": "B827EBFFFE8DB887"
+          }
+        }
+      ],
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "ns.up.join.cluster.attempt", //The Network Server sends the Join Request to the cluster-local Join Server
+    "time": "2022-07-05T09:01:06.995430193Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.JoinRequest",
+      "payload": {
+        "join_request_payload": {
+          "join_eui": "0000000000000000",
+          "dev_eui": "70B3D57ED0050EAD",
+          "dev_nonce": "AF7C"
+        }
+      },
+      "dev_addr": "AP9S4w==",
+      "selected_mac_version": "MAC_V1_0_2",
+      "net_id": "AAAA",
+      "downlink_settings": {
+        "rx2_dr": 3
+      },
+      "rx_delay": 5,
+      "cf_list": {
+        "freq": [
+          8671000,
+          8673000,
+          8675000,
+          8677000,
+          8679000
+        ]
+      },
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "js.join.accept", //The local Join Server accepts the Join Request
+    "time": "2022-07-05T09:01:06.998805073Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "00FF52E3"
+        }
+      }
+    ],
+    "correlation_ids": [
+      "rpc:/ttn.lorawan.v3.NsJs/HandleJoin:01G76SF01KFGDBGNQKRWG64DBP"
+    ]
+  },
+  {
+    "name": "ns.up.join.cluster.success", //The Network Server indicates that the Join Request to the cluster-local Join Server succeeded
+    "time": "2022-07-05T09:01:06.999074200Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.JoinResponse",
+      "session_keys": {
+        "session_key_id": "AYHNl4A0v5Eu3uRRH34tEA=="
+      }
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "ns.up.join.process", //The Network Server indicates that the Join Request was successfully processed
+    "time": "2022-07-05T09:01:07.192284684Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.UplinkMessage",
+      "payload": {
+        "join_request_payload": {
+          "join_eui": "0000000000000000",
+          "dev_eui": "70B3D57ED0050EAD",
+          "dev_nonce": "AF7C"
+        }
+      },
+      "rx_metadata": [
+        {
+          "gateway_ids": {
+            "gateway_id": "gw2",
+            "eui": "B827EBFFFE8DB887"
+          }
+        }
+      ],
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "gs.up.forward", //The Gateway Server indicates that the successfully processed Join Request was forwarded to the Network Server
+    "time": "2022-07-05T09:01:07.192498007Z",
+    "identifiers": [
+      {
+        "gateway_ids": {
+          "gateway_id": "gw2",
+          "eui": "B827EBFFFE8DB887"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/google.protobuf.Value",
+      "value": "cluster"
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB"
+    ]
+  },
+  {
+    "name": "ns.down.join.schedule.attempt", //The Network Server attempts to schedule a Join Accept message for transmission (to the end device) on the Gateway Server
+    "time": "2022-07-05T09:01:08.800956312Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.DownlinkMessage",
+      "payload": {
+        "m_hdr": {
+          "m_type": "JOIN_ACCEPT"
+        },
+        "join_accept_payload": {
+          "join_nonce": "000000",
+          "net_id": "000000",
+          "dev_addr": "00FF52E3",
+          "dl_settings": {
+            "rx2_dr": 3
+          },
+          "rx_delay": 5,
+          "cf_list": {
+            "freq": [
+              8671000,
+              8673000,
+              8675000,
+              8677000,
+              8679000
+            ]
+          }
+        }
+      },
+      "request": {
+        "downlink_paths": [
+          {
+            "uplink_token": "ChEKDwoDZ3cyEgi4J+v//o24hxDUjazMAhoMCNL7j5YGEIXF5NYDIKDYyrikFCoLCNP7j5YGEICh5gQ="
+          }
+        ],
+        "rx1_delay": 5,
+        "rx1_data_rate": {
+          "lora": {
+            "bandwidth": 125000,
+            "spreading_factor": 12
+          }
+        },
+        "rx1_frequency": "868300000",
+        "rx2_data_rate": {
+          "lora": {
+            "bandwidth": 125000,
+            "spreading_factor": 12
+          }
+        },
+        "rx2_frequency": "869525000",
+        "priority": "HIGHEST",
+        "frequency_plan_id": "EU_863_870_TTN"
+      },
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+        "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+      "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "gs.down.schedule.attempt", //The Gateway Server attempts to schedule a downlink message
+    "time": "2022-07-05T09:01:08.801328916Z",
+    "identifiers": [
+      {
+        "gateway_ids": {
+          "gateway_id": "gw2",
+          "eui": "B827EBFFFE8DB887"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.DownlinkMessage",
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+        "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+        "rpc:/ttn.lorawan.v3.NsGs/ScheduleDownlink:01G76SF1T1FC3Q3N7RBSMEXDKA"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+      "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+      "rpc:/ttn.lorawan.v3.NsGs/ScheduleDownlink:01G76SF1T1FC3Q3N7RBSMEXDKA"
+    ]
+  },
+  {
+    "name": "gs.down.send", //The Gateway Server sends a downlink message
+    "time": "2022-07-05T09:01:08.801388035Z",
+    "identifiers": [
+      {
+        "gateway_ids": {
+          "gateway_id": "gw2",
+          "eui": "B827EBFFFE8DB887"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.DownlinkMessage",
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+        "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+        "rpc:/ttn.lorawan.v3.NsGs/ScheduleDownlink:01G76SF1T1FC3Q3N7RBSMEXDKA"
+      ]
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+      "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+      "rpc:/ttn.lorawan.v3.NsGs/ScheduleDownlink:01G76SF1T1FC3Q3N7RBSMEXDKA"
+    ]
+  },
+  {
+    "name": "ns.down.join.schedule.success", //The Network Server indicates that a Join Accept message was successfully scheduled for transmission (to the end device) on the Gateway Server
+    "time": "2022-07-05T09:01:08.801724107Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "004C2AA4"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.ScheduleDownlinkResponse",
+      "downlink_path": {
+        "fixed": {
+          "gateway_ids": {
+            "gateway_id": "gw2",
+            "eui": "B827EBFFFE8DB887"
+          }
+        }
+      },
+      "rx1": true
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:downlink:01G76SF1T0JHYTRMXTQ69DG1E6",
+      "ns:transmission:01G76SF1T0WAQAB4RF2M6EKSJR",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "ns.up.join.accept.forward", //The Network Server forwards the Join Accept message to the Application Server
+    "time": "2022-07-05T09:01:08.806834516Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "00FF52E3"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
+      "end_device_ids": {
+        "device_id": "dev2",
         "application_ids": {
           "application_id": "app1"
         },
-        "dev_eui": "4200000000000000",
-        "join_eui": "4200000000000000",
-        "dev_addr": "0063ECE2"
+        "dev_eui": "70B3D57ED0050EAD",
+        "join_eui": "0000000000000000",
+        "dev_addr": "00FF52E3"
+      },
+      "correlation_ids": [
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+      ],
+      "join_accept": {
+        "session_key_id": "AYHNl4A0v5Eu3uRRH34tEA==",
+        "received_at": "2022-07-05T09:01:06.988023916Z"
       }
-    }
-  ],
-  "correlation_ids": [
-    "as:up:01D7KWB0VX1D7G3RKFN9HDA39Q",
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA",
-    "ns:uplink:01D7KWB0N5C1T8TE2HAVBJN5Y4",
-    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01D7KWB0N5G2N5C0AFXT4YMF8R"
-  ]
-}
-{
-  "name": "as.up.join.forward", // Application Server forwards the join-accept to an application (CLI, MQTT, webhooks, etc).
-  "time": "2019-04-04T09:54:35.010243Z",
-  "identifiers": [
-    {
-      "device_ids": {
-        "device_id": "dev1",
+    },
+    "correlation_ids": [
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K"
+    ]
+  },
+  {
+    "name": "as.up.join.receive", //The Application Server receives the Join Accept message
+    "time": "2022-07-05T09:01:08.804362691Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "00FF52E3"
+        }
+      }
+    ],
+    "correlation_ids": [
+      "as:up:01G76SF1T4N87XN57MY6H36X4C",
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01G76SF1T4N1VR08BVHQ6MTTJN"
+    ]
+  },
+  {
+    "name": "as.up.join.forward", //The Application Server forwards the Join Accept message to the application
+    "time": "2022-07-05T09:01:08.806553539Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "dev2",
+          "application_ids": {
+            "application_id": "app1"
+          },
+          "dev_eui": "70B3D57ED0050EAD",
+          "join_eui": "0000000000000000",
+          "dev_addr": "00FF52E3"
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
+      "end_device_ids": {
+        "device_id": "dev2",
         "application_ids": {
           "application_id": "app1"
         },
-        "dev_eui": "4200000000000000",
-        "join_eui": "4200000000000000",
-        "dev_addr": "0063ECE2"
+        "dev_eui": "70B3D57ED0050EAD",
+        "join_eui": "0000000000000000",
+        "dev_addr": "00FF52E3"
+      },
+      "correlation_ids": [
+        "as:up:01G76SF1T4N87XN57MY6H36X4C",
+        "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+        "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+        "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+        "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+        "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01G76SF1T4N1VR08BVHQ6MTTJN"
+      ],
+      "received_at": "2022-07-05T09:01:08.804377195Z",
+      "join_accept": {
+        "session_key_id": "AYHNl4A0v5Eu3uRRH34tEA==",
+        "received_at": "2022-07-05T09:01:06.988023916Z"
       }
-    }
-  ],
-  "correlation_ids": [
-    "as:up:01D7KWB0VX1D7G3RKFN9HDA39Q",
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA",
-    "ns:uplink:01D7KWB0N5C1T8TE2HAVBJN5Y4",
-    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01D7KWB0N5G2N5C0AFXT4YMF8R"
-  ]
-}
-{
-  "name": "gs.down.send", // Gateway Server sent the join-accept to the gateway.
-  "time": "2019-04-04T09:54:35.046147Z",
-  "identifiers": [
-    {
-      "gateway_ids": {
-        "gateway_id": "multitech",
-        "eui": "00800000A0000DB4"
-      }
-    }
-  ],
-  "correlation_ids": [
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "rpc:/ttn.lorawan.v3.NsGs/ScheduleDownlink:01D7KWB0W84AJ1P5A3AQV6R4J7"
-  ]
-}
-{
-  "name": "gs.up.forward", // Gateway Server forwarded join-request to the Network Server.
-  "time": "2019-04-04T09:54:35.991226Z",
-  "identifiers": [
-    {
-      "gateway_ids": {
-        "gateway_id": "multitech",
-        "eui": "00800000A0000DB4"
-      }
-    }
-  ],
-  "correlation_ids": [
-    "gs:conn:01D7KWADW2E5CJA32VS1MTR2J6",
-    "gs:uplink:01D7KWB0N2KVCV8HZABC8DDHSA"
-  ]
-}
+    },
+    "correlation_ids": [
+      "as:up:01G76SF1T4N87XN57MY6H36X4C",
+      "gs:conn:01G76RS17HGZZXV740X0N2XDV8",
+      "gs:up:host:01G76RS1T9JM1RGFWT6A0ZEGNB",
+      "gs:uplink:01G76SF01BNW5SKRAND31Z0MGB",
+      "ns:uplink:01G76SF01C64KZ26CKK4SK5G10",
+      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G76SF01BBAMZAQRXYK97RZ8K",
+      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01G76SF1T4N1VR08BVHQ6MTTJN"
+    ]
+  }
+]
 ```
 </details>


### PR DESCRIPTION
#### Summary
Closes #827 

#### Changes
I observed a verbose stream of events in the Console of a locally deployed TTS Open Source instance, where I had 1 gateway and 1 device connected. I included some events that weren't included before in this example:

- `ns.up.join.receive`
- `ns.up.join.cluster.attempt`
- `ns.up.join.process`
- `ns.down.join.schedule.attempt`
- `gs.down.schedule.attempt`
- `ns.down.join.schedule.success`
- `ns.up.join.accept.forward`

#### Notes for Reviewers
I tried to understand the process of communication between TTS components based on the events dump from the Console, descriptions of these events in our documentation and some resources online, but haven't been able to understand it 100% and I think it might have something to do with the fact that some events might be arriving late in the Console. For example, according to timestamps, the `as.up.join.receive` event appeared before the `ns.up.join.accept.forward` event, which doesn't make sense to me if I take into account the description of the `ns.up.join.accept.forward` event which says that it indicates forwarding the Join Accept message to the Application Server. 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
