### PR TITLE
doc: Add Server Address mismatch error when using TTS CLI

### DIFF
--- a/doc/content/the-things-stack/interact/cli/troubleshooting/_index.md
+++ b/doc/content/the-things-stack/interact/cli/troubleshooting/_index.md
@@ -102,3 +102,15 @@ The `--location-public` flag would be interpreted as being `true`, and `false` a
 ```bash
 ttn-lw-cli gateways set <gateway-id> --location-public=false --status-public=false --auto-update=true
 ```
+
+## Server Address Mismatch
+
+If you [configure {{% tts %}} CLI]({{< ref "/the-things-stack/interact/cli/configuring-cli" >}}) to use one cluster server address (for example `eu1`) and try to perform actions on the entities registered in other cluster (for example `au1`), you will probably face the following error:
+
+```
+error:cmd/ttn-lw-cli/commands:end_device_server_address_mismatch (Network/Application/Join Server address mismatch)
+```
+
+If you want to perform operations on the entities registered in `a certain` cluster, then you need to ensure the CLI `is configured with server addresses for that` cluster.
+
+Keep in mind that Identity Server and OAuth addresses are always in `eu1` cluster, as described [here]({{< ref "/the-things-stack/cloud/addresses#command-line-interface" >}}).


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Adding the error `error:cmd/ttn-lw-cli/commands:end_device_server_address_mismatch (Network/Application/Join Server address mismatch)` to the Troubleshooting CLI documentation.

https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/1302

#### Screenshots

**New Section:**

![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837895/4f4d71d3-b14d-4881-9854-49a41260f39a)


#### Changes

- Added the Server Address mismatch error when using The Things Stack CLI.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
