### PR TITLE
Update typos in API call paths for Managing Application Packages

### DIFF
--- a/doc/content/hardware/devices/adding-devices/manual/otaa/_index.md
+++ b/doc/content/hardware/devices/adding-devices/manual/otaa/_index.md
@@ -223,7 +223,7 @@ Make a `PUT` request to the [`/api/v3/ns/applications/{end_device.ids.applicatio
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
--d @./req.json \
+-d @./ns.json \
  https://thethings.example.com/api/v3/ns/applications/my-test-app/devices/test-device
 {"ids":{"device_id":"test-device","application_ids":{"application_id":"my-test-app"},"dev_eui":"0000000000000011","join_eui":"1111111111111111"},"created_at":"2024-01-10T14:34:54.493279Z","updated_at":"2024-01-10T14:34:54.493279Z","lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870_TTN","supports_join":true}
 ```
@@ -249,7 +249,7 @@ Make a `PUT` request to the [`/api/v3/as/applications/{end_device.ids.applicatio
 
 ```bash
 curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
--d @./req.json \
+-d @./as.json \
  https://thethings.example.com/api/v3/as/applications/my-test-app/devices/test-device
 {"ids":{"device_id":"test-device","application_ids":{"application_id":"my-test-app"},"dev_eui":"0000000000000011","join_eui":"1111111111111111"},"created_at":"2024-01-10T14:37:56.826742Z","updated_at":"2024-01-10T14:37:56.826742Z"}%
 ```

--- a/doc/content/integrations/application-packages/using-the-api.md
+++ b/doc/content/integrations/application-packages/using-the-api.md
@@ -14,7 +14,7 @@ Besides using the CLI, you can also use the [application package HTTP APIs]({{< 
 To list the available application packages for the given device `dev1` of the application `app1`:
 
 ```bash
-curl 'https://eu1.cloud.thethings.network/api/app1/devices/dev1/packages' \
+curl 'https://eu1.cloud.thethings.network/api/v3/as/applications/app1/devices/dev1/packages' \
   -X 'GET' \
   -H 'content-type: application/json' \
   -H 'authorization: Bearer NNSXS.XXXXXXXXX'
@@ -56,7 +56,7 @@ In the following examples, replace the `test-package` with any of the packages l
 To create a default association between the application package and the FPort `100` of an application `app1`:
 
 ```bash
-curl 'https://eu1.cloud.thethings.network/applications/app1/packages/associations/100' \
+curl 'https://eu1.cloud.thethings.network/api/v3/as/applications/app1/packages/associations/100' \
   -X 'PUT' \
   -H 'content-type: application/json' \
   -H 'authorization: Bearer NNSXS.XXXXXXXXX' \
@@ -85,7 +85,7 @@ The default association will associate the application package with all devices 
 To create an association between the application package and the FPort `100` of a device `dev1` of an application `app1`:
 
 ```bash
-curl 'https://eu1.cloud.thethings.network/applications/app1/devices/dev1/packages/associations/100' \
+curl 'https://eu1.cloud.thethings.network/api/v3/as/applications/app1/devices/dev1/packages/associations/100' \
   -X 'PUT' \
   -H 'content-type: application/json' \
   -H 'authorization: Bearer XXXXXXXXX' \


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Update the typos in the API call paths under [managing application packages](https://www.thethingsindustries.com/docs/integrations/application-packages/using-the-api/#listing-the-available-packages).

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**


![image](https://github.com/user-attachments/assets/5c13ee87-3386-402a-98d5-2c603ff8b5d0)

![image](https://github.com/user-attachments/assets/7fe83b92-2646-4c4d-9f2f-f9e797460b82)

#### Changes
<!-- What are the changes made in this pull request? -->

- Updated the API path under [listing application packages](https://www.thethingsindustries.com/docs/integrations/application-packages/using-the-api/#listing-the-available-packages)
- Updated the API path under [creating associations](https://www.thethingsindustries.com/docs/integrations/application-packages/using-the-api/#creating-associations) for both application and end device
#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
