### PR TITLE
doc: Add new API error

### DIFF
--- a/doc/content/api/concepts/troubleshooting/_index.md
+++ b/doc/content/api/concepts/troubleshooting/_index.md
@@ -24,7 +24,7 @@ Unlike other server components, the Identity Server component of {{% tts %}} is 
 
 This error indicates that the client HTTP protocol version is old, so the server refuses to perform the request and requires a client update to HTTP 1.1 version or higher.
 
-###### "no_application_rights" or "no_user_rights" error
+###### "no_application_rights" or "no_user_rights" or "neither_user_nor_organization" error
 
 The API key you are using doesn't have sufficient rights to perform the desired API request. It might also be caused by a missing `Bearer` keyword in the `Authorization` header used in the API call.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Ref: https://thethingsindustries.atlassian.net/browse/TTS-6571

Added new error `"neither_user_nor_organization" error`  heading in the [API troubleshooting guide](https://www.thethingsindustries.com/docs/api/concepts/troubleshooting/). 
As there is an explanation for a similar error, just added the error next to the existing error.

<details><summary>Error</summary>
<p>

```
{
    "code": 7,
    "message": "error:pkg/identityserver:neither_user_nor_organization (caller is neither a user nor an organization)",
    "details": [
        {
            "@type": "type.googleapis.com/ttn.lorawan.v3.ErrorDetails",
            "namespace": "pkg/identityserver",
            "name": "neither_user_nor_organization",
            "message_format": "caller is neither a user nor an organization",
            "correlation_id": "3c19ae70c2dc4d95b1c03fc0542b290d",
            "code": 7
        }
    ]
}
```

</p>
</details> 

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**

![Screenshot 2025-03-14 193646](https://github.com/user-attachments/assets/3d88553b-f4b3-44b9-8c76-28d7b87dbdc3)

#### Changes
<!-- What are the changes made in this pull request? -->

Added new error heading alone, as there is an explanation for a similar error.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left. 