### PR TITLE
Add ttui-header and ttui-footer

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -46,3 +46,18 @@ pygmentsUseClasses = true
     name = "Get The Things Stack"
     url = "https://www.thethingsindustries.com/stack/plans/"
     weight = 1
+
+  [[menu.social_media]]
+    name = "X"
+    url = "https://twitter.com/thethingsindust"
+    weight = 1
+
+  [[menu.social_media]]
+    name = "LinkedIn"
+    url = "https://www.linkedin.com/company/10346190"
+    weight = 2
+
+  [[menu.social_media]]
+    name = "YouTube"
+    url = "https://www.youtube.com/channel/UCv85CXnZUXEKnlZpQapTAwQ"
+    weight = 3

--- a/doc/package.json
+++ b/doc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Hugo Theme for The Things Stack",
   "dependencies": {
-    "@ttui/design": "https://ttui.thethingsindustries.com/release/ttui-1.7.4.tar.gz"
+    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz"
   },
   "devDependencies": {}
 }

--- a/doc/package.json
+++ b/doc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Hugo Theme for The Things Stack",
   "dependencies": {
-    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz"
+    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.10.0.tar.gz"
   },
   "devDependencies": {}
 }

--- a/doc/package.json
+++ b/doc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Hugo Theme for The Things Stack",
   "dependencies": {
-    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz"
+    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz"
   },
   "devDependencies": {}
 }

--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -37,3 +37,7 @@
 }
 
 @import "vendor/bulma-tooltip.min";
+
+.DocSearch-Modal {
+   transform: translate(0, 56px)
+}

--- a/doc/themes/the-things-stack/assets/js/theme.js
+++ b/doc/themes/the-things-stack/assets/js/theme.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "@ttui/design/ui/ttui-vendor.js";
-import "@ttui/design/ui/main.js";
-import "@ttui/design/ui/components/heading-expanded/index.js";
+import "@tti/design/ui/ttui-vendor.js";
+import "@tti/design/ui/main.js";
+import "@tti/design/ui/components/ttui-header";
 
 function addNavBarBurgers(){
   var $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)

--- a/doc/themes/the-things-stack/assets/js/theme.js
+++ b/doc/themes/the-things-stack/assets/js/theme.js
@@ -15,6 +15,7 @@
 import "@tti/design/ui/ttui-vendor.js";
 import "@tti/design/ui/main.js";
 import "@tti/design/ui/components/ttui-header";
+import "@tti/design/ui/components/ttui-footer";
 
 function addNavBarBurgers(){
   var $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0)

--- a/doc/themes/the-things-stack/layouts/_default/baseof.html
+++ b/doc/themes/the-things-stack/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html class="has-navbar-fixed-top">
+<html>
 
 {{ partial "head/head.html" . }}
 

--- a/doc/themes/the-things-stack/layouts/partials/footer/footer.html
+++ b/doc/themes/the-things-stack/layouts/partials/footer/footer.html
@@ -32,7 +32,7 @@
 
 {{- $script := resources.Get "js/vendor/basicLightbox.min.js" }}
 <script src="{{ $script.Permalink }}"></script>
-{{- $script := resources.Get "js/theme.js" | js.Build | resources.Minify | resources.Fingerprint }}
+{{- $script := resources.Get "js/theme.js" | js.Build  }}
 <script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity }}" crossorigin="anonymous"></script>
 
 {{- partial "intercom.html" . -}}

--- a/doc/themes/the-things-stack/layouts/partials/footer/footer.html
+++ b/doc/themes/the-things-stack/layouts/partials/footer/footer.html
@@ -1,34 +1,47 @@
-<footer class="footer">
-  <div class="container">
-    <div class="columns">
-      <nav class="column is-one-third">
-        <h3 class="title is-6">The Things Stack</h3>
-        {{- $currentPage := . -}}
-        {{- range .Site.Menus.main }}
-        <p><a class="{{ if $currentPage.IsMenuCurrent "main" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Name }}</a></p>
-        {{- end }}
-      </nav>
-      {{- if .Site.Menus.contributing }}
-      <nav class="column is-one-third">
-        <h3 class="title is-6">Contributing</h3>
-        {{- $currentPage := . -}}
-        {{- range .Site.Menus.contributing }}
-        <p><a class="{{ if $currentPage.IsMenuCurrent "contributing" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Name }}</a></p>
-        {{- end }}
-      </nav>
-      {{ end -}}
-      {{- if .Site.Menus.about_us }}
-      <nav class="column is-one-third">
-        <h3 class="title is-6">About Us</h3>
-        {{- $currentPage := . -}}
-        {{- range .Site.Menus.about_us }}
-        <p><a class="{{ if $currentPage.IsMenuCurrent "about_us" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Name }}</a></p>
-        {{- end }}
-      </nav>
-      {{ end -}}
-    </div>
-  </div>
-</footer>
+<section class="ttui-container bg-background-07 pb-ls-s pt-ls-s">
+  <ttui-footer
+    privacy-policy-url="https://www.thethingsindustries.com/document/privacypolicy/"
+    terms-url="https://www.thethingsindustries.com/document/eula/"
+  >
+    <ttui-footer-nav slot="menu" title="The Things Stack">
+      {{- range .Site.Menus.main }}
+      <ttui-footer-nav-item>
+        <a href="{{ .URL }}">{{ .Name }}</a>
+      </ttui-footer-nav-item>
+      {{- end }}
+    </ttui-footer-nav>
+    {{- if .Site.Menus.contributing }}
+    <ttui-footer-nav slot="menu" title="Contributing">
+      {{- range .Site.Menus.contributing }}
+      <ttui-footer-nav-item>
+        <a href="{{ .URL }}">{{ .Name }}</a>
+      </ttui-footer-nav-item>
+      {{- end }}
+    </ttui-footer-nav>
+    {{ end -}}
+    {{- if .Site.Menus.about_us }}
+    <ttui-footer-nav slot="menu" title="About Us">
+      {{- range .Site.Menus.about_us }}
+      <ttui-footer-nav-item>
+        <a href="{{ .URL }}">{{ .Name }}</a>
+      </ttui-footer-nav-item>
+      {{- end }}
+    </ttui-footer-nav>
+    {{ end -}}
+
+    {{- if .Site.Menus.social_media }}
+    <ttui-footer-social slot="social">
+      {{- range .Site.Menus.social_media }}
+      <ttui-footer-social-icon
+        platform="{{ .Name | lower }}"
+        url="{{ .URL }}"
+        align-left
+      ></ttui-footer-social-icon>
+      {{- end }}
+    </ttui-footer-social>
+  </ttui-footer>
+  {{ end -}}
+</section>
 
 {{- $script := resources.Get "js/vendor/basicLightbox.min.js" }}
 <script src="{{ $script.Permalink }}"></script>

--- a/doc/themes/the-things-stack/layouts/partials/head/head.html
+++ b/doc/themes/the-things-stack/layouts/partials/head/head.html
@@ -32,5 +32,5 @@
   <meta name="twitter:card" content="summary" />
   {{ partial "gtm_head.html" . }}
 
-  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.7.2/main.css" />
+  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.8.0/main.css" />
 </head>

--- a/doc/themes/the-things-stack/layouts/partials/head/head.html
+++ b/doc/themes/the-things-stack/layouts/partials/head/head.html
@@ -32,5 +32,5 @@
   <meta name="twitter:card" content="summary" />
   {{ partial "gtm_head.html" . }}
 
-  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.8.0/main.css" />
+  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.9.4/main.css" />
 </head>

--- a/doc/themes/the-things-stack/layouts/partials/header/nav.html
+++ b/doc/themes/the-things-stack/layouts/partials/header/nav.html
@@ -12,9 +12,8 @@
       -}}
       <div class="navbar-item">
         {{- range .Site.Menus.buttons }}
-        <a class="ttui-btn ttui-btn--primary md:d-none" href="{{ .URL }}"
-          >{{ .Pre }}{{ .Name }}</a
-        >
+        <button class="ttui-btn ttui-btn--primary md:d-none" onclick="window.open('{{ .URL }}', '_blank')"
+          >{{ .Pre }}{{ .Name }}</button>
         {{- end }}
       </div>
       {{- end -}} {{- end }}

--- a/doc/themes/the-things-stack/layouts/partials/header/nav.html
+++ b/doc/themes/the-things-stack/layouts/partials/header/nav.html
@@ -1,60 +1,36 @@
-<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
-  <div class="container is-fluid">
-    <div class="navbar-brand">
-      <a class="navbar-item" href="{{ relURL "" }}">
-        <img class="logo" src="{{ "img/TTS-logo.svg" | relURL }}">
-      </a>
-      {{- if .Site.Params.search.enabled -}}
-          <div class="navbar-item navbar-search-menu" id="search-input-menu">
-          </div>
-        {{- end -}}
-      {{- $currentPage := . -}}
-      {{- range .Site.Menus.brand }}
-      <a class="navbar-item{{ if $currentPage.IsMenuCurrent "brand" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
+<div class="theme-tts">
+  <ttui-header>
+    <nav slot="nav">
+      {{- range .Site.Menus.main }}
+      <a href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
       {{- end }}
-      <span class="navbar-burger burger" data-target="topMenu">
-        <span></span>
-        <span></span>
-        <span></span>
-      </span>
-    </div>
-    <div id="topMenu" class="navbar-menu">
-      <div class="navbar-start">
-        {{- $currentPage := . -}}
-        {{- range .Site.Menus.main }}
-        <a class="navbar-item{{ if $currentPage.IsMenuCurrent "main" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
-        {{- end }}
-
-      </div>
-      <div class="navbar-end">
-        {{- if .Site.Menus.right }}
-        {{- range .Site.Menus.right }}
-        <a class="navbar-item{{ if $currentPage.IsMenuCurrent "right" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
-        {{- end }}
-        {{- end }}
-        {{- if .Site.Menus.buttons }}
-          {{- if not .Params.hidebuttons -}}
-          <div class="navbar-item">
-            {{- range .Site.Menus.buttons }}
-            <a class="button is-primary{{ if $currentPage.IsMenuCurrent "buttons" . }} is-active{{ end }}" href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
-            {{- end }}
-          </div>
-          {{- end -}}
+    </nav>
+    <div slot="right">
+      {{- if .Site.Params.search.enabled -}}
+      <div class="navbar-item navbar-search-menu" id="search-input-menu"></div>
+      {{- end -}} {{- if .Site.Menus.buttons }} {{- if not .Params.hidebuttons
+      -}}
+      <div class="navbar-item">
+        {{- range .Site.Menus.buttons }}
+        <a class="ttui-btn ttui-btn--primary md:d-none" href="{{ .URL }}"
+          >{{ .Pre }}{{ .Name }}</a
+        >
         {{- end }}
       </div>
+      {{- end -}} {{- end }}
     </div>
-  </div>
-</nav>
+  </ttui-header>
+</div>
 
 {{- if .Site.Params.search.enabled -}}
-  <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
-  <script type="text/javascript">
-    docsearch({
-      appId: {{ .Site.Params.search.appid }},
-      apiKey: {{ .Site.Params.search.apikey }},
-      indexName: {{ .Site.Params.search.index }},
-      container: '#search-input-menu',
-      debug: false, // Set debug to true if you want to inspect the dropdown.
-    });
-  </script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+<script type="text/javascript">
+  docsearch({
+    appId: {{ .Site.Params.search.appid }},
+    apiKey: {{ .Site.Params.search.apikey }},
+    indexName: {{ .Site.Params.search.index }},
+    container: '#search-input-menu',
+    debug: false, // Set debug to true if you want to inspect the dropdown.
+  });
+</script>
 {{- end -}}

--- a/doc/yarn.lock
+++ b/doc/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz":
+"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.10.0.tar.gz":
   version "0.0.0"
-  resolved "https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz#959d2d5a6bbebadc858be9936ea08e2cb6571a3c"
+  resolved "https://ttui.thethingsindustries.com/release/ttui-1.10.0.tar.gz#11a69b26b4c21181c37b1784452f27c12c4111d5"

--- a/doc/yarn.lock
+++ b/doc/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-"@ttui/design@https://ttui.thethingsindustries.com/release/ttui-1.7.4.tar.gz":
+"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz":
   version "0.0.0"
-  resolved "https://ttui.thethingsindustries.com/release/ttui-1.7.4.tar.gz#03bddf2d0cc548d977ba7b4a2fb7c6876bd3b939"
+  resolved "https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz#54802fdbdb033fb8bc83c43b57e8a19b22fb5a12"

--- a/doc/yarn.lock
+++ b/doc/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz":
+"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz":
   version "0.0.0"
-  resolved "https://ttui.thethingsindustries.com/release/ttui-1.8.0.tar.gz#54802fdbdb033fb8bc83c43b57e8a19b22fb5a12"
+  resolved "https://ttui.thethingsindustries.com/release/ttui-1.9.4.tar.gz#959d2d5a6bbebadc858be9936ea08e2cb6571a3c"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Include ttui-header and ttui-footer

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/46600603/b78d2393-453c-45d3-839a-eebfe5393a62

#### Changes
<!-- What are the changes made in this pull request? -->

- Replace header with ttui-header
- Update some page styling and the search input 
- Replace footer with ttui-footer

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

To run this locally you will need to run `yarn link` and be running  `yarn watch-linked` on this branch of the design repository https://github.com/TheThingsIndustries/design/pull/216

In this repo `cd docs` and `yarn link @tti/design`.

For some reason this does not work with the minified js, for now in the this commit
[util: TEMPORARY remove js minify for yarn link](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/1265/commits/f64db2dc68bd7691267df4be5d40adbc2123221c) I remove the js minify, we should put this back for deployment

You can then run the project as normal with `make`

@KrishnaIyer there is a screen size where there is to much in the menu, maybe we could organise this into dropdown for desktop?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
