### PR TITLE
doc: Replace non-resolving Sandbox shortcode in tabs

### DIFF
--- a/doc/content/the-things-stack/interact/cli/configuring-cli/_index.md
+++ b/doc/content/the-things-stack/interact/cli/configuring-cli/_index.md
@@ -17,9 +17,9 @@ To configure the CLI, you first have to create a configuration file, then make t
 
 To generate the CLI configuration file, use the following command in your terminal:
 
-{{< tabs/container "Cloud, {{% ttss %}}, and Open Source" "Enterprise" >}}
+{{< tabs/container "Cloud, Sandbox, and Open Source" "Enterprise" >}}
 
-{{< tabs/tab "Cloud, {{% ttss %}}, and Open Source" >}}
+{{< tabs/tab "Cloud, Sandbox, and Open Source" >}}
 
 If using {{% ttss %}}, use the following command as per your regional `cluster`:
 

--- a/doc/content/the-things-stack/interact/cli/installing-cli/_index.md
+++ b/doc/content/the-things-stack/interact/cli/installing-cli/_index.md
@@ -23,9 +23,9 @@ Read this section to find out how to install {{% tts %}} CLI on your operating s
 
 On macOS, Homebrew is the recommended package manager. See the [official Homebrew documentation](https://brew.sh/) for installation instructions.
 
-{{< tabs/container "Cloud, {{% ttss %}}, and Open Source" "Enterprise" >}}
+{{< tabs/container "Cloud, Sandbox, and Open Source" "Enterprise" >}}
 
-{{< tabs/tab "Cloud, {{% ttss %}}, and Open Source" >}}
+{{< tabs/tab "Cloud, Sandbox, and Open Source" >}}
 
 Once Homebrew is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 
@@ -67,9 +67,9 @@ Now you can run the CLI using `tti-lw-cli` in your terminal.
 
 On Linux, `snap` is the recommended package manager. See the [official `snap` documentation](https://snapcraft.io/docs) for installation instructions.
 
-{{< tabs/container "Cloud, {{% ttss %}}, and Open Source" "Enterprise" >}}
+{{< tabs/container "Cloud, Sandbox, and Open Source" "Enterprise" >}}
 
-{{< tabs/tab "Cloud, {{% ttss %}}, and Open Source" >}}
+{{< tabs/tab "Cloud, Sandbox, and Open Source" >}}
 
 Once `snap` is installed on your system, you can install {{% tts %}} CLI using the following command in your terminal:
 

--- a/doc/content/the-things-stack/interact/cli/login/_index.md
+++ b/doc/content/the-things-stack/interact/cli/login/_index.md
@@ -11,9 +11,9 @@ This section explains how to login to {{% tts %}} using the command-line interfa
 
 The CLI needs to be logged on in order to create gateways, applications, devices and API keys. With {{% tts %}} running, login with the following command:
 
-{{< tabs/container "Cloud, {{% ttss %}}, and Open Source" "Enterprise" >}}
+{{< tabs/container "Cloud, Sandbox, and Open Source" "Enterprise" >}}
 
-{{< tabs/tab "Cloud, {{% ttss %}}, and Open Source" >}}
+{{< tabs/tab "Cloud, Sandbox, and Open Source" >}}
 
 ```bash
 ttn-lw-cli login


### PR DESCRIPTION
#### Summary
Shortcodes in container tabs aren't resolving at the moment so these look broken 

![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/65215579/6f7a85fe-2931-434d-9e69-ce34b906e713)

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
