### PR TITLE
Add delimiter for ECS Changelog summary

### DIFF
--- a/doc/content/enterprise/aws/ecs/changelog/index.md
+++ b/doc/content/enterprise/aws/ecs/changelog/index.md
@@ -6,6 +6,8 @@ aliases: [/getting-started/aws/ecs/changelog]
 
 All meaningful changes to templates are documented in this file.
 
+<!--more-->
+
 ## Unreleased
 
 ### `4-2a-configuration`


### PR DESCRIPTION
### Summary
The Template Changelog summary is not delimited properly.

Ref: https://www.thethingsindustries.com/docs/enterprise/aws/ecs/

### Screenshots
Before:

![image](https://github.com/user-attachments/assets/efb0738c-f74f-44e3-b4df-1214b342ed74)

After:

![image](https://github.com/user-attachments/assets/679d50ca-da4b-4864-95e4-06019dccc979)

### Changes

Added a delimiter for the template changelog summary.

### Notes for Reviewers
None.

### Checklist

- [x]  Scope: The referenced issue is addressed, there are no unrelated changes.
- [x]  Run Locally: Verified that the docs build using make server, posted screenshots, verified external links. Test with HUGO_PARAMS_SEARCH_ENABLED=true if style changes will affect the search bar.
- [ ]  New Features Marked: Documentation for new features is marked using the new-in-version shortcode, according to the guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/CONTRIBUTING.md).
- [x]  Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/CONTRIBUTING.md).
- [x]  Commits: Commit messages follow guidelines in [CONTRIBUTING](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/CONTRIBUTING.md), there are no fixup commits left.