### PR TITLE
doc: Add New error while claiming TTIGPro

### DIFF
--- a/doc/content/hardware/gateways/models/thethingsindoorgatewaypro/_index.md
+++ b/doc/content/hardware/gateways/models/thethingsindoorgatewaypro/_index.md
@@ -148,3 +148,11 @@ If you configured wrong Ethernet settings and you do not have WiFi or Cellular c
 ## Advanced: Serial Output
 
 {{% ttigpro %}} writes comprehensive logs via its USB-C port which also functions as serial port. You can connect a serial port client (e.g. PUTTY on Windows, `screen` on macOS or `minicom` on Linux) with a baud rate of 115200, 8 data bits, no parity and 1 stop bit. This provides extensive insight in why Cellular, WiFi and/or Ethernet is failing.
+
+## Troubleshooting
+
+#### I get an error "gateway subscription not attached and active" while claiming The Things Industries Gateway Pro
+
+The error occurs if the gateway does not have active subscription. For more information refer [subscription](https://www.thethingsindustries.com/docs/hardware/gateways/models/thethingsindoorgatewaypro/#subscription). After purchasing the TTIG Pro gateway, you will receive an email with instructions on how to create subscriptions for the gateway. If you don't see the email in your inbox, please check your spam folder as well.
+
+If the issue persists, please contact `support@thethingsindustries.com`.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add new error `gateway subscription not attached and active` while claiming The Things Indoor Gateway Pro. This is to add under new heading `Troubleshooting` in the [TTIGPro page](https://www.thethingsindustries.com/docs/hardware/gateways/models/thethingsindoorgatewaypro/)

<details><summary>Error Details</summary>
<p>


```
"error":"error:pkg/deviceclaimingserver:claim gateway (claim gateway)",
"error_cause":"error:unknown:unknown (gateway subscription not attached and active)",
```

</p>
</details> 

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**

![image](https://github.com/user-attachments/assets/db98975d-2efa-46d6-ba95-17d31e0ad978)


#### Changes
<!-- What are the changes made in this pull request? -->

Added new error `gateway subscription not attached and active` while claiming TTIGPro gateway and explanation.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left. 