### PR TITLE
doc: Add Application (Client) ID info in Microsoft Entra

### DIFF
--- a/doc/content/reference/federated-auth/oidc/microsoft-entra.md
+++ b/doc/content/reference/federated-auth/oidc/microsoft-entra.md
@@ -38,7 +38,7 @@ Add a new registration with the following values.
 
 Select **Register**.
 
-Open your app registration. Note the **Directory (tenant) ID**. This will be of the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+Open your app registration. Note the **Directory (tenant) ID**. This will be of the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Also, note the **Application (client) ID**.
 
 In the registration, navigate to the **Authentication** panel. For the `Select the tokens you would like to be issued by the authorization endpoint:` section, choose `ID tokens (used for implicit and hybrid flows)`.
 
@@ -55,8 +55,8 @@ Register the provider. Set the following values
 ```bash
 OIDC_PROVIDER_ID="provider ID"                                # Provider ID from above.
 OIDC_PROVIDER_NAME="My OIDC Provider"                         # Name used to display on the Console.
-OIDC_CLIENT_ID="client123"                                    # Client ID is the Secret ID above.
-OIDC_CLIENT_SECRET="secret123"                                # Client Secret is the secret Value from above..
+OIDC_CLIENT_ID="client123"                                    # Client ID is the Application (client)ID from above.
+OIDC_CLIENT_SECRET="secret123"                                # Client Secret is the secret Value from above.
 OIDC_MICROSOFT_TENANT="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 OIDC_ALLOWED_EMAIL_DOMAINS="example.com"                      # This is a required field to skip email verification.
 ```

--- a/doc/content/reference/federated-auth/oidc/microsoft-entra.md
+++ b/doc/content/reference/federated-auth/oidc/microsoft-entra.md
@@ -55,7 +55,7 @@ Register the provider. Set the following values
 ```bash
 OIDC_PROVIDER_ID="provider ID"                                # Provider ID from above.
 OIDC_PROVIDER_NAME="My OIDC Provider"                         # Name used to display on the Console.
-OIDC_CLIENT_ID="client123"                                    # Client ID is the Application (client)ID from above.
+OIDC_CLIENT_ID="client123"                                    # Client ID is the Application (client) ID from above.
 OIDC_CLIENT_SECRET="secret123"                                # Client Secret is the secret Value from above.
 OIDC_MICROSOFT_TENANT="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 OIDC_ALLOWED_EMAIL_DOMAINS="example.com"                      # This is a required field to skip email verification.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Update info about the Application (Client) ID in the [Microsoft Entra](https://www.thethingsindustries.com/docs/reference/federated-auth/oidc/microsoft-entra/) guide.

#### Screenshots

**Before:**

![no-application(Client) ID](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/9304207/297199ea-d435-4786-910f-84d3ae1a498c)
![application(client) as client ID](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/9304207/2e1bcbde-bd26-41aa-9ff5-4c6160ec7267)

**After:**

![with-application(Client)-ID](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/9304207/a7169e00-9994-4f69-971c-b28feb48817c)

![secret ID as client ID](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/9304207/8a20f0da-8e4d-4607-93f7-8758072ef1fa)

#### Changes

- Add info about the Application (Client) ID for the client ID.
- Updated the `Secret ID` as Application (Client) ID in the [Registering the Provider in The Things Stack Section](https://www.thethingsindustries.com/docs/reference/federated-auth/oidc/microsoft-entra/#registering-the-provider-in-the-things-stack)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
