### PR TITLE
doc: Add Missing HTTP method in nbTrans API

### DIFF
--- a/doc/content/concepts/features/lorawan/adr/_index.md
+++ b/doc/content/concepts/features/lorawan/adr/_index.md
@@ -257,7 +257,7 @@ To set the min NbTrans to `2` and max NbTrans to `3` for for data rate index 5 (
 The request using `cURL` is as follows.
 
 ```bash
-curl -v -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
+curl -v -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
 -d @./req.json https://thethings.example.com/api/v3/ns/applications/test-app/devices/eui-1231231231231231
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

There is no HTTP method in the example API call to configure the nbTrans [here](https://www.thethingsindustries.com/docs/concepts/features/lorawan/adr/#configure-nbtrans-for-an-end-device-per-data-rate)

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**


![image](https://github.com/user-attachments/assets/9356f16e-1514-40cd-a1f3-11572759626a)


#### Changes
<!-- What are the changes made in this pull request? -->

Added missing HTTP method `-X PUT` to configure nbTrans for an end device under [Configuring nbTrans](https://www.thethingsindustries.com/docs/concepts/features/lorawan/adr/#configure-nbtrans-for-an-end-device-per-data-rate)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left. 