### PR TITLE
doc: Fix getting started LoRaWAN

### DIFF
--- a/doc/content/getting-started/lorawan-basics/_index.md
+++ b/doc/content/getting-started/lorawan-basics/_index.md
@@ -27,7 +27,7 @@ A typical LoRaWAN network consists of the following basic elements.
   - Specialized devices that receive messages from end devices and forward them to the Network Server, as well as forward messages from the Network Server to the end devices.
 
 **Network Server**
-  - A piece of software running on a server manages the entire network.
+  - A piece of software running on a server that manages the entire network.
   - Also referred to as LoRaWAN Network Server/LNS or simply Network software.
 
 **Application servers**

--- a/doc/content/getting-started/lorawan-basics/_index.md
+++ b/doc/content/getting-started/lorawan-basics/_index.md
@@ -12,7 +12,7 @@ LoRa is a wireless modulation technique derived from Chirp Spread Spectrum (CSS)
 
 LoRaWAN is a Media Access Control (MAC) layer protocol built on top of LoRa modulation. It is a software layer which defines how devices use the LoRa hardware, for example when they transmit, and the format of messages.
 
-The LoRaWAN protocol is developed and maintained by the LoRa Alliance. The first LoRaWAN specification was released in January 2015. The table below shows the version history of the LoRaWAN specifications. At the time of this writing the latest specifications are 1.0.4 (in 1.0 series) and 1.1 (1.1 series).
+The LoRaWAN protocol is developed and maintained by the LoRa Alliance. The first LoRaWAN specification was released in January 2015. At the time of this writing the latest specifications are 1.0.4 (in 1.0 series) and 1.1 (1.1 series).
 
 ### Architecture
 
@@ -21,13 +21,13 @@ The LoRaWAN protocol is developed and maintained by the LoRa Alliance. The first
 A typical LoRaWAN network consists of the following basic elements.
 
 **End Devices**
-  - Sensors or actuators send LoRa modulated wireless messages to the gateways or receive messages wirelessly back from the gateways. .
+  - Sensors or actuators send LoRa modulated wireless messages to the gateways or receive messages wirelessly back from the gateways.
 
 **Gateways**
-  - Specialized devices that receive messages from end devices and forward them to the Network Server.
+  - Specialized devices that receive messages from end devices and forward them to the Network Server, as well as forward messages from the Network Server to the end devices.
 
 **Network Server**
-  - A piece of software running on a server that manages the end devices.
+  - A piece of software running on a server manages the entire network.
   - Also referred to as LoRaWAN Network Server/LNS or simply Network software.
 
 **Application servers**
@@ -53,13 +53,13 @@ Messages flowing in the opposite direction (originating from the Network Server 
 
 ### Security
 
-All LoRaWAN data is encrypted AES-128 symmetric keys. All devices have a unique AES-128 key called the "Root Key" associated with them.
+All LoRaWAN data is encrypted using AES-128 symmetric keys. All devices have one or two unique AES-128 keys called the "root keys" associated with them, depending on the version of LoRaWAN they use.
 
-This root key is used to derive separate keys for the application data and network data.
+These root keys are used to derive separate keys for the application data and network data.
 
 Application data is encrypted using one of these derived keys. This key is known only to the Application Server and the End Device.
 
 Network (settings) data is encrypted using different key(s). These keys are known only to the Network Server and the End Device.
 
-{{< note "These keys are called Session Keys since they are rotated when a device session changes. Device sessions are a much deeper topic and is omitted from this basic guide in the interest of simplicity. See the linked references for more information." />}}
+{{< note "These keys are called Session Keys since they are rotated when a device session changes. Device sessions are a much deeper topic and is omitted from this basic guide in the interest of simplicity. See [LoRaWAN Security](https://www.thethingsnetwork.org/docs/lorawan/security/) for more information." />}}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

During the restructuring, some unnecessary text has been migrated from The Things Network Learn section to The Things Stack - Getting Started - LoRaWAN page. There is also some technically incorrect information included on this page.

Related to: Issues in Getting Started - LoRaWAN page #1086


#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![image](https://user-images.githubusercontent.com/36432168/236454263-e90ce9bb-404b-4e63-bebe-8446e11744fb.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@nejraselimovic 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [X] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
