### PR TITLE
doc: Update typo in TTIG claim command

### DIFF
--- a/doc/content/hardware/gateways/models/thethingsindoorgateway/_index.md
+++ b/doc/content/hardware/gateways/models/thethingsindoorgateway/_index.md
@@ -99,7 +99,7 @@ Please adapt the example for your specific case.
 ```bash
 tti-lw-cli gateways claim 00800000A00009EF \
 --authentication-code abcdef \
---target-gateway-id gtw1
+--target-gateway-id gtw1 \
 --target-cups-uri https://eu1.cloud.thethings.network:443 \
 --target-gateway-server-address eu1.cloud.thethings.network \
 --target-frequency-plan-id EU_863_870 \


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Update the typo in the CLI command used to claim the TTIG. There is a missing `\` in the command.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**

![image](https://github.com/user-attachments/assets/27f0fed7-205b-4804-91d4-fc86054ec544)


#### Changes
<!-- What are the changes made in this pull request? -->

Updated a missing `\`  in the command to claim the TTIG. 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left. 