### PR TITLE
doc: Document claiming devices using claim auth code

### DIFF
--- a/doc/content/devices/adding-devices/_index.md
+++ b/doc/content/devices/adding-devices/_index.md
@@ -31,7 +31,7 @@ You will be presented with options to easily onboard your device using its QR co
 
 {{< tabs/tab "With QR Code" >}}
 
-#### Onboarding devices using QR codes
+## Onboarding devices using QR codes
 
 If your device has a [TR005 LoRaWAN® Device Identification QR Code](https://lora-alliance.org/resource_hub/tr005-lorawan-device-identification-qr-codes/), adding a device is a simple process.
 Note not all QR codes on the physical device are scannable. Only TR005 LoRaWAN® Device Identification QR Codes, are supported for this method.
@@ -57,7 +57,7 @@ Choose a **Frequency plan** appropriate for your region. Your device and gateway
 
 {{< tabs/tab "Without QR Code" >}}
 
-#### Onboarding devices without QR codes
+## Onboarding devices without QR codes
 
 If your device doesn't have a standard [TR005 LoRaWAN® Device Identification QR Code](https://lora-alliance.org/resource_hub/tr005-lorawan-device-identification-qr-codes/), or has a vendor specific QR code, then the device identification and keys have to be entered manually.
 

--- a/doc/content/devices/adding-devices/adding-devices-in-bulk/_index.md
+++ b/doc/content/devices/adding-devices/adding-devices-in-bulk/_index.md
@@ -87,3 +87,79 @@ See the following video from [The Things Network youtube channel](https://youtu.
 <details><summary>Show video</summary>
 {{< youtube "ouz-VuiosU4" >}}
 </details>
+
+## Claim devices using Claim Authentication Code
+
+Devices can be added in bulk together with their ownership information, through a process of device claiming using their claim authentication codes.
+
+Claiming devices can be done using {{% tts %}} Console or the CLI, for single or multiple devices.
+
+{{< tabs/container "Console" "CLI" >}}
+
+{{< tabs/tab "Console" >}}
+
+To claim a single device, first navigate to your application in {{% tts %}} Console and click the **+ Register end device** button.
+
+Select the **Enter end device specifics manually**, then provide **Frequency plan**, **LoRaWAN version** and **Regional Parameters version**.
+
+In the **Provisioning information** section, fill in the **JoinEUI** of The Things Join Server and **Confirm**. 
+
+Then, enter the **DevEUI**, **Claim authentication code** and **End device ID** of a device that you wish to claim.
+
+Finish by clicking **Register end device**.
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "CLI" >}}
+
+To claim a single end device via the CLI, issue the following command:
+
+```bash
+ttn-lw-cli create <application-id> <device-id> \
+    --dev-eui <dev-eui> \
+    --app-eui <app-eui> \
+    --frequency-plan-id <frequency plan> \
+    --lorawan-version <lorawan-version> \
+    --lorawan-phy-version <lorawan-phy-version> \
+    --supports-join \
+    --claim-authentication-code.value <claim-authentication-code>
+```
+
+{{< /tabs/tab >}}
+
+To claim multiple devices, you need to create a [JSON file]({{< ref "/devices/adding-devices/adding-devices-in-bulk/device-json" >}}) containing devices info with defined `claim_authentication_code`. An example of an end device object:
+
+```json
+{
+  "ids": {
+    "device_id": "my-device",
+    "dev_eui": "0102030405060708",
+    "join_eui": "0102030405060708"
+  },
+  "name": "My Device",
+  "description": "Living room temperature sensor",
+  "lorawan_version": "MAC_V1_0_2",
+  "lorawan_phy_version": "PHY_V1_0_2_REV_B",
+  "frequency_plan_id": "EU_863_870_TTN",
+  "supports_join": true,
+  "claim_authentication_code": {
+    "value": "1234"
+  }
+}
+```
+
+{{< tabs/tab "Console" >}}
+
+Then, you only need to import the JSON file as explained above in [Import devices via the Console]({{< ref "/devices/adding-devices/adding-devices-in-bulk#import-devices-via-the-console" >}}).
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "CLI">}}
+
+Then, issue the CLI command to import the JSON file as explained above in [Import devices via the CLI]({{< ref "/devices/adding-devices/adding-devices-in-bulk#import-devices-via-the-cli" >}}).
+
+{{< note >}} The `join-server-enabled` option in the [CLI configuration]({{< ref "/the-things-stack/interact/cli/configuring-cli" >}}) has to be set to `false` when claiming devices using the CLI. {{</ note >}}
+
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}

--- a/doc/content/devices/concepts/device-claiming/_index.md
+++ b/doc/content/devices/concepts/device-claiming/_index.md
@@ -23,6 +23,45 @@ Device makers provision devices on a LoRaWAN Join Server that supports claiming.
 
 Device makers send the proof of ownership together with the physical end devices to the owner. There are various ways to transfer the proof of ownership: it can be encoded in a QR code or text printed on the device packaging, or sent as an import file.
 
-Device owners claim the device by scanning the QR code, entering the claim authentication code or importing a file with claim authentication codes. This is integrated in the [adding devices flow]({{< ref "/devices/adding-devices" >}}).
+Device owners claim the device by scanning the QR code, entering the claim authentication code or importing a file with claim authentication codes. The process of claiming a device using its QR code is integrated in the [adding devices flow]({{< ref "/devices/adding-devices" >}}). Instructions on how to claim a device using claim authentication code are presented below.
 
 Device claiming works with LoRaWAN Join Servers configured in {{% tts %}}. By default, {{% tts %}} Cloud and Community Edition are preconfigured to use The Things Join Server and Semtech Join Server. If you operate {{% tts %}} Enterprise or Open Source, configure the [LoRaWAN Backend Interfaces interoperability repository]({{< ref "/reference/interop-repository" >}}) and the [Device Claiming repository]({{< ref "/reference/device-claiming-repository" >}}) accordingly.
+
+## Claiming devices using Claim Authentication Code
+
+{{< tabs/container "Console" "CLI" >}}
+
+{{< tabs/tab "Console" >}}
+
+Navigate to your application in {{% tts %}} Console and click the **+ Register end device** button.
+
+Select the **Enter end device specifics manually**, then provide **Frequency plan**, **LoRaWAN version** and **Regional Parameters version**.
+
+In the **Provisioning information** section, fill in the **JoinEUI** of The Things Join Server and **Confirm**. 
+
+Then, enter the **DevEUI**, **Claim authentication code** and **End device ID** of a device that you wish to claim.
+
+Finish by clicking **Register end device**.
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "CLI" >}}
+
+To claim end device via CLI, issue the following command:
+
+```bash
+ttn-lw-cli create <application-id> <device-id> \
+    --dev-eui <dev-eui> \
+    --app-eui <app-eui> \
+    --frequency-plan-id <frequency plan> \
+    --lorawan-version <lorawan-version> \
+    --lorawan-phy-version <lorawan-phy-version> \
+    --supports-join \
+    --claim-authentication-code.value <claim-authentication-code>
+```
+
+{{< note >}} The `join-server-enabled` option in the CLI configuration has to be set to `false` when claiming devices using the CLI. {{</ note >}}
+
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}

--- a/doc/content/devices/concepts/device-claiming/_index.md
+++ b/doc/content/devices/concepts/device-claiming/_index.md
@@ -23,45 +23,6 @@ Device makers provision devices on a LoRaWAN Join Server that supports claiming.
 
 Device makers send the proof of ownership together with the physical end devices to the owner. There are various ways to transfer the proof of ownership: it can be encoded in a QR code or text printed on the device packaging, or sent as an import file.
 
-Device owners claim the device by scanning the QR code, entering the claim authentication code or importing a file with claim authentication codes. The process of claiming a device using its QR code is integrated in the [adding devices flow]({{< ref "/devices/adding-devices" >}}). Instructions on how to claim a device using claim authentication code are presented below.
+Device owners claim the device by scanning the QR code, entering the claim authentication code or importing a file with claim authentication codes. The process of claiming a device using its QR code is integrated in the [adding devices flow]({{< ref "/devices/adding-devices" >}}), while the process of claiming devices using their claim authentication code is explained in the [Adding devices in bulk]({{< ref "/devices/adding-devices/adding-devices-in-bulk" >}}) section.
 
 Device claiming works with LoRaWAN Join Servers configured in {{% tts %}}. By default, {{% tts %}} Cloud and Community Edition are preconfigured to use The Things Join Server and Semtech Join Server. If you operate {{% tts %}} Enterprise or Open Source, configure the [LoRaWAN Backend Interfaces interoperability repository]({{< ref "/reference/interop-repository" >}}) and the [Device Claiming repository]({{< ref "/reference/device-claiming-repository" >}}) accordingly.
-
-## Claiming devices using Claim Authentication Code
-
-{{< tabs/container "Console" "CLI" >}}
-
-{{< tabs/tab "Console" >}}
-
-Navigate to your application in {{% tts %}} Console and click the **+ Register end device** button.
-
-Select the **Enter end device specifics manually**, then provide **Frequency plan**, **LoRaWAN version** and **Regional Parameters version**.
-
-In the **Provisioning information** section, fill in the **JoinEUI** of The Things Join Server and **Confirm**. 
-
-Then, enter the **DevEUI**, **Claim authentication code** and **End device ID** of a device that you wish to claim.
-
-Finish by clicking **Register end device**.
-
-{{< /tabs/tab >}}
-
-{{< tabs/tab "CLI" >}}
-
-To claim end device via CLI, issue the following command:
-
-```bash
-ttn-lw-cli create <application-id> <device-id> \
-    --dev-eui <dev-eui> \
-    --app-eui <app-eui> \
-    --frequency-plan-id <frequency plan> \
-    --lorawan-version <lorawan-version> \
-    --lorawan-phy-version <lorawan-phy-version> \
-    --supports-join \
-    --claim-authentication-code.value <claim-authentication-code>
-```
-
-{{< note >}} The `join-server-enabled` option in the CLI configuration has to be set to `false` when claiming devices using the CLI. {{</ note >}}
-
-{{< /tabs/tab >}}
-
-{{< /tabs/container >}}


### PR DESCRIPTION
#### Summary
Closes #1079 

#### Notes for Reviewers
Is this good place to locate these instructions? I find it a bit weird that it's separated from QR code-related docs and adding devices, but I somehow don't see these in Adding Devices. Also I'm curious, why does `join-server-enabled` option have to be set to false?

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
