### PR TITLE
doc: Add migration tool troubleshooting section

### DIFF
--- a/doc/content/the-things-stack/migrating/migration-tool/troubleshooting/_index.md
+++ b/doc/content/the-things-stack/migrating/migration-tool/troubleshooting/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Troubleshooting"
+description: "Troubleshooting the Migration tool"
+weight:
+---
+
+<!--more-->
+
+This section provides help for common issues you may encounter while using the migration tool.
+
+## error:pkg/redis:not_found (entity not found)
+
+If the device is not properly registered in all {{% tts %}} components (Identity Server, Join Server, Network Server and/or Application Server) while trying to export the device using the migration tool, the following error might occur:
+
+```
+error:go.thethings.network/lorawan-stack-migrate/pkg/export:export (export device `newdev1`)
+error:pkg/redis:not_found (entity not found)
+```
+
+We suggest you delete such devices from {{% tts %}} Application and try exporting other devices.
+
+## transport: error while dialing: dial tcp 52.212.223.226:8884: i/o timeout while exporting devices from {{% tts %}}
+
+This error indicates that there might be an issue with your network such as your organization's network firewall blocking the connections on port `8884`.
+
+To isolate the issue, try migrating a device by connecting the Laptop/PC to the other networks, i.e., cellular hotspot, etc. Also, you may check any firewall restrictions in your network on port `8884`.
+
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Add migration tool troubleshooting section with the errors `error:pkg/redis:not_found (entity not found)` and `transport: error while dialing: dial tcp 52.212.223.226:8884: i/o timeout`.

#### Screenshots
![image](https://github.com/TheThingsIndustries/lorawan-stack-docs/assets/105837895/f338efcc-a06f-4125-8159-df4e5d291767)

#### Changes
<!-- What are the changes made in this pull request? -->

- Added a troubleshooting migration tool section with the error and resolutions.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
