### PR TITLE
Release 3.32.3 documentation

### DIFF
--- a/doc/config/_default/config.toml
+++ b/doc/config/_default/config.toml
@@ -23,7 +23,7 @@ pygmentsUseClasses = true
   github_repository = "https://github.com/TheThingsIndustries/lorawan-stack-docs"
   github_repository_edit = "https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/content"
   tts_github_repository = "https://github.com/TheThingsNetwork/lorawan-stack"
-  version = "3.32.2"
+  version = "3.32.3"
 
 [markup]
   [markup.goldmark]

--- a/doc/content/the-things-stack/host/aws/ecs/changelog/index.md
+++ b/doc/content/the-things-stack/host/aws/ecs/changelog/index.md
@@ -10,6 +10,10 @@ All meaningful changes to templates are documented in this file.
 
 - Add GRPC methods rate limiting metric to prometheus rules.
 
+### Proxy
+
+- Add `NsMACSettingsProfileRegistry` grpc service and routes.
+
 ### AMI/BYOL template
 
 - Add a new `TLSCertificateSecretARN` parameter to allow loading TLS certificates from AWS secrets to BYOL and PAYG single template deployments.

--- a/doc/content/whats-new/3.32.3.md
+++ b/doc/content/whats-new/3.32.3.md
@@ -1,0 +1,13 @@
+---
+date: 2024-12-10T12:15:45Z
+title: "3.32.3"
+featured: {
+  added: [],
+  changed: [],
+  fixed: []
+}
+---
+
+### Fixed
+
+- Parsers for newly added normalized payload fields.


### PR DESCRIPTION
#### Summary
Release 3.32.3 documentation.

#### Automatic Changes
- Added documentation for 3.32.3.

#### Manual Changes
- [ ] Update the 'featured' section in 'doc/content/whats-new/3.32.3.md' with only selected items that should be featured.
- [ ] If the are build errors due to missing message definitions, manually add the new  and  definitions where necessary.

#### Checklist for Reviewers
- [ ] A new section has been created in ['whats-new'](doc/content/whats-new) with the corresponding CHANGELOG from [TheThingsIndustries/lorawan-stack](https://github.com/TheThingsIndustries/lorawan-stack). The title is the release version and the date is the release date.
- [ ] The latest UPGRADING.md from the [lorawan-stack-aws](https://github.com/TheThingsIndustries/lorawan-stack-aws) has been copied to [/the-things-stack/host/aws/ecs/changelog](https://github.com/TheThingsIndustries/lorawan-stack-docs/tree/master/doc/content/the-things-stack/host/aws/ecs/changelog/index.md)
- [ ] The documentation version is up to date with the latest PATCH (3.${minor}.${patch}). No "v" is prefixed.
- [ ] The TTI and TTN API documentation has been generated and updated in [doc/data/api](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/data/api). This includes the following files:

```
doc/data/api/tti.lorawan.v3/messages.yml
doc/data/api/tti.lorawan.v3/services.yml
doc/data/api/tti.lorawan.v3/enums.yml
doc/data/api/ttn.lorawan.v3/messages.yml
doc/data/api/ttn.lorawan.v3/services.yml
doc/data/api/ttn.lorawan.v3/enums.yml
```

- [ ] The TTI CLI documentation has been generated and updated in [doc/data](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/doc/data). This includes the following files:

```
doc/data/commands/ttn-lw-cli.json
doc/content/ttn-lw-cli/*.md
```

- [ ] All generated documentation matches the version that is being released.