### PR TITLE
Document interop config component selectors

### DIFF
--- a/doc/themes/the-things-stack/assets/css/common/variables.scss
+++ b/doc/themes/the-things-stack/assets/css/common/variables.scss
@@ -1,9 +1,9 @@
 // Bulma settings
 // See https://bulma.io/documentation/layout/container/
 
-$desktop: 1344px;
-$widescreen: 1632px;
-$fullhd: 1824px;
+$desktop: 1632px;
+$widescreen: 1824px;
+$fullhd: 1920px;
 
 // Colors
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Documentation for https://github.com/TheThingsNetwork/lorawan-stack/pull/5606

#### Changes
<!-- What are the changes made in this pull request? -->

- Documents use of component selectors, including an example for The Things Join Server
- Removes some documentation bloat

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This also makes the content wider; wasting horizontal space keeps on annoying me; I don't need CSS overrides to decide what the best content width is for me.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
