### PR TITLE
doc: Troubleshoot using multiple boolean parameters in CLI cmd

### DIFF
--- a/doc/content/the-things-stack/interact/cli/troubleshooting/_index.md
+++ b/doc/content/the-things-stack/interact/cli/troubleshooting/_index.md
@@ -79,3 +79,26 @@ reason=value does not match regex pattern "^[a-z0-9](?:[-]?[a-z0-9]){2,}$"
 ```
 
 See [ID and EUI Constraints]({{< ref "reference/id-eui-constraints" >}}) section for more info.
+
+## Setting Multiple Boolean Parameters
+
+When setting multiple boolean parameters within a CLI command, you need to use the equals (`=`) sign to assign values, otherwise you might be facing errors.
+
+For example, if you run:
+
+```bash
+ttn-lw-cli gateways set <gateway-id> --location-public false --status-public false --auto-update true
+```
+
+you would be facing the following error:
+
+```bash
+WARN Multiple IDs found in arguments, considering the first
+error:cmd/ttn-lw-cli/commands:invalid_gateway_eui (invalid gateway EUI)
+```
+
+The `--location-public` flag would be interpreted as being `true`, and `false` as an excessive positional argument. Same goes for `--status-public` and `--auto-update` flags as well. In order for all parameters to obtain desired values, you would instead need to run:
+
+```bash
+ttn-lw-cli gateways set <gateway-id> --location-public=false --status-public=false --auto-update=true
+```


### PR DESCRIPTION
#### Summary
Closes #1272 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
