### PR TITLE
doc: Add CLI command to multicast doc

### DIFF
--- a/doc/content/devices/configuring-devices/multicast/index.md
+++ b/doc/content/devices/configuring-devices/multicast/index.md
@@ -30,6 +30,21 @@ Since there are no uplinks in multicast groups, there is no MAC layer communicat
 
 - `mac-settings.ping-slot-periodicity.value`
 
+CLI example:
+
+```bash
+ttn-lw-cli end-devices create $APP_ID $DEVICE_ID \
+ --frequency-plan-id $FREQUENCY_PLAN \
+ --lorawan-version $LORAWAN_VERSION \
+ --lorawan-phy-version $LORAWAN_PHY_VERSION \
+ --session.dev-addr $DEV_ADDR \
+ --session.keys.app-s-key.key $APP_SESSION_KEY \
+ --session.keys.nwk-s-key.key $NWK_SESSION_KEY \
+ --multicast \
+ --supports-class-b \
+ --mac-settings.ping-slot-periodicity PING_EVERY_4S
+```
+
 See the [MAC Settings]({{< ref "/devices/configuring-devices/mac-settings" >}}) guide for more information about configuring MAC layer parameters.
 
 ## Creating a Multicast Group


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add an example CLI command, including the flag `--mac-settings.ping-slot-periodicity <value>`, to register a sample Class B Multicast device to the multicast documentation guide. **Ref:** [Class B and Multicast](https://www.thethingsindustries.com/docs/devices/configuring-devices/multicast/#class-b-and-multicast)

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**Before:**
![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837818/980d79b6-1b6f-48cf-a952-4d44b4a51157)


**After:**
![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837818/db6aa83b-8308-4b49-b6ea-72e5e1fe225f)


#### Changes
<!-- What are the changes made in this pull request? -->

 - Added an example CLI command for registering a Class B multicast device.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
