### PR TITLE
Update Typos in adding OTAA devices through API call 

### DIFF
--- a/doc/content/hardware/devices/adding-devices/manual/otaa/_index.md
+++ b/doc/content/hardware/devices/adding-devices/manual/otaa/_index.md
@@ -223,7 +223,7 @@ Make a `PUT` request to the [`/api/v3/ns/applications/{end_device.ids.applicatio
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
--d @./req.json \
+-d @./ns.json \
  https://thethings.example.com/api/v3/ns/applications/my-test-app/devices/test-device
 {"ids":{"device_id":"test-device","application_ids":{"application_id":"my-test-app"},"dev_eui":"0000000000000011","join_eui":"1111111111111111"},"created_at":"2024-01-10T14:34:54.493279Z","updated_at":"2024-01-10T14:34:54.493279Z","lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","supports_join":true}
 ```
@@ -249,7 +249,7 @@ Make a `PUT` request to the [`/api/v3/as/applications/{end_device.ids.applicatio
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
--d @./req.json \
+-d @./as.json \
  https://thethings.example.com/api/v3/as/applications/my-test-app/devices/test-device
 {"ids":{"device_id":"test-device","application_ids":{"application_id":"my-test-app"},"dev_eui":"0000000000000011","join_eui":"1111111111111111"},"created_at":"2024-01-10T14:37:56.826742Z","updated_at":"2024-01-10T14:37:56.826742Z"}%
 ```


### PR DESCRIPTION


<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Update the typos in the API calls under adding OTTA devices through the HTTP method. The changes are made in `HTTP (REST) API` section of https://www.thethingsindustries.com/docs/hardware/devices/adding-devices/manual/otaa/

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**


![image](https://github.com/user-attachments/assets/5df8508f-6d03-49a2-abc6-6f341ae939d5)

![image](https://github.com/user-attachments/assets/d568fa5c-334c-4a7f-aae7-88973faa59f9)


#### Changes
<!-- What are the changes made in this pull request? -->

Updated the file name in the HTTP(API) call made to NS while adding OTAA device from `req.json` to `ns.json`.
Updated the file name in the  HTTP(API) call made to AS while adding OTAA device from `req.json` to `as.json`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
