### PR TITLE
doc: Add note on exporting metrics

### DIFF
--- a/doc/content/the-things-stack/management/telemetry/_index.md
+++ b/doc/content/the-things-stack/management/telemetry/_index.md
@@ -10,6 +10,8 @@ aliases: [/reference/telemetry]
 
 {{< warning >}} Metrics are not covered by our compatibility commitment. This means that metrics may be changed or removed in major, minor, or patch releases. This page only lists metrics that are considered relatively stable, but even these metrics may be changed. {{</ warning >}}
 
+{{< note >}} Metrics are exported and available only when a corresponding action takes place in {{% tts %}}. For example, to get the connected gateway's metric (`ttn_lw_gs_connected_gateways`), a gateway should be connected to propagate that metric. {{</ note >}}
+
 ## Process and Go Metrics
 
 {{% tts %}} uses the [Prometheus instrumentation library for Go](https://github.com/prometheus/client_golang/) that includes a collector for the state of the process (on Linux) and metrics from the Go runtime.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

In The Things Stack, metrics are exported only when a corresponding action occurs. Adding a note on exporting the metrics in the [telemetry](https://www.thethingsindustries.com/docs/the-things-stack/management/telemetry/) guide.
Ref: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1028#issuecomment-1946445488

#### Screenshots

**Before:**
![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837895/d2b10473-37c6-4493-8259-c28ddc540473)

**After:**
![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837895/0f1a0143-dd03-4b79-875f-ef657bd0a355)


#### Changes

- Added a note point on exporting metrics.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
