### PR TITLE
doc: Troubleshooting packet collision

### DIFF
--- a/doc/content/devices/troubleshooting/_index.md
+++ b/doc/content/devices/troubleshooting/_index.md
@@ -215,3 +215,9 @@ Generally speaking, changing frequency plans in {{% tts %}} is not recommended a
 ## I see a "no decoder defined for codec {codec_id}" error after very downlink message.
 
 This error indicates that your end device was added from the [Device Repository](https://github.com/TheThingsNetwork/lorawan-devices), but in the device's codec file there are no `downlinkEncoder` and `downlinkDecoder` functions defined. To fix this, you can reach out to the device manufacturer to update your device's codec file in the Device Repository. Alternatively, you can define the [payload formatter]({{< ref "/integrations/payload-formatters" >}}) on your own.
+
+## Transmitting downlink message fails with the collision packet error.
+
+The `COLLISION_PACKET` error occurs when downlink transmissions overlap - this happens when two or more packets overlap in time and use the same spreading factor, bandwith and frequency plan settings.
+
+To avoid packet collisions, users can enable server-side buffering of donwlink messages. If server-side buffering is enabled, the Gateway Server schedules the downlink message to be sent after the downlink message that was already queued but not sent yet, so that their transmissions don't overlap. To enable this, navigate to your gateway's **General settings** section, expand the **LoRaWAN** section and **Enable** the **Schedule downlink late** option by ticking the box. Note that this is a recommended setting for gateways that use [UDP packet forwarder]({{< ref "/gateways/concepts/udp" >}}).


### PR DESCRIPTION
#### Summary
Closes #1121 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
