### PR TITLE
doc: Update k8s ingress controller port mapping

### DIFF
--- a/doc/content/enterprise/kubernetes/generic/prerequisites/_index.md
+++ b/doc/content/enterprise/kubernetes/generic/prerequisites/_index.md
@@ -152,11 +152,11 @@ gtwmqttv3secure:
   protocol: TCP
   port: 8882
   exposedPort: 8882
-lbs:
+semtechws:
   protocol: TCP
   port: 1887
   exposedPort: 1887
-lbssecure:
+semtechwssecure:
   protocol: TCP
   port: 8887
   exposedPort: 8887
@@ -199,7 +199,7 @@ ingress:
     http:
       traefik.ingress.kubernetes.io/router.entrypoints: websecure
     semtechws:
-      traefik.ingress.kubernetes.io/router.entrypoints: semtechwssecure, semtechws
+      traefik.ingress.kubernetes.io/router.entrypoints: semtechwssecure,semtechws
       traefik.ingress.kubernetes.io/router.tls: "true"
   serviceAnnotations:
     traefik.ingress.kubernetes.io/service.serversscheme: h2c


### PR DESCRIPTION
#### Summary

A port mapping is wrong for the k8s Helm chart. This was in the configuration of Traefik and caused some trouble.

#### Screenshots



#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [x] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/blob/master/CONTRIBUTING.md), there are no fixup commits left.
