### PR TITLE
Add k8s troubleshooting item for failed version check warning

### DIFF
--- a/doc/content/enterprise/kubernetes/generic/troubleshooting/_index.md
+++ b/doc/content/enterprise/kubernetes/generic/troubleshooting/_index.md
@@ -34,3 +34,7 @@ For this error, make sure that the value set in `ingress.traefik.tls.secretName`
 ## pkg/util/store:driver (driver error)
 
 {{% tts %}} runs Kubernetes jobs to initialize and migrate Postgres. This error can occur if the {{% tts %}} is accessed either before these jobs are run or if the jobs failed to execute. Check the status of the jobs for more details on what went wrong.
+
+## Failed to check version update (certificate signed by unknown authority)
+
+If the `skip-version-check` flag is disabled, the stack will check for new updates. To check for updates, requests are going to be sent to [thethingsindustries.com](https://thethingsindustries.com). For the requests to succeed, a CA certificate must be present in the trust store of the cluster that accepts the thethingsindustries.com domain (e.g. [Amazon Root CA 1](https://www.amazontrust.com/repository/)).  Another alternative is adding it to the list of certificates in the `rootCA` field in the Helm chart.


### PR DESCRIPTION
#### Summary

References support issue [#1238](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1238#issuecomment-2728691164).

#### Screenshots

<img width="1507" alt="Screenshot 2025-03-17 at 12 38 05" src="https://github.com/user-attachments/assets/15c4bc39-29c7-45c2-b6f3-4899de9ca148" />


#### Changes
<!-- What are the changes made in this pull request? -->

- Add k8s troubleshooting item.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md).
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md), there are no fixup commits left.
