### PR TITLE
doc: Note about JoinEUI range

### DIFF
--- a/doc/content/the-things-stack/host/join-server/_index.md
+++ b/doc/content/the-things-stack/host/join-server/_index.md
@@ -22,7 +22,11 @@ The Things Join Server operated by The Things Industries is configured in {{% tt
 
 ## Device Provisioning
 
-If have provisioner access to deployment of The Things Join Server, use the [Command-line Interface `ttjs`](https://www.npmjs.com/package/ttjs-cli) to provision devices in bulk.
+If you have provisioner access to deployment of The Things Join Server, use the [Command-line Interface `ttjs`](https://www.npmjs.com/package/ttjs-cli) to provision devices in bulk.
+
+When it comes to using JoinEUIs for provisioning devices on The Things Join Server, there are two cases:
+- If you are using The Things Join Server hosted by The Things Industries and you don't have your own EUI, you are free to use `70B3D57ED0000000`. On the other hand, if you do have your own EUI that you want to use, you need to [contact The Things Industries support](mailto:support@thethingsindustries.com) for assistance.
+- If you are using an externally hosted The Things Join Server, you must acquire your JoinEUI via IEEE.
 
 ## Device Claiming
 
@@ -30,4 +34,4 @@ The Things Join Server supports LoRaWAN Backend Interfaces 1.0 and 1.1 as well a
 
 ## Security Features
 
-The Things Join Server operated by The Things Industries supports pre-provisioned Microchip ATECC608 secure elements which provided enhanced hardware security protection for LoRaWAN devices. [Learn more about ATECC608 secure elements]({{< ref "/devices/atecc608a" >}}).
+The Things Join Server operated by The Things Industries supports pre-provisioned Microchip ATECC608 secure elements which provide enhanced hardware security protection for LoRaWAN devices. [Learn more about ATECC608 secure elements]({{< ref "/devices/atecc608a" >}}).


### PR DESCRIPTION
#### Summary
Closes #1166 

#### Notes for Reviewers
I'm not sure if I understood this correctly so I'm also not sure if this PR covers the issue.. So my question - when a user uses TTJS, there is a pool of JoinEUIs (mentioned in PR), which are assigned to devices upon device provisioning and need to be used when registering those devices on TTS? And users are confused because this range isn't clearly stated in our docs?

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
