### PR TITLE
Fix Console documentation link redirect

### DIFF
--- a/doc/content/devices/adding-devices/adding-devices-in-bulk/_index.md
+++ b/doc/content/devices/adding-devices/adding-devices-in-bulk/_index.md
@@ -6,6 +6,7 @@ aliases:
   [
     /getting-started/migrating-from-v2/import-devices,
     /getting-started/migrating-from-networks/import-devices,
+    /the-things-stack/migrating/import-devices,
     /the-things-stack/migrating-from-v2/import-devices,
     /the-things-stack/migrating-from-networks/import-devices,
     /getting-started/migrating,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes in-product documentation link.

#### Changes
<!-- What are the changes made in this pull request? -->

The **Importing End Devices** doc link in the Console on `/console/applications/{application_id}/devices/import` is fixed this way.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The real fix is in the Console of course, but this is the quick workaround. Will file a PR for that as well.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
