### PR TITLE
Fix architecture summary

### DIFF
--- a/doc/content/the-things-stack/concepts/architecture/_index.md
+++ b/doc/content/the-things-stack/concepts/architecture/_index.md
@@ -6,6 +6,8 @@ weight: 1
 
 {{% tts %}} follows a API driven microservice architecture, well suited for high availability and reliability.
 
+<!--more-->
+
 {{< figure src="tts-architecture.jpeg" alt="The Things Stack Architecture" >}}
 
 {{% tts %}} has the following main components.


### PR DESCRIPTION
#### Summary

The architecture summary is not delimited properly.

#### Screenshots

Before:

<img width="1495" alt="Screenshot 2025-01-16 at 18 01 32" src="https://github.com/user-attachments/assets/4c38ec64-73ab-4e75-9485-f15fa028a6e3" />

After:

<img width="1490" alt="Screenshot 2025-01-16 at 18 01 42" src="https://github.com/user-attachments/assets/abf9708b-bb35-46ce-b787-fe54161c566f" />


#### Changes
<!-- What are the changes made in this pull request? -->

- Added delimiter for architecture summary.

#### Notes for Reviewers

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
