### PR TITLE
doc: Add description for new aws template param (TLSCertificateSecretARN)

### DIFF
--- a/doc/content/the-things-stack/host/aws/ami/deployment-guide/_index.md
+++ b/doc/content/the-things-stack/host/aws/ami/deployment-guide/_index.md
@@ -80,9 +80,10 @@ This template allows the user to customize the deployment. The following is a li
 |SendGrid API Key*|API key for [SendGrid](https://sendgrid.com/) to send emails.|-|
 |Amazon ElastiCache KMS Key ID*|Key used for Redis at-rest encryption. Leave empty to disable encryption. (Warning) A change to this field requires manual migration of the database.|-|
 |Amazon ElastiCache Password*|Password used to access Redis. Leave empty to disable TLS connection. (Warning) A change to this field requires manual migration of the database.|-|
-|TLS Certificate|TLS certificate to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
-|TLS Certificate Key|TLS certificate key to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
-|TLS Certificate CA|TLS certificate CA to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
+|TLS Certificate*|TLS certificate to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
+|TLS Certificate Key*|TLS certificate key to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
+|TLS Certificate CA*|TLS certificate CA to use. If left empty, TLS certificates from Let's Encrypt will automatically be requested.|-|
+|ARN of an AWS Secret containing the TLS certificate data*|TLS certificate data specified as an AWS secret. If this secret is specified, TLSCertificate, TLSCertificateCA and TLSCertificateKey values will be ignored. The AWS secret must have 3 key/value pairs with the key names: cert, key, ca.|-|
 
 > \* Optional field
 

--- a/doc/content/the-things-stack/host/aws/ami/deployment-guide/_index.md
+++ b/doc/content/the-things-stack/host/aws/ami/deployment-guide/_index.md
@@ -39,6 +39,7 @@ The following are necessary to complete this guide:
 4. A LoRaWAN® compliant Gateway
 5. A LoRaWAN compliant End Device
 6. Access to a name server for DNS mapping
+7. (Optional) An AWS Secret containing TLS certificate data, if a custom TLS certificate is needed
 
 ## Deployment using AWS Cloud Formation
 


### PR DESCRIPTION
#### Summary

Add description for new param added in this [PR](https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/1173) for the AWS deployment template.

<img width="827" alt="Screenshot 2024-10-08 at 16 39 46" src="https://github.com/user-attachments/assets/ab97ffa5-1395-4b6f-8777-60a15da4e4cb">

#### Notes for Reviewers

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
