### PR TITLE
doc: Document token refresh refused err

### DIFF
--- a/doc/content/getting-started/console/troubleshooting/_index.md
+++ b/doc/content/getting-started/console/troubleshooting/_index.md
@@ -41,3 +41,7 @@ An uplink was received and forwarded by multiple gateways, but due to backhaul l
 ### Invalid Major / JoinRequestPHYPayload Length / Unknown MType
 
 These are typically non-LoRaWAN traffic received by a gateway on your network.
+
+### Token Refresh Refused
+
+If you see `error:pkg/web/oauthclient:refresh (token refresh refused)` error in the Console and you're unable to access it, try clearing your browser's cache and history, and retry accessing the Console. You can also try accessing the Console from the incognito window or another browser.


### PR DESCRIPTION
#### Summary
Closes #1030 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
