### PR TITLE
Quickfix homepage cards styling

### DIFF
--- a/doc/themes/the-things-stack/layouts/index.html
+++ b/doc/themes/the-things-stack/layouts/index.html
@@ -25,7 +25,7 @@
 
 <div class="section">
   <div class="container is-max-desktop">
-    <div class="columns">
+    <div class="columns" style="flex-wrap: wrap" >
       {{ range $cards}}
         <div class="column is-flex">
           <div class="card is-fullwidth">


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix cards being cutoff on smaller screen sizes by enabling flex wrapping.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

Before 

<img width="1044" alt="Screenshot 2023-05-04 at 10 35 34" src="https://user-images.githubusercontent.com/46600603/236153475-d557759c-9e79-4cc6-a02b-3cabd249e0f5.png">

After

<img width="852" alt="Screenshot 2023-05-04 at 10 34 43" src="https://user-images.githubusercontent.com/46600603/236153502-f0cac977-1805-4392-ac0b-277933106913.png">

<img width="1159" alt="Screenshot 2023-05-04 at 10 34 34" src="https://user-images.githubusercontent.com/46600603/236153536-3038ba34-b17b-4ca4-aebc-70cf26845a39.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Add `flex-wrap: wrap`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There may be a way to do this with bulma css, but I could not see anything at first glance.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
