### PR TITLE
doc: Add frequency plans for Japan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,10 @@ Please respect the following guidelines for content in our documentation site.
   - If a line is longer than 120 columns, insert a line break
   - In very special cases, longer lines are tolerated
 
+## Building Frequency Plans Documentation
+
+The [Frequency Plans](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/content/reference/frequency-plans/_index.md) section contains all frequency plans that are officially supported by {{% tts %}}. The list of frequency plans is populated from the [LoRaWAN Frequency Plans for {{% tts %}} Github repository](https://github.com/TheThingsNetwork/lorawan-frequency-plans/). To update the list of frequency plans with the newest changes from the Frequency Plans repository, run `make freq.deps`.
+
 ## Legal
 
 The Things Stack Documentation is Apache 2.0 licensed.

--- a/doc/data/frequency-plans.yml
+++ b/doc/data/frequency-plans.yml
@@ -159,9 +159,17 @@
   country-codes: [ar, au, bo, br, ca, cl, co, do, nz, py, pe, sr, uy]
   file: AU_915_928_FSB_8.yml
 
+- id: CN_470_510_FSB_1
+  band-id: CN_470_510
+  name: China 470-510 MHz, FSB 1
+  description: Default frequency plan for China, using sub-band 1
+  base-frequency: 470
+  country-codes: [cn]
+  file: CN_470_510_FSB_1.yml
+
 - id: CN_470_510_FSB_11
   band-id: CN_470_510
-  name: China 470-510 MHz, FSB 11
+  name: China 470-510 MHz, FSB 11 (used by TTN)
   description: TTN Community Network frequency plan for China, using sub-band 11
   base-frequency: 470
   country-codes: [cn]
@@ -184,9 +192,50 @@
   country-codes: [jp, my, sg]
   file: lbt_80_over_128.yml
 
+- id: AS_920_923_TTN_JP_1
+  name: Japan 920-923 MHz with LBT (channels 31-38)
+  description: Frequency plan for Japan, using continuous frequencies up to 923.4MHz with LBT.
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_TTN_JP_1.yml
+
+- id: AS_920_923_TTN_JP_1_LAND_MOBILE
+  name: Japan 920-923 MHz with LBT (channels 31-38), Max EIRP 27 dBm
+  description: |
+    Frequency plan for Japanese land mobile station, using continuous frequencies up to 923.4MHz with MAX EIRP 27 dBm and LBT.
+    (note) A user who installs land mobile station in Japan must apply to Japanese Ministry of Internal Affairs and Communications.
+  base-frequency: 915
+  base-id: AS_920_923_TTN_JP_1
+  country-codes: [jp]
+  file: AS_920_923_TTN_JP_1_LAND_MOBILE.yml
+
+- id: AS_920_923_TTN_JP_2
+  name: Japan 920-923 MHz with LBT (channels 24-27 and 35-38)
+  description: Frequency plan for Japan, using top and bottom frequencies ≤ 923.4 MHz with LBT.
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_TTN_JP_2.yml
+
+- id: AS_920_923_TTN_JP_3
+  name: Japan 920-923 MHz with LBT (channels 24-31)
+  description: Frequency plan for Japan (16 channels), using continuous frequencies from 920.6 MHz, expected to be used with AS_920_923_TTN_JP_1.
+  base-frequency: 915
+  country-codes: [jp]
+  file: AS_920_923_TTN_JP_3.yml
+
+- id: AS_920_923_TTN_JP_3_LAND_MOBILE
+  name: Japan 920-923 MHz with LBT (channels 24-31), Max EIRP 27 dBm
+  description: |
+    Frequency plan for Japanese land mobile station (16 channels), using continuous frequencies from 920.6 MHz with MAX EIRP 27 dBm and LBT, expected to be used with AS_920_923_TTN_JP_1.
+    (note) A user who installs land mobile station in Japan must apply to Japanese Ministry of Internal Affairs and Communications.
+  base-frequency: 915
+  base-id: AS_920_923_TTN_JP_3
+  country-codes: [jp]
+  file: AS_920_923_TTN_JP_3_LAND_MOBILE.yml
+
 - id: AS_923
   band-id: AS_923
-  name: Asia 915–928 MHz (AS923 Group 1) with only default channels
+  name: Asia 915-928 MHz (AS923 Group 1) with only default channels
   description: Compatibility frequency plan for Asian countries with common channels in the 923.0-923.5 MHz sub-band
   base-frequency: 915
   file: AS_923.yml
@@ -200,17 +249,81 @@
 
 - id: AS_923_3
   band-id: AS_923_3
-  name: Asia 915–921 MHz (AS923 Group 3) with only default channels
+  name: Asia 915-921 MHz (AS923 Group 3) with only default channels
   description: Compatibility frequency plan for Asian countries with common channels in the 916.5-917.0 MHz sub-band
   base-frequency: 915
   file: AS_923_3.yml
 
 - id: AS_923_4
   band-id: AS_923_4
-  name: Asia 917–920 MHz (AS923 Group 4) with only default channels
+  name: Asia 917-920 MHz (AS923 Group 4) with only default channels
   description: Compatibility frequency plan for Asian countries with common channels in the 917.3-917.5 MHz sub-band
   base-frequency: 915
   file: AS_923_4.yml
+
+- id: AS_923_NDT
+  band-id: AS_923
+  name: Asia 915-928 MHz (AS923 Group 1) with only default channels and dwell time disabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 923.0-923.5 MHz sub-band and dwell time disabled
+  base-frequency: 915
+  base-id: AS_923
+  file: disable_dwell_time.yml
+
+- id: AS_923_DT
+  band-id: AS_923
+  name: Asia 915-928 MHz (AS923 Group 1) with only default channels and dwell time enabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 923.0-923.5 MHz sub-band and dwell time enabled
+  base-frequency: 915
+  base-id: AS_923
+  file: enable_dwell_time_400ms.yml
+
+- id: AS_923_2_NDT
+  band-id: AS_923_2
+  name: Asia 920-923 MHz (AS923 Group 2) with only default channels and dwell time disabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time disabled
+  base-frequency: 915
+  base-id: AS_923_2
+  file: disable_dwell_time.yml
+
+- id: AS_923_2_DT
+  band-id: AS_923_2
+  name: Asia 920-923 MHz (AS923 Group 2) with only default channels and dwell time enabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
+  base-frequency: 915
+  base-id: AS_923_2
+  file: enable_dwell_time_400ms.yml
+
+- id: AS_923_3_NDT
+  band-id: AS_923_3
+  name: Asia 920-923 MHz (AS923 Group 3) with only default channels and dwell time disabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time disabled
+  base-frequency: 915
+  base-id: AS_923_3
+  file: disable_dwell_time.yml
+
+- id: AS_923_3_DT
+  band-id: AS_923_3
+  name: Asia 920-923 MHz (AS923 Group 3) with only default channels and dwell time enabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
+  base-frequency: 915
+  base-id: AS_923_3
+  file: enable_dwell_time_400ms.yml
+
+- id: AS_923_4_NDT
+  band-id: AS_923_4
+  name: Asia 920-923 MHz (AS923 Group 4) with only default channels and dwell time disabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time disabled
+  base-frequency: 915
+  base-id: AS_923_4
+  file: disable_dwell_time.yml
+
+- id: AS_923_4_DT
+  band-id: AS_923_4
+  name: Asia 920-923 MHz (AS923 Group 4) with only default channels and dwell time enabled
+  description: Compatibility frequency plan for Asian countries with common channels in the 921.4-922.0 MHz sub-band and dwell time enabled
+  base-frequency: 915
+  base-id: AS_923_4
+  file: enable_dwell_time_400ms.yml
 
 - id: AS_923_925
   band-id: AS_923_925


### PR DESCRIPTION
#### Summary
Following up on an email from Yoshida Hidetoshi (TTN Japan) to add missing Japanese frequency plans to documentation.

#### Changes
I compared frequency plans available in TTS Console, the ones available in [frequency plans repo](https://github.com/TheThingsNetwork/lorawan-frequency-plans) and the ones described in the [documentation](https://www.thethingsindustries.com/docs/reference/frequency-plans/). In this PR, I'm adding those for Japan and one plan for China that I saw was missing.

#### Notes for Reviewers
I'm a bit lost because there's so many similar labels and I'm not sure if I'm interpreting info from frequency plans repository correctly (e.g. I'm not sure how to obtain a base frequency, so I just put there the minimum frequency that's indicated in the .yml file), so any suggestions or additional useful references are warmly welcome. 

I also spotted this: [this plan](https://github.com/TheThingsNetwork/lorawan-frequency-plans/blob/master/AS_923_925_TTN_AU.yml) and [this plan](https://github.com/TheThingsNetwork/lorawan-frequency-plans/blob/master/AS_920_923_TTN_AU.yml) are supposed to be two different plans, but their settings seem to be the same. If I can get a confirmation that this isn't correct, I'll create in issue in the frequency plans repository.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
