### PR TITLE
doc: Add description for new csv fields on migration procedure

### DIFF
--- a/doc/content/getting-started/migrating/device-csv.md
+++ b/doc/content/getting-started/migrating/device-csv.md
@@ -23,16 +23,26 @@ Column | Required | Alias | Format | Meaning
 `join_eui` | **Yes** | `app_eui` | Hexadecimal string | LoRaWAN JoinEUI (or AppEUI)
 `id` | No | | Alphanumeric string, lowercase with hyphens | Device ID (falls back to DevEUI if not set)
 `name` | No | | Free form | Name
-`frequency_plan_id` | No * | | See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) | Frequency plan ID
+`description` | No | | string | Optional, description of the device
 `lorawan_version` | No * | | See [`MACVersion`]({{< ref "/reference/api/end_device#enum:MACVersion" >}}) | LoRaWAN version
 `lorawan_phy_version` | No * | | See [`PHYVersion`]({{< ref "/reference/api/end_device#enum:PHYVersion" >}}) | LoRaWAN Regional Parameters version
-`app_key` | **Yes** | | Hexadecimal string | LoRaWAN AppKey
-`nwk_key` | No | | Hexadecimal string | LoRaWAN NwkKey
+`frequency_plan_id` | No * | | See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) | Frequency plan ID
 `brand_id` | No | | Vendor ID string from [Device Repository]({{< ref "/integrations/payload-formatters/device-repo" >}}) | Device brand ID
 `model_id` | No | | Model ID from [Device Repository]({{< ref "/integrations/payload-formatters/device-repo" >}}) | Device model ID
 `firmware_version` | No | | Firmware version from [Device Repository]({{< ref "/integrations/payload-formatters/device-repo" >}}) | Firmware version
 `hardware_version` | No | | Hardware version from [Device Repository]({{< ref "/integrations/payload-formatters/device-repo" >}}) | Hardware version
 `band_id` | No | | See [Frequency Plans]({{< ref "/reference/frequency-plans" >}}) | LoRaWAN Band ID
+`supports_class_c` | No | | boolean | `true` for Class C devices, `false` otherwise.
+`app_key` | **Yes** | | Hexadecimal string | LoRaWAN AppKey
+`nwk_key` | No | | Hexadecimal string | LoRaWAN NwkKey
+`rx1_delay` | No | | string | Delay for the first Class A receive window (Rx1). Typical values are `"RX_DELAY_1"` (1 second) and `"RX_DELAY_5"` (5 seconds). See [MACSettings]({{< ref "reference/api/end_device#message:MACSettings" >}}) for more information.
+`supports_32_bit_f_cnt` | No | | boolean |  `true` if device supports 32-bit frame counters, `false` if device only supports 16-bit frame counters. 
+`dev_addr` | **For existing session** | | Hexadecimal string | **Needed for ABP devices or when migrating OTAA devices with an existing session**. See [Device Address]({{< ref "/reference/glossary#device-address" >}}) for more information.
+`app_s_key` | **For existing session** | | string | **Needed for ABP devices or when migrating OTAA devices with an existing session**. See [Application Session Key]({{< ref "reference/glossary#application-session-key" >}}) for more information.
+`f_nwk_s_int_key` | **For existing session** | | string | Forwarding Network Session Integrity Key, also referred to as **Network Session Key** in LoRaWAN v1.0.x compatibility mode. See [SessionKeys]({{< ref "reference/api/end_device#message:SessionKeys" >}}) and [Forwarding Network Session Integrity Key]({{< ref "/reference/glossary#forwarding-network-session-integrity-key" >}}) for more information.
+`last_f_cnt_up` | **For existing session** | | uint | Last uplink frame counter used.
+`last_n_f_cnt_down` | **For existing session** | | uint | Last network downlink frame counter used.
+`last_a_f_cnt_down` | **For existing session** | | uint | Last application downlink frame counter used.
 
 \* If you don't set this, you must set the fallback value when importing the CSV file. See [Importing devices]({{< ref "/getting-started/migrating/import-devices" >}}).
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Documentation for the new fields added to the csv converter. 
Added by https://github.com/TheThingsNetwork/lorawan-stack/pull/5582

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![localhost_1313_getting-started_migrating_device-csv_ (1)](https://user-images.githubusercontent.com/28912302/178041231-c728c1b2-926a-4223-a88f-814a6399856f.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Added a few more fields to the csv table.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tried to leave the order of the fields as similar as possible to the [JSON](https://www.thethingsindustries.com/docs/getting-started/migrating/device-json/#json-end-device-format) page.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
