### PR TITLE
doc: Document unable to access device err

### DIFF
--- a/doc/content/devices/troubleshooting/_index.md
+++ b/doc/content/devices/troubleshooting/_index.md
@@ -60,7 +60,7 @@ Next, recreate your device as documented in the [Using the API]({{< ref "/the-th
 
 ## I see "Unable to access the end device" error
 
-If you're facing this error, your end device has probably been configured with an incorrect server address, so {{% tts %}} Console treats and shows it as in `Other cluster`. To regain access to your end device, you should configure it with the correct server address. That can be done by accessing device's **General settings** and configuring server address, or by deleting and recreating the end device with an appropriate server address.
+If you're facing this error, your end device has probably been configured with incorrect server addresses, so {{% tts %}} Console treats and shows it as in `Other cluster`. To regain access to your end device, you should configure it with the correct server addresses. That can be done by accessing device's **General settings** and configuring server addresses, or by deleting and recreating the end device with appropriate server addresses.
  
 ## How do I see device events?
 

--- a/doc/content/devices/troubleshooting/_index.md
+++ b/doc/content/devices/troubleshooting/_index.md
@@ -58,6 +58,10 @@ curl -X DELETE 'https://thethings.example.com/api/v3/<js/ns/as>/applications/<ap
 
 Next, recreate your device as documented in the [Using the API]({{< ref "/the-things-stack/interact/api/#multi-step-actions" >}}) section.
 
+## I see "Unable to access the end device" error
+
+If you're facing this error, your end device has probably been configured with an incorrect server address, so {{% tts %}} Console treats and shows it as in `Other cluster`. To regain access to your end device, you should configure it with the correct server address. That can be done by accessing device's **General settings** and configuring server address, or by deleting and recreating the end device with an appropriate server address.
+ 
 ## How do I see device events?
 
 Device event logs can be found in the console in the device's general information page. See [Working with Events]({{< ref "the-things-stack/management/events" >}}) for other ways of subscribing to events.


### PR DESCRIPTION
#### Summary
Closing #1192 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
