### PR TITLE
doc: Add error unknown certificate authority with webhooks

### DIFF
--- a/doc/content/integrations/webhooks/troubleshooting.md
+++ b/doc/content/integrations/webhooks/troubleshooting.md
@@ -35,3 +35,29 @@ The event details contain a detailed description of a failure cause:
 ```
 
 By inspecting details shown above, you can see that the Webhook failed with a status code `404`, indicating that the configured BaseURL is not found. To avoid this error, always make sure to check if the upstream endpoint URL is accessible.
+
+## I see webhooks fail with `x509_unknown_authority` error. What should I do?
+
+The error could occur if the certificates configured to the Webhook endpoint have an incomplete certificate chain. Below is the example error message in {{% tts %}} console application live events:
+
+```
+"cause": {
+      "namespace": "pkg/errors",
+      "name": "request",
+      "message_format": "request to `{url}` failed",
+      "attributes": {
+        "op": "Post",
+        "url": "<Webhook Endpoint>"
+      },
+      "correlation_id": "d8e2065e6b924ed2ac6322979ed14997",
+      "cause": {
+        "namespace": "pkg/errors",
+        "name": "x509_unknown_authority",
+        "message_format": "unknown certificate authority",
+        "correlation_id": "fc22f122d6a7406ab073925569cb7d00",
+        "code": 14
+  }
+}
+```
+
+We recommend checking if the webhook endpoint certificate has been generated correctly. If you face any issues, you can contact the certificate provider for further assistance. You may also use this [tool](https://www.ssllabs.com/ssltest/analyze.html) to test the webhook endpoint certificate's complete chain.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Add the error unknown certificate authority with webhooks in the troubleshooting webhooks.

#### Screenshots

![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837895/da081d06-8b4c-4cff-8b96-f841e6b25cfc)


#### Changes

- Add error unknown certificate authority with the example event.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
