### PR TITLE
doc: Add tenant and cluster selector to the Server Addresses page

### DIFF
--- a/doc/content/the-things-stack/concepts/server-addresses/_index.md
+++ b/doc/content/the-things-stack/concepts/server-addresses/_index.md
@@ -14,6 +14,10 @@ Deployments of {{% tts %}} in a single cluster use the same server address for a
 Distributed deployments, like {{% tts %}} Cloud and Community Edition, use different addresses per region for routing components, while the address of global components (like Identity Server) is always the same. Enterprise and Open Source deployments may be in a single cluster, or distributed over multiple clusters with multiple addresses.
 The server addresses for the different {{% tts %}} deployments are listed below.
 
+You can update the examples below with your tenant ID and cluster ID by filling them here.
+
+{{< tenant-cluster-selector >}}
+
 ## Deployments
 
 **Cloud and Dedicated Cloud**: See [Cloud Addresses]({{< ref "/the-things-stack/cloud/addresses" >}}).
@@ -28,9 +32,9 @@ The server addresses for the different {{% tts %}} deployments are listed below.
 
 To access the Console, simply enter the [server address of your deployment](#deployments) in a browser.
 
-**Example 1**: to access the `eu1` Community Edition Console, enter `https://eu1.cloud.thethings.network` in your browser.
+**Example 1**: To access the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition Console, enter <code data-content="cluster-address"> https://<span data-content="cluster-id"></span>.cloud.thethings.network</code> in your browser.
 
-**Example 2**: To access the `au1` Cloud Console, enter `https://tenant.au1.cloud.thethings.industries`, where `tenant` is your Tenant ID.
+**Example 2**: To access the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud Console, enter <code data-content="cluster-address"> https://<span data-content="tenant-id"></span>.<span  data-content="cluster-id"></span>.cloud.thethings.industries</code>, where `tenant` is your Tenant ID.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, access the Console at the domain you used in place of `https://thethings.example.com`.
 
@@ -38,9 +42,9 @@ To access the Console, simply enter the [server address of your deployment](#dep
 
 The LNS gateway address is a combination of the **protocol** (wss), the **server address**, and the **port** (8887).
 
-**Example 1**: the `eu1` Community Edition LNS address is `wss://eu1.cloud.thethings.network:8887`.
+**Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition LNS address is <code data-content="cluster-address">wss://<span data-content="cluster-id"></span>.cloud.thethings.network:8887</code>.
 
-**Example 2**: The LNS address for an `au1` Cloud tenant is `wss://tenant.au1.cloud.thethings.industries:8887`, where `tenant` should be replaced with your Tenant ID.
+**Example 2**: The LNS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">wss://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:8887</code>, where `tenant` should be replaced with your Tenant ID.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the LNS address is the domain you used in configuration, for example `wss://thethings.example.com:8887`.
 
@@ -48,9 +52,9 @@ The LNS gateway address is a combination of the **protocol** (wss), the **server
 
 The CUPS gateway address is a combination of the **protocol** (https), the **server address**, and the **port** (443).
 
-**Example 1**: the `eu1` Community Edition CUPS address is `https://eu1.cloud.thethings.network:443`.
+**Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition CUPS address is <code data-content="cluster-address">https://<span data-content="cluster-id"></span>.cloud.thethings.network:443</code>.
 
-**Example 2**: The CUPS address for an `au1` Cloud tenant is `https://tenant.au1.cloud.thethings.industries:443`, where `tenant` should be replaced with your Tenant ID.
+**Example 2**: The CUPS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:443</code>, where `tenant` should be replaced with your Tenant ID.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the CUPS address is the domain you used in configuration, for example `https://thethings.example.com:443`.
 
@@ -58,8 +62,8 @@ The CUPS gateway address is a combination of the **protocol** (https), the **ser
 
 The The Things Kickstarter Gateway Account Server address is a combination of the **scheme** (https) and the **server address**. The port is inferred from the scheme.
 
-**Example 1**: For the `eu1` The Things Stack Community Edition cluster, the value is `https://eu1.cloud.thethings.network`. Replace `eu1` with the applicable cluster value (ex: `nam1`, `au1` etc).
+**Example 1**: For the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> The Things Stack Community Edition cluster, the value is <code data-content="cluster-address">https://<span data-content="cluster-id"></span>.cloud.thethings.network</code>.
 
-**Example 2**: For The Things Stack Cloud cluster `au1` with tenant `tenant`, the value is `https://tenant.au1.cloud.thethings.industries`. Replace  `tenant` with your Tenant ID and `au1` with the appropriate cluster value.
+**Example 2**: For The Things Stack Cloud cluster <code data-content="cluster-address"><span data-content="cluster-id"></span></code> with tenant <code data-content="cluster-address"><span data-content="tenant-id"></span></code>, the value is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the address is the domain you used in configuration, for example `https://thethings.example.com`.

--- a/doc/content/the-things-stack/concepts/server-addresses/_index.md
+++ b/doc/content/the-things-stack/concepts/server-addresses/_index.md
@@ -14,7 +14,7 @@ Deployments of {{% tts %}} in a single cluster use the same server address for a
 Distributed deployments, like {{% tts %}} Cloud and Community Edition, use different addresses per region for routing components, while the address of global components (like Identity Server) is always the same. Enterprise and Open Source deployments may be in a single cluster, or distributed over multiple clusters with multiple addresses.
 The server addresses for the different {{% tts %}} deployments are listed below.
 
-You can update the examples below with your tenant ID and cluster ID by filling them here.
+You can update the examples below with your tenant ID and cluster ID by filling them here.  The `<tenant-id>` will be replaced with the provoded tenant ID.
 
 {{< tenant-cluster-selector >}}
 
@@ -34,7 +34,7 @@ To access the Console, simply enter the [server address of your deployment](#dep
 
 **Example 1**: To access the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition Console, enter <code data-content="cluster-address"> https://<span data-content="cluster-id"></span>.cloud.thethings.network</code> in your browser.
 
-**Example 2**: To access the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud Console, enter <code data-content="cluster-address"> https://<span data-content="tenant-id"></span>.<span  data-content="cluster-id"></span>.cloud.thethings.industries</code>, where `tenant` is your Tenant ID.
+**Example 2**: To access the <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud Console, enter <code data-content="cluster-address"> https://<span data-content="tenant-id"></span>.<span  data-content="cluster-id"></span>.cloud.thethings.industries</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, access the Console at the domain you used in place of `https://thethings.example.com`.
 
@@ -44,7 +44,7 @@ The LNS gateway address is a combination of the **protocol** (wss), the **server
 
 **Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition LNS address is <code data-content="cluster-address">wss://<span data-content="cluster-id"></span>.cloud.thethings.network:8887</code>.
 
-**Example 2**: The LNS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">wss://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:8887</code>, where `tenant` should be replaced with your Tenant ID.
+**Example 2**: The LNS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">wss://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:8887</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the LNS address is the domain you used in configuration, for example `wss://thethings.example.com:8887`.
 
@@ -54,7 +54,7 @@ The CUPS gateway address is a combination of the **protocol** (https), the **ser
 
 **Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition CUPS address is <code data-content="cluster-address">https://<span data-content="cluster-id"></span>.cloud.thethings.network:443</code>.
 
-**Example 2**: The CUPS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:443</code>, where `tenant` should be replaced with your Tenant ID.
+**Example 2**: The CUPS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:443</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the CUPS address is the domain you used in configuration, for example `https://thethings.example.com:443`.
 

--- a/doc/content/the-things-stack/concepts/server-addresses/_index.md
+++ b/doc/content/the-things-stack/concepts/server-addresses/_index.md
@@ -14,7 +14,7 @@ Deployments of {{% tts %}} in a single cluster use the same server address for a
 Distributed deployments, like {{% tts %}} Cloud and Community Edition, use different addresses per region for routing components, while the address of global components (like Identity Server) is always the same. Enterprise and Open Source deployments may be in a single cluster, or distributed over multiple clusters with multiple addresses.
 The server addresses for the different {{% tts %}} deployments are listed below.
 
-You can update the examples below with your tenant ID and cluster ID by filling them here.  The `<tenant-id>` will be replaced with the provoded tenant ID.
+You can update the examples below with your tenant ID and cluster ID by filling them here.  The `<tenant-id>` will be replaced with the provided tenant ID.
 
 {{< tenant-cluster-selector >}}
 
@@ -44,7 +44,7 @@ The LNS gateway address is a combination of the **protocol** (wss), the **server
 
 **Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition LNS address is <code data-content="cluster-address">wss://<span data-content="cluster-id"></span>.cloud.thethings.network:8887</code>.
 
-**Example 2**: The LNS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">wss://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:8887</code>.
+**Example 2**: The LNS address for a <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">wss://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:8887</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the LNS address is the domain you used in configuration, for example `wss://thethings.example.com:8887`.
 
@@ -54,7 +54,7 @@ The CUPS gateway address is a combination of the **protocol** (https), the **ser
 
 **Example 1**: The <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Community Edition CUPS address is <code data-content="cluster-address">https://<span data-content="cluster-id"></span>.cloud.thethings.network:443</code>.
 
-**Example 2**: The CUPS address for an <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:443</code>.
+**Example 2**: The CUPS address for a <code data-content="cluster-address"><span data-content="cluster-id"></span></code> Cloud tenant is <code data-content="cluster-address">https://<span data-content="tenant-id"></span>.<span data-content="cluster-id"></span>.cloud.thethings.industries:443</code>.
 
 **Example 3**: If you installed {{% tts %}} Enterprise or Open Source, the CUPS address is the domain you used in configuration, for example `https://thethings.example.com:443`.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refer to the issue 'Improve the page 'Server Addresses' to easily find the server addresses' https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/1147

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/36432168/fb3af416-5b04-4645-9623-b1e5a98db495)


#### Changes
<!-- What are the changes made in this pull request? -->

- Added tenant id and cluster id selector to dynamically change the server addresses.
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@nejraselimovic 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
