### PR TITLE
Add NOC API references and fix line quotes

### DIFF
--- a/doc/content/getting-started/installation/configuration/index.md
+++ b/doc/content/getting-started/installation/configuration/index.md
@@ -228,14 +228,14 @@ Make sure that you use the correct `tls` configuration depending on whether you 
 
 If you are using your own certificate files, make sure to uncomment the lines that define `source` type, `root-ca`, `certificate` and `key`. The paths assigned to these do not need to be altered, because they point to the location of these files inside the Docker container, and not on your machine.
 
-{{< highlight yaml "linenos=table,linenostart=52" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=52 to=57 >}}
+{{< highlight yaml "linenos=table,linenostart=53" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=53 to=59 >}}
 {{< /highlight >}}
 
 If you are using Let's Encrypt in a multi-tenant {{% tts %}} environment, all tenant addresses have to be specified in the `ttn-lw-stack-docker.yml` file using `tls.acme.hosts` configuration option with `*.thethings.example.com` wildcard.
 
-{{< highlight yaml "linenos=table,linenostart=59" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=59 to=68 >}}
+{{< highlight yaml "linenos=table,linenostart=61" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=61 to=70 >}}
 {{< /highlight >}}
 
 ### Console Component URLs
@@ -243,15 +243,15 @@ If you are using Let's Encrypt in a multi-tenant {{% tts %}} environment, all te
 The `console` section configures the URLs for the Web UI and the secret used by the console client. These tell {{% tts %}} where all its components are accessible. Be sure to replace these, and all the other server addresses, with yours.
 
 {{< highlight yaml "linenos=table,linenostart=89" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=89 to=109 >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=89 to=115 >}}
 {{< /highlight >}}
 
 {{< warning >}} Failure to correctly configure component URLs is a common problem that will prevent the stack from starting. Be sure to replace all instances of `thethings.example.com` with your domain name! {{</ warning >}}
 
 The `client-secret` will be needed later when authorizing the Console. Be sure to set and remember it!
 
-{{< highlight yaml "linenos=table,linenostart=111" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=111 to=116 >}}
+{{< highlight yaml "linenos=table,linenostart=116" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=116 to=121 >}}
 {{< /highlight >}}
 
 ### NOC
@@ -262,22 +262,22 @@ Besides `ui` and `oauth` settings, storage settings need to be configured in the
 
 To authorize the NOC, be sure to set and remember the client secret.
 
-{{< highlight yaml "linenos=table,linenostart=152" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=152 to=173 >}}
+{{< highlight yaml "linenos=table,linenostart=161" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=161 to=170 >}}
 {{< /highlight >}}
 
 To visualize data, configure the `grafana` section.
 
-{{< highlight yaml "linenos=table,linenostart=174" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=174 to=180 >}}
+{{< highlight yaml "linenos=table,linenostart=179" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=179 to=185 >}}
 {{< /highlight >}}
 
 ### Multi-tenancy
 
 {{< distributions "Enterprise" >}} If running a multi-tenant environment, we need to configure the default tenant ID, and the base domain from which tenant IDs are inferred. See the [`tenancy` configuration reference]({{< ref "/reference/configuration/the-things-stack#multi-tenancy" >}}).
 
-{{< highlight yaml "linenos=table,linenostart=181" >}}
-{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=181 to=184 >}}
+{{< highlight yaml "linenos=table,linenostart=185" >}}
+{{< readfile path="/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml" from=185 to=189 >}}
 {{< /highlight >}}
 
 For multi-tenant environments you'll also need to configure tenant admin keys:

--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-custom-certificates.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-custom-certificates.yml
@@ -2,12 +2,12 @@
 # Email configuration for "thethings.example.com"
 is:
   email:
-    sender-name: 'The Things Stack'
-    sender-address: 'noreply@thethings.example.com'
+    sender-name: "The Things Stack"
+    sender-address: "noreply@thethings.example.com"
     network:
-      name: 'The Things Stack'
-      console-url: 'https://thethings.example.com/console'
-      identity-server-url: 'https://thethings.example.com/oauth'
+      name: "The Things Stack"
+      console-url: "https://thethings.example.com/console"
+      identity-server-url: "https://thethings.example.com/oauth"
 
     # If sending email with Sendgrid
     # provider: sendgrid
@@ -24,19 +24,19 @@ is:
   # Web UI configuration for "thethings.example.com":
   oauth:
     ui:
-      canonical-url: 'https://thethings.example.com/oauth'
+      canonical-url: "https://thethings.example.com/oauth"
       is:
-        base-url: 'https://thethings.example.com/api/v3'
+        base-url: "https://thethings.example.com/api/v3"
 
 # HTTP server configuration
 http:
   cookie:
-    block-key: ''                # generate 32 bytes (openssl rand -hex 32)
-    hash-key: ''                 # generate 64 bytes (openssl rand -hex 64)
+    block-key: "" # generate 32 bytes (openssl rand -hex 32)
+    hash-key: "" # generate 64 bytes (openssl rand -hex 64)
   metrics:
-    password: 'metrics'               # choose a password
+    password: "metrics" # choose a password
   pprof:
-    password: 'pprof'                 # choose a password
+    password: "pprof" # choose a password
 
 # If using custom certificates:
 tls:
@@ -57,72 +57,72 @@ tls:
 # If Gateway Server enabled, defaults for "thethings.example.com":
 gs:
   mqtt:
-    public-address: 'thethings.example.com:1882'
-    public-tls-address: 'thethings.example.com:8882'
+    public-address: "thethings.example.com:1882"
+    public-tls-address: "thethings.example.com:8882"
   mqtt-v2:
-    public-address: 'thethings.example.com:1881'
-    public-tls-address: 'thethings.example.com:8881'
+    public-address: "thethings.example.com:1881"
+    public-tls-address: "thethings.example.com:8881"
 
 # If Gateway Configuration Server enabled, defaults for "thethings.example.com":
 gcs:
   basic-station:
     default:
-      lns-uri: 'wss://thethings.example.com:8887'
+      lns-uri: "wss://thethings.example.com:8887"
   the-things-gateway:
     default:
-      mqtt-server: 'mqtts://thethings.example.com:8881'
+      mqtt-server: "mqtts://thethings.example.com:8881"
 
 # Web UI configuration for "thethings.example.com":
 console:
   ui:
-    canonical-url: 'https://thethings.example.com/console'
+    canonical-url: "https://thethings.example.com/console"
     is:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     gs:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     ns:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     as:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     js:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     qrg:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     edtc:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     dcs:
       base-url: "https://thethings.example.com/api/v3"
   oauth:
-    authorize-url: 'https://thethings.example.com/oauth/authorize'
-    token-url: 'https://thethings.example.com/oauth/token'
-    logout-url: 'https://thethings.example.com/oauth/logout'
-    client-id: 'console'
-    client-secret: 'console'          # choose or generate a secret
+    authorize-url: "https://thethings.example.com/oauth/authorize"
+    token-url: "https://thethings.example.com/oauth/token"
+    logout-url: "https://thethings.example.com/oauth/logout"
+    client-id: "console"
+    client-secret: "console" # choose or generate a secret
 
 # If Application Server enabled, defaults for "thethings.example.com":
 as:
   mqtt:
-    public-address: 'https://thethings.example.com:1883'
-    public-tls-address: 'https://thethings.example.com:8883'
+    public-address: "https://thethings.example.com:1883"
+    public-tls-address: "https://thethings.example.com:8883"
   webhooks:
     downlink:
-      public-address: 'thethings.example.com:1885/api/v3'
+      public-address: "thethings.example.com:1885/api/v3"
 
 # If Device Claiming Server enabled, defaults for "thethings.example.com":
 dcs:
   oauth:
-    authorize-url: 'https://thethings.example.com/oauth/authorize'
-    token-url: 'https://thethings.example.com/oauth/token'
-    logout-url: 'https://thethings.example.com/oauth/logout'
-    client-id: 'device-claiming'
-    client-secret: 'device-claiming'          # choose or generate a secret
+    authorize-url: "https://thethings.example.com/oauth/authorize"
+    token-url: "https://thethings.example.com/oauth/token"
+    logout-url: "https://thethings.example.com/oauth/logout"
+    client-id: "device-claiming"
+    client-secret: "device-claiming" # choose or generate a secret
   ui:
-    canonical-url: 'https://thethings.example.com/claim'
+    canonical-url: "https://thethings.example.com/claim"
     as:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     dcs:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     is:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     ns:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"

--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-enterprise.yml
@@ -90,7 +90,9 @@ gcs:
 # Web UI configuration for "thethings.example.com":
 console:
   ui:
+    account-url: "https://thethings.example.com/console"
     canonical-url: "https://thethings.example.com/console"
+    noc-url: "https://thethings.example.com/noc"
     is:
       base-url: "https://thethings.example.com/api/v3"
     gs:
@@ -107,9 +109,9 @@ console:
       base-url: "https://thethings.example.com/api/v3"
     edtc:
       base-url: "https://thethings.example.com/api/v3"
-    noc-url: "https://thethings.example.com/noc"
-    account-url: "https://thethings.example.com/console"
     dcs:
+      base-url: "https://thethings.example.com/api/v3"
+    noc:
       base-url: "https://thethings.example.com/api/v3"
   oauth:
     authorize-url: "https://thethings.example.com/oauth/authorize"

--- a/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-open-source.yml
+++ b/doc/content/getting-started/installation/configuration/ttn-lw-stack-docker-open-source.yml
@@ -2,12 +2,12 @@
 # Email configuration for "thethings.example.com"
 is:
   email:
-    sender-name: 'The Things Stack'
-    sender-address: 'noreply@thethings.example.com'
+    sender-name: "The Things Stack"
+    sender-address: "noreply@thethings.example.com"
     network:
-      name: 'The Things Stack'
-      console-url: 'https://thethings.example.com/console'
-      identity-server-url: 'https://thethings.example.com/oauth'
+      name: "The Things Stack"
+      console-url: "https://thethings.example.com/console"
+      identity-server-url: "https://thethings.example.com/oauth"
 
     # If sending email with Sendgrid
     # provider: sendgrid
@@ -24,19 +24,19 @@ is:
   # Web UI configuration for "thethings.example.com":
   oauth:
     ui:
-      canonical-url: 'https://thethings.example.com/oauth'
+      canonical-url: "https://thethings.example.com/oauth"
       is:
-        base-url: 'https://thethings.example.com/api/v3'
+        base-url: "https://thethings.example.com/api/v3"
 
 # HTTP server configuration
 http:
   cookie:
-    block-key: ''                # generate 32 bytes (openssl rand -hex 32)
-    hash-key: ''                 # generate 64 bytes (openssl rand -hex 64)
+    block-key: "" # generate 32 bytes (openssl rand -hex 32)
+    hash-key: "" # generate 64 bytes (openssl rand -hex 64)
   metrics:
-    password: 'metrics'               # choose a password
+    password: "metrics" # choose a password
   pprof:
-    password: 'pprof'                 # choose a password
+    password: "pprof" # choose a password
 
 # If using custom certificates:
 # tls:
@@ -47,84 +47,85 @@ http:
 
 # Let's encrypt for "thethings.example.com"
 tls:
-  source: 'acme'
+  source: "acme"
   acme:
-    dir: '/var/lib/acme'
-    email: 'you@thethings.example.com'
-    hosts: ['thethings.example.com']
-    default-host: 'thethings.example.com'
+    dir: "/var/lib/acme"
+    email: "you@thethings.example.com"
+    hosts: ["thethings.example.com"]
+    default-host: "thethings.example.com"
 
 # If Gateway Server enabled, defaults for "thethings.example.com":
 gs:
   mqtt:
-    public-address: 'thethings.example.com:1882'
-    public-tls-address: 'thethings.example.com:8882'
+    public-address: "thethings.example.com:1882"
+    public-tls-address: "thethings.example.com:8882"
   mqtt-v2:
-    public-address: 'thethings.example.com:1881'
-    public-tls-address: 'thethings.example.com:8881'
+    public-address: "thethings.example.com:1881"
+    public-tls-address: "thethings.example.com:8881"
 
 # If Gateway Configuration Server enabled, defaults for "thethings.example.com":
 gcs:
   basic-station:
     default:
-      lns-uri: 'wss://thethings.example.com:8887'
+      lns-uri: "wss://thethings.example.com:8887"
   the-things-gateway:
     default:
-      mqtt-server: 'mqtts://thethings.example.com:8881'
+      mqtt-server: "mqtts://thethings.example.com:8881"
 
 # Web UI configuration for "thethings.example.com":
 console:
   ui:
-    canonical-url: 'https://thethings.example.com/console'
+    canonical-url: "https://thethings.example.com/console"
+    account-url: "https://thethings.example.com/console"
     is:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     gs:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     gcs:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     ns:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     as:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     js:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     qrg:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     edtc:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     dcs:
       base-url: "https://thethings.example.com/api/v3"
   oauth:
-    authorize-url: 'https://thethings.example.com/oauth/authorize'
-    token-url: 'https://thethings.example.com/oauth/token'
-    logout-url: 'https://thethings.example.com/oauth/logout'
-    client-id: 'console'
-    client-secret: 'console'          # choose or generate a secret
+    authorize-url: "https://thethings.example.com/oauth/authorize"
+    token-url: "https://thethings.example.com/oauth/token"
+    logout-url: "https://thethings.example.com/oauth/logout"
+    client-id: "console"
+    client-secret: "console" # choose or generate a secret
 
 # If Application Server enabled, defaults for "thethings.example.com":
 as:
   mqtt:
-    public-address: 'thethings.example.com:1883'
-    public-tls-address: 'thethings.example.com:8883'
+    public-address: "thethings.example.com:1883"
+    public-tls-address: "thethings.example.com:8883"
   webhooks:
     downlink:
-      public-address: 'thethings.example.com:1885/api/v3'
+      public-address: "thethings.example.com:1885/api/v3"
 
 # If Device Claiming Server enabled, defaults for "thethings.example.com":
 dcs:
   oauth:
-    authorize-url: 'https://thethings.example.com/oauth/authorize'
-    token-url: 'https://thethings.example.com/oauth/token'
-    logout-url: 'https://thethings.example.com/oauth/logout'
-    client-id: 'device-claiming'
-    client-secret: 'device-claiming'          # choose or generate a secret
+    authorize-url: "https://thethings.example.com/oauth/authorize"
+    token-url: "https://thethings.example.com/oauth/token"
+    logout-url: "https://thethings.example.com/oauth/logout"
+    client-id: "device-claiming"
+    client-secret: "device-claiming" # choose or generate a secret
   ui:
-    canonical-url: 'https://thethings.example.com/claim'
+    canonical-url: "https://thethings.example.com/claim"
     as:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     dcs:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     is:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"
     ns:
-      base-url: 'https://thethings.example.com/api/v3'
+      base-url: "https://thethings.example.com/api/v3"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3589

This PR adds the NOC API Console configuration and fixes some line references in the configuration guide.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

Old TLS fragment:
<img width="589" alt="image" src="https://user-images.githubusercontent.com/36161392/227514003-d55f4510-4f3b-4814-89c8-b8d9dddfe1fc.png">
New:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/36161392/227513910-fc50d8f0-b98c-4b87-9c44-cf40c948fe69.png">

Old Let's Encrypt:
<img width="794" alt="image" src="https://user-images.githubusercontent.com/36161392/227514450-bd02d3ae-45b0-4690-a28a-f6dbe43a46be.png">
New:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/36161392/227514516-94e3c580-bb0e-4bba-b0bc-c202588b7806.png">

New component URIs:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/36161392/227514568-51094f38-bf31-4b8b-b9fc-fbde78fb20d0.png">

Old OAuth client secret reference:
<img width="774" alt="image" src="https://user-images.githubusercontent.com/36161392/227514817-220a5bf6-6b14-4d67-9ad8-f521e9e420bd.png">
New:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/36161392/227514866-14fc1e66-84d6-4161-8c3a-41577fdee8a8.png">

Old NOC OAuth client secret reference:
<img width="876" alt="image" src="https://user-images.githubusercontent.com/36161392/227514998-55c2edea-a7a9-4672-b3bb-fd5f9e4aad52.png">
New:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/36161392/227515068-00c78fd1-e3af-495b-bfd9-cfe7f81d4d6b.png">

Old NOC Grafana reference:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/36161392/227515234-75eaf296-b24e-47e3-9271-87aac4727adf.png">
New:
<img width="840" alt="image" src="https://user-images.githubusercontent.com/36161392/227515272-25b4f426-373a-4abd-af8c-f482ef1248b6.png">

Old multi tenancy:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/36161392/227515344-ba32a810-36b8-4f14-b5d9-1e378b0117f9.png">
New:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/36161392/227515445-af7eb1df-65a0-4482-857e-93e051ad6a45.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `noc` section to the appropriate configs.
- Adjust, and fix, some references to the configuration files in order for the referenced lines to actually make sense.
- Format the configuration files.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
