### PR TITLE
doc: Add mtls to the list of ECS deployment templates

### DIFF
--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -315,3 +315,9 @@ To automatically renew the certificate from Let's Encrypt, we will now deploy te
 **Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/5-7b-ecs-certbot-scheduled-task.gen.template (replace `3.x.y` with the current minor and patch version).
 
 >We recommend to schedule this task to run every 14 days.
+
+## Mutual TLS (optional)
+
+The template `2-4c-mtls-s3` generates an S3 bucket to store CA certificates, needed for mutual TLS authentication via a supported proxy (Envoy).
+
+More information can be found in the [Mutual TLS]({{< ref "/getting-started/aws/ecs/mutual-tls" >}}) section.

--- a/doc/content/getting-started/aws/ecs/deployment/_index.md
+++ b/doc/content/getting-started/aws/ecs/deployment/_index.md
@@ -320,4 +320,6 @@ To automatically renew the certificate from Let's Encrypt, we will now deploy te
 
 The template `2-4c-mtls-s3` generates an S3 bucket to store CA certificates, needed for mutual TLS authentication via a supported proxy (Envoy).
 
+**Template:** https://thethingsindustries.s3.amazonaws.com/public/cloud/3.x.y/2-4c-mtls-s3.gen.template (replace `3.x.y` with the current minor and patch version).
+
 More information can be found in the [Mutual TLS]({{< ref "/getting-started/aws/ecs/mutual-tls" >}}) section.


### PR DESCRIPTION
#### Summary
Closes #1064 

#### Notes for Reviewers
I cannot access templates on https://thethingsindustries.s3.amazonaws.com, can you please provide a link to the template? Do we need more info about the template?

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
