### PR TITLE
Add API tab for webhook retries

### DIFF
--- a/doc/content/integrations/webhooks/retries.md
+++ b/doc/content/integrations/webhooks/retries.md
@@ -19,11 +19,62 @@ Webhook queuing allows individual HTTP requests to be retried at later times, wh
 
 ## Enabling webhook retries
 
+{{< tabs/container "Console" "HTTP (REST) API">}}
+
+{{< tabs/tab "Console" >}}
+
 The webhook retries feature can be enabled on both new and existing webhooks via the Console, by ticking the **Retries** checkbox in the webhook settings:
 
 After the checkbox has been ticked, and the webhook has been saved, future requests will be enqueued and retried on failure.
 
 {{< figure src="../webhook-retries.png" alt="Webhook queueing enabled" >}}
+
+{{< /tabs/tab >}}
+
+{{< tabs/tab "HTTP (REST) API" >}}
+
+###### Details
+
+<div class="fixed-table table-api-item">
+
+| Item         | Value                                                                                                                                                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Endpoint     | [`/api/v3/as/webhooks/{webhook.ids.application_ids.application_id}/{webhook.ids.webhook_id}`]({{< ref "/api/reference/http/routes/#aswebhooks{webhook.ids.application_ids.application_id}{webhook.ids.webhook_id}-put" >}}) |
+| Request type | `PUT`                                                                                                                                                                                                                       |
+
+</br>
+</div>
+
+###### Example
+
+To enable webhook retries option of `my-webhook` associated with application `my-test-app` on `thethings.example.com`, first create a JSON file named `req.json` in the same folder with the following contents. Set the `enabled` field to `false` to disable the same.
+
+```json
+{
+  "webhook": {
+    "queue": {
+      "enabled": true
+    }
+  },
+  "field_mask": {
+    "paths": ["queue.enabled"]
+  }
+}
+```
+
+The request using `cURL` is as follows.
+
+```bash
+
+ curl -X 'PUT' -v -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" \
+ -d @./req.json https://thethings.example.com/api/v3/as/webhooks/my-test-app/my-webhook | jq
+{"ids":{"application_ids":{"application_id":"my-test-app"},"webhook_id":"my-webhook"},"created_at":"2025-02-26T08:04:08.967052214Z","updated_at":"2025-04-24T07:39:19.381493044Z","base_url":"https://www.example.com","format":"json","queue":{"enabled":true}}
+
+```
+
+{{< /tabs/tab >}}
+
+{{< /tabs/container >}}
 
 ## What counts as a failed try ?
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add API tab for webhook retries option. Currently, console instructions alone are in the documentation. 

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->
**New:**

![Screenshot 2025-04-24 162806](https://github.com/user-attachments/assets/5ad894f8-c1b6-4ee2-9d75-205ec75cbd4f)
![Screenshot 2025-04-24 162825](https://github.com/user-attachments/assets/0116d9cf-daaf-49be-8f73-c3556a69f259)



#### Changes
<!-- What are the changes made in this pull request? -->

Added API tab where instructions on enabling webhook retries through API.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links. Test with `HUGO_PARAMS_SEARCH_ENABLED=true` if style changes will affect the search bar.
- [ ] New Features Marked: Documentation for new features is marked using the `new-in-version` shortcode, according to the guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left. 