### PR TITLE
Differentiate between links and inline code snippets

### DIFF
--- a/doc/themes/the-things-stack/assets/css/common/variables.scss
+++ b/doc/themes/the-things-stack/assets/css/common/variables.scss
@@ -13,13 +13,13 @@ $blue-alt: #D9E4FF;
 $white: #FFFFFF;
 $graphite: #292929;
 $white-bis: #FBFBFB;
-$white-ter : #ECECEC;
+$white-ter: #ECECEC;
 $red: #F9595A;
 $blue-bg: #E5ECFF;
 $gray: #AEAEAE;
 $red: #FF5C5C;
 
-$code: $blue;
+$code: $graphite;
 $link-hover: darken($blue, 20%);
 $link: $blue;
 $primary: $blue;

--- a/doc/themes/the-things-stack/assets/css/vendor/bulma/sass/base/generic.sass
+++ b/doc/themes/the-things-stack/assets/css/vendor/bulma/sass/base/generic.sass
@@ -77,7 +77,7 @@ a
   color: $link
   cursor: pointer
   text-decoration: none
-  strong
+  strong, code
     color: currentColor
   &:hover
     color: $link-hover


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1004 

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![localhost_1313_getting-started_migrating_migrate-from-chirpstack_(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/73070465/208363095-3a3c12f3-84ae-411a-8d9f-add76e18f01b.png)

#### Changes
<!-- What are the changes made in this pull request? -->

- Change default colour of inline code blocks to black while keeping the blue colour when hyperlinked

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Check out the screenshot. It contains both standard and hyperlinked inline code blocks

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
