### PR TITLE
doc: Fix distribution icons link

### DIFF
--- a/doc/themes/the-things-stack/layouts/partials/distribution-icons.html
+++ b/doc/themes/the-things-stack/layouts/partials/distribution-icons.html
@@ -2,7 +2,7 @@
 {{ range sort . "weight" "asc" }}
   {{ $distribution_strings = append .name $distribution_strings }}
 {{ end }}
-<a href="{{ "download" | relURL }}" target="_blank" class="badge-stack has-tooltip has-tooltip-arrow has-tooltip-light" data-tooltip="{{ delimit $distribution_strings ", " " and " }} Only">
+<a href="{{ "/getting-started/what-is-tts#the-things-stack-deployments" | relURL }}" target="_blank" class="badge-stack has-tooltip has-tooltip-arrow has-tooltip-light" data-tooltip="{{ delimit $distribution_strings ", " " and " }} Only">
 {{ range sort . "weight" "asc" }}
   <img class="badge" src="{{ .icon | relURL }}"></img>
 {{ end }}


### PR DESCRIPTION
#### Summary
Fix a bad link (https://www.thethingsindustries.com/docs/download) to which clicking on a distribution type icon leads to. 

#### Changes
Set this link to https://www.thethingsindustries.com/docs/getting-started/what-is-tts/#the-things-stack-deployments, so that a user can see which deployment icon is related to.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
